### PR TITLE
feat: add public admin role assignment endpoint

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1514,6 +1514,54 @@ impl VaultDAO {
         storage::get_config(&env)
     }
 
+    /// Assign a role to an address.
+    ///
+    /// Only an account with the `Admin` role can call this function.
+    /// Roles control what operations an address is permitted to perform:
+    /// - [`Role::Member`]    — read-only access (default)
+    /// - [`Role::Treasurer`] — can propose and approve transfers
+    /// - [`Role::Admin`]     — full operational control
+    ///
+    /// # Arguments
+    /// * `admin`   - The caller; must hold the `Admin` role and authorize.
+    /// * `target`  - The address whose role is being set.
+    /// * `role`    - The new [`Role`] to assign.
+    ///
+    /// # Errors
+    /// - [`VaultError::NotInitialized`] if the vault has not been initialized.
+    /// - [`VaultError::Unauthorized`]   if the caller is not an Admin.
+    pub fn set_role(
+        env: Env,
+        admin: Address,
+        target: Address,
+        role: Role,
+    ) -> Result<(), VaultError> {
+        // Require explicit authorization from the caller
+        admin.require_auth();
+
+        // Vault must be initialized
+        if !storage::is_initialized(&env) {
+            return Err(VaultError::NotInitialized);
+        }
+
+        // Only Admin may assign roles
+        if storage::get_role(&env, &admin) != Role::Admin {
+            return Err(VaultError::Unauthorized);
+        }
+
+        // Persist the new role
+        storage::set_role(&env, &target, role.clone());
+        storage::extend_instance_ttl(&env);
+
+        // Emit role-assignment event
+        events::emit_role_assigned(&env, &target, role as u32);
+
+        // Append to the tamper-evident audit trail
+        storage::create_audit_entry(&env, AuditAction::SetRole, &admin, 0);
+
+        Ok(())
+    }
+
     /// Get role for an address
     pub fn get_role(env: Env, addr: Address) -> Role {
         storage::get_role(&env, &addr)

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -7451,3 +7451,109 @@ fn test_get_config_reflects_updates() {
     assert_eq!(config_after.spending_limit, config_before.spending_limit);
     assert_eq!(config_after.daily_limit, config_before.daily_limit);
 }
+
+// ============================================================================
+// set_role tests (feature/public-set-role-endpoint)
+// ============================================================================
+
+/// Admin can assign Treasurer role to another address.
+#[test]
+fn test_set_role_admin_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let signer1 = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+    signers.push_back(signer1.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+
+    // user starts as Member (default)
+    assert_eq!(client.get_role(&user), Role::Member);
+
+    // Admin assigns Treasurer
+    client.set_role(&admin, &user, &Role::Treasurer);
+    assert_eq!(client.get_role(&user), Role::Treasurer);
+}
+
+/// Non-admin cannot assign roles.
+#[test]
+fn test_set_role_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let signer1 = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+    signers.push_back(signer1.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+
+    // signer1 is a Member — cannot assign roles
+    let result = client.try_set_role(&signer1, &user, &Role::Treasurer);
+    assert_eq!(result, Err(Ok(VaultError::Unauthorized)));
+
+    // role must remain unchanged
+    assert_eq!(client.get_role(&user), Role::Member);
+}
+
+/// Admin can overwrite an existing role.
+#[test]
+fn test_set_role_overwrite() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let signer1 = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+    signers.push_back(signer1.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+
+    // Assign Treasurer first
+    client.set_role(&admin, &user, &Role::Treasurer);
+    assert_eq!(client.get_role(&user), Role::Treasurer);
+
+    // Overwrite with Admin
+    client.set_role(&admin, &user, &Role::Admin);
+    assert_eq!(client.get_role(&user), Role::Admin);
+
+    // Downgrade back to Member
+    client.set_role(&admin, &user, &Role::Member);
+    assert_eq!(client.get_role(&user), Role::Member);
+}
+
+/// set_role fails before the vault is initialized.
+#[test]
+fn test_set_role_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let result = client.try_set_role(&admin, &user, &Role::Treasurer);
+    assert_eq!(result, Err(Ok(VaultError::NotInitialized)));
+}


### PR DESCRIPTION
Exposes a public set_role contract function so administrators can assign roles through the frontend and SDK. Previously, role assignment only existed as an internal storage helper with no callable contract endpoint.

Changes

lib.rs

Added VaultDAO::set_role(env, admin, target, role) -> Result<(), VaultError>
Requires admin.require_auth() — explicit on-chain authorization
Returns VaultError::NotInitialized if vault hasn't been initialized
Returns VaultError::Unauthorized if caller doesn't hold the Admin role
Persists the role via storage::set_role
Emits events::emit_role_assigned with the target address and role value
Appends AuditAction::SetRole to the tamper-evident on-chain audit trail
test.rs

test_set_role_admin_success — admin assigns Treasurer role, verified via get_role
test_set_role_non_admin_fails — non-admin gets Unauthorized, role unchanged
test_set_role_overwrite — admin can promote, demote, and reassign roles
test_set_role_not_initialized — returns NotInitialized before vault setup
Testing

All checks pass: cargo test, cargo clippy, cargo fmt.

Acceptance Criteria

 Public set_role endpoint added
 Only Admin can call it
 Role assignment persists correctly
 Role assignment emits event
 Role assignment creates audit entry
 Tests cover success and all failure cases


closes #270