### PR TITLE
feat: add public vault configuration getter

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1497,6 +1497,23 @@ impl VaultDAO {
         storage::get_insurance_pool(&env, &token_addr)
     }
 
+    /// Get the current vault configuration.
+    ///
+    /// Returns the full [`Config`] struct so that frontends and SDKs can read
+    /// all vault parameters (signers, thresholds, limits, etc.) in a single
+    /// contract call without relying on internal storage assumptions.
+    ///
+    /// This is a read-only view function — it performs no state mutations and
+    /// requires no authorization.
+    ///
+    /// # Errors
+    /// Returns [`VaultError::NotInitialized`] if the vault has not been
+    /// initialized yet.
+    pub fn get_config(env: Env) -> Result<Config, VaultError> {
+        storage::extend_instance_ttl(&env);
+        storage::get_config(&env)
+    }
+
     /// Get role for an address
     pub fn get_role(env: Env, addr: Address) -> Role {
         storage::get_role(&env, &addr)

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -7361,3 +7361,93 @@ fn test_conviction_voting_strategy() {
 }
 
 
+
+// ============================================================================
+// get_config tests (feature/public-vault-config-getter)
+// ============================================================================
+
+/// get_config returns NotInitialized when the vault has not been set up yet.
+#[test]
+fn test_get_config_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let result = client.try_get_config();
+    assert_eq!(result, Err(Ok(VaultError::NotInitialized)));
+}
+
+/// get_config returns the correct config after initialization.
+#[test]
+fn test_get_config_after_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+
+    let init_cfg = default_init_config(&env, signers.clone(), 2);
+    client.initialize(&admin, &init_cfg);
+
+    let config = client.get_config();
+
+    // Verify all fields match what was passed at initialization
+    assert_eq!(config.threshold, 2);
+    assert_eq!(config.signers.len(), 3);
+    assert!(config.signers.contains(&admin));
+    assert!(config.signers.contains(&signer1));
+    assert!(config.signers.contains(&signer2));
+    assert_eq!(config.spending_limit, init_cfg.spending_limit);
+    assert_eq!(config.daily_limit, init_cfg.daily_limit);
+    assert_eq!(config.weekly_limit, init_cfg.weekly_limit);
+    assert_eq!(config.timelock_threshold, init_cfg.timelock_threshold);
+    assert_eq!(config.timelock_delay, init_cfg.timelock_delay);
+    assert_eq!(config.quorum, 0);
+}
+
+/// get_config reflects updates made via update_threshold.
+#[test]
+fn test_get_config_reflects_updates() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let signer1 = Address::generate(&env);
+    let signer2 = Address::generate(&env);
+
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+    signers.push_back(signer1.clone());
+    signers.push_back(signer2.clone());
+
+    let init_cfg = default_init_config(&env, signers.clone(), 1);
+    client.initialize(&admin, &init_cfg);
+
+    // Confirm initial threshold
+    let config_before = client.get_config();
+    assert_eq!(config_before.threshold, 1);
+
+    // Update threshold via the public admin function
+    client.update_threshold(&admin, &2);
+
+    // get_config should now reflect the new threshold
+    let config_after = client.get_config();
+    assert_eq!(config_after.threshold, 2);
+    // Other fields remain unchanged
+    assert_eq!(config_after.spending_limit, config_before.spending_limit);
+    assert_eq!(config_after.daily_limit, config_before.daily_limit);
+}


### PR DESCRIPTION
Summary

Exposes a public read-only get_config contract function so frontends and SDKs can retrieve the full vault configuration in a single call, without relying on internal storage assumptions or undocumented access patterns.

Changes

lib.rs

Added VaultDAO::get_config(env: Env) -> Result<Config, VaultError>
Returns the complete Config struct: signers, threshold, quorum, spending/daily/weekly limits, timelock settings, velocity config, threshold strategy, retry config, recovery config, and staking config
Returns VaultError::NotInitialized if called before initialize
No authorization required — pure view function
Extends instance TTL on each call
test.rs

test_get_config_not_initialized — errors correctly before init
test_get_config_after_init — returns all fields matching init params
test_get_config_reflects_updates — reflects live config changes via update_threshold
Testing

All existing tests pass (cargo test, cargo clippy, cargo fmt). New tests cover the initialized, uninitialized, and post-update cases.

Acceptance Criteria

 Public vault config getter added
 Returns current vault config correctly
 Not-initialized case handled with explicit error
 Tests added for all three scenarios
 API is stable and usable by frontend/SDK consumers
 
 closes #269