### PR TITLE
feat: gas limits, snapshot voting, and performance metrics

### DIFF
--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -123,4 +123,12 @@ pub enum VaultError {
     ChainNotSupported = 1401,
     /// Amount exceeds bridge limit
     ExceedsBridgeLimit = 1402,
+
+    // Gas limit errors (15xx)
+    /// Proposal execution would exceed the configured gas (CPU instruction) limit
+    GasLimitExceeded = 1500,
+
+    // Snapshot voting errors (16xx)
+    /// Caller was not a signer at proposal creation time (snapshot)
+    VoterNotInSnapshot = 1600,
 }

--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -271,3 +271,39 @@ pub fn emit_rewards_claimed(env: &Env, proposal_id: u64, farm: &Address, amount:
         (farm.clone(), amount),
     );
 }
+
+// ============================================================================
+// Gas Limit Events (feature/gas-limits)
+// ============================================================================
+
+/// Emit when a proposal execution is blocked by its gas limit
+pub fn emit_gas_limit_exceeded(env: &Env, proposal_id: u64, gas_used: u64, gas_limit: u64) {
+    env.events().publish(
+        (Symbol::new(env, "gas_limit_exceeded"), proposal_id),
+        (gas_used, gas_limit),
+    );
+}
+
+/// Emit when gas configuration is updated by admin
+pub fn emit_gas_config_updated(env: &Env, admin: &Address) {
+    env.events()
+        .publish((Symbol::new(env, "gas_cfg_updated"),), admin.clone());
+}
+
+// ============================================================================
+// Performance Metrics Events (feature/performance-metrics)
+// ============================================================================
+
+/// Emit when vault-wide metrics are updated
+pub fn emit_metrics_updated(
+    env: &Env,
+    executed: u64,
+    rejected: u64,
+    expired: u64,
+    success_rate_bps: u32,
+) {
+    env.events().publish(
+        (Symbol::new(env, "metrics_updated"),),
+        (executed, rejected, expired, success_rate_bps),
+    );
+}


### PR DESCRIPTION
Closes #121
Closes #127 
Closes #128 



---

**Overview**

This PR implements three governance hardening features for the VaultDAO Soroban contract: configurable gas limits per proposal execution, snapshot-based voting to prevent vote manipulation through late token transfers, and vault-wide performance metrics tracking.

---

**Changes**

**Gas Limits (`feature/gas-limits`)**

Proposal execution now enforces a configurable CPU instruction budget. A `GasConfig` struct stores `enabled`, `default_gas_limit`, `base_cost`, and `condition_cost`. When enabled, `execute_proposal` estimates execution cost as `base_cost + (conditions.len() * condition_cost)` and returns `GasLimitExceeded` if the proposal's limit is breached. The same check applies in `batch_execute_proposals`, silently skipping over-budget proposals rather than aborting the batch. The `gas_limit` and `gas_used` fields are stored on each `Proposal` for auditability. Admin can update gas settings via `set_gas_config`.

**Snapshot Voting (`feature/snapshot-voting`)**

Voting power is now determined at proposal creation time. `propose_transfer` and `propose_swap` capture `snapshot_ledger` and `snapshot_signers` (a copy of the active signer set from `Config`) at the moment of creation. `approve_proposal` and `abstain_from_proposal` both verify that the caller appears in `proposal.snapshot_signers` before proceeding, returning `VoterNotInSnapshot` otherwise. This prevents an attacker from gaining approval rights by being added as a signer during an active voting window.

**Performance Metrics (`feature/performance-metrics`)**

A `VaultMetrics` struct accumulates vault-wide counters: `total_proposals`, `executed_count`, `rejected_count`, `expired_count`, `total_execution_time_ledgers`, `total_gas_used`, and `last_updated_ledger`. Helper methods `success_rate_bps()` and `avg_execution_time_ledgers()` provide derived aggregates. Storage helpers `metrics_on_proposal`, `metrics_on_execution`, `metrics_on_rejection`, and `metrics_on_expiry` update the record at each lifecycle transition. A `metrics_updated` event is emitted after every execution. The public `get_metrics()` function exposes all data on-chain.

---

**Files changed**

- types.rs — Added `gas_limit`, `gas_used`, `snapshot_ledger`, `snapshot_signers` fields to `Proposal`; added `GasConfig` and `VaultMetrics` structs
- errors.rs — Added `GasLimitExceeded = 1500`, `VoterNotInSnapshot = 1600`
- storage.rs — Added `GasConfig` and `Metrics` DataKey variants; storage helpers for gas config and metrics; fixed `comparison_chain` clippy lint in `apply_reputation_decay`
- events.rs — Added `emit_gas_limit_exceeded`, `emit_gas_config_updated`, `emit_metrics_updated`
- lib.rs — Updated `propose_transfer`, `propose_swap`, `execute_proposal`, `reject_proposal`, `batch_execute_proposals`, `approve_proposal`, `abstain_from_proposal`; added `set_gas_config`, `get_gas_config`, `get_metrics`
- test.rs — Added 6 new tests: `test_gas_limit_exceeded`, `test_gas_limit_allows_execution`, `test_snapshot_voting_prevents_new_signer`, `test_snapshot_existing_signers_can_vote`, `test_metrics_proposal_count`, `test_metrics_rejection_tracking`

---

**CI**

All pipeline checks pass:
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — 0 errors, 0 warnings
- `cargo test` — 40 passed, 0 failed

---

**Acceptance criteria**

- Gas limit field on proposals, configurable via admin, enforced at execution and in batch — complete
- Snapshot ledger and signer set captured at proposal creation, snapshot-only voting enforced — complete
- Metrics type with timing and gas data, collection at all lifecycle transitions, retrieval via `get_metrics`, aggregation helpers, events — complete