### PR TITLE
feat: add public proposal enumeration endpoint

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1549,6 +1549,46 @@ impl VaultDAO {
         storage::get_proposal(&env, proposal_id)
     }
 
+    /// List proposal IDs in ascending creation order (paginated).
+    ///
+    /// Returns up to `limit` proposal IDs, skipping the first `offset` entries.
+    /// IDs are ordered by creation sequence (lowest ID = oldest proposal).
+    /// The result is empty when no proposals exist or `offset` exceeds the total.
+    /// `limit` is capped at 100 per call to bound gas usage.
+    ///
+    /// # Arguments
+    /// * `offset` - Number of proposals to skip (use 0 for the first page).
+    /// * `limit`  - Maximum number of IDs to return (capped at 100).
+    pub fn list_proposal_ids(env: Env, offset: u64, limit: u64) -> Vec<u64> {
+        storage::extend_instance_ttl(&env);
+        storage::get_proposal_ids_paginated(&env, offset, limit)
+    }
+
+    /// List full proposal objects in ascending creation order (paginated).
+    ///
+    /// Equivalent to calling `list_proposal_ids` and then `get_proposal` for
+    /// each ID, but in a single contract invocation. Proposals that cannot be
+    /// loaded (e.g. storage gaps) are silently skipped.
+    /// `limit` is capped at 50 per call to bound gas usage on large payloads.
+    ///
+    /// # Arguments
+    /// * `offset` - Number of proposals to skip (use 0 for the first page).
+    /// * `limit`  - Maximum number of proposals to return (capped at 50).
+    pub fn list_proposals(env: Env, offset: u64, limit: u64) -> Vec<Proposal> {
+        storage::extend_instance_ttl(&env);
+        // Tighter cap for full objects — each Proposal is much larger than a u64
+        let obj_limit: u64 = if limit > 50 { 50 } else { limit };
+        let ids = storage::get_proposal_ids_paginated(&env, offset, obj_limit);
+        let mut proposals: Vec<Proposal> = Vec::new(&env);
+        for i in 0..ids.len() {
+            let id = ids.get(i).unwrap();
+            if let Ok(p) = storage::get_proposal(&env, id) {
+                proposals.push_back(p);
+            }
+        }
+        proposals
+    }
+
     /// Get current pooled slash insurance balance
     pub fn get_insurance_pool(env: Env, token_addr: Address) -> i128 {
         storage::get_insurance_pool(&env, &token_addr)

--- a/contracts/vault/src/storage.rs
+++ b/contracts/vault/src/storage.rs
@@ -327,6 +327,37 @@ pub fn increment_proposal_id(env: &Env) -> u64 {
     id
 }
 
+/// Return a page of existing proposal IDs in ascending creation order.
+///
+/// IDs are assigned sequentially starting at 1. This function scans the
+/// range `[offset+1 .. next_id)` and collects up to `limit` IDs that have
+/// a stored proposal entry, skipping any gaps left by deleted proposals.
+///
+/// # Arguments
+/// * `offset` - Number of proposals to skip (0-based).
+/// * `limit`  - Maximum number of IDs to return. Capped at 100 internally.
+pub fn get_proposal_ids_paginated(env: &Env, offset: u64, limit: u64) -> Vec<u64> {
+    let cap: u64 = if limit > 100 { 100 } else { limit };
+    let next_id = get_next_proposal_id(env);
+    let mut ids: Vec<u64> = Vec::new(env);
+    let mut skipped: u64 = 0;
+
+    for id in 1..next_id {
+        if !env.storage().persistent().has(&DataKey::Proposal(id)) {
+            continue;
+        }
+        if skipped < offset {
+            skipped += 1;
+            continue;
+        }
+        ids.push_back(id);
+        if ids.len() as u64 >= cap {
+            break;
+        }
+    }
+    ids
+}
+
 // ============================================================================
 // Priority Queue
 // ============================================================================

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -7681,3 +7681,173 @@ fn test_update_limits_invalid_hierarchy() {
         Err(Ok(VaultError::InvalidAmount))
     );
 }
+
+// ============================================================================
+// Proposal enumeration tests (feature/proposal-enumeration-endpoint)
+// ============================================================================
+
+/// list_proposal_ids returns empty vec when no proposals exist.
+#[test]
+fn test_list_proposal_ids_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+
+    let ids = client.list_proposal_ids(&0u64, &10u64);
+    assert_eq!(ids.len(), 0);
+}
+
+/// list_proposals returns empty vec when no proposals exist.
+#[test]
+fn test_list_proposals_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+
+    let proposals = client.list_proposals(&0u64, &10u64);
+    assert_eq!(proposals.len(), 0);
+}
+
+/// list_proposal_ids returns all IDs in ascending order.
+#[test]
+fn test_list_proposal_ids_ascending_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+    client.set_role(&admin, &admin, &Role::Treasurer);
+
+    // Create three proposals
+    let id1 = client.propose_transfer(
+        &admin, &recipient, &token, &100i128,
+        &Symbol::new(&env, "p1"), &Priority::Normal,
+        &soroban_sdk::Vec::new(&env), &ConditionLogic::And, &0i128,
+    );
+    let id2 = client.propose_transfer(
+        &admin, &recipient, &token, &200i128,
+        &Symbol::new(&env, "p2"), &Priority::Normal,
+        &soroban_sdk::Vec::new(&env), &ConditionLogic::And, &0i128,
+    );
+    let id3 = client.propose_transfer(
+        &admin, &recipient, &token, &300i128,
+        &Symbol::new(&env, "p3"), &Priority::Normal,
+        &soroban_sdk::Vec::new(&env), &ConditionLogic::And, &0i128,
+    );
+
+    let ids = client.list_proposal_ids(&0u64, &10u64);
+    assert_eq!(ids.len(), 3);
+    assert_eq!(ids.get(0).unwrap(), id1);
+    assert_eq!(ids.get(1).unwrap(), id2);
+    assert_eq!(ids.get(2).unwrap(), id3);
+    // Strictly ascending
+    assert!(ids.get(0).unwrap() < ids.get(1).unwrap());
+    assert!(ids.get(1).unwrap() < ids.get(2).unwrap());
+}
+
+/// list_proposals returns full proposal objects with correct data.
+#[test]
+fn test_list_proposals_returns_full_objects() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+    client.set_role(&admin, &admin, &Role::Treasurer);
+
+    client.propose_transfer(
+        &admin, &recipient, &token, &500i128,
+        &Symbol::new(&env, "memo"), &Priority::High,
+        &soroban_sdk::Vec::new(&env), &ConditionLogic::And, &0i128,
+    );
+
+    let proposals = client.list_proposals(&0u64, &10u64);
+    assert_eq!(proposals.len(), 1);
+
+    let p = proposals.get(0).unwrap();
+    assert_eq!(p.amount, 500);
+    assert_eq!(p.recipient, recipient);
+    assert_eq!(p.token, token);
+    assert_eq!(p.status, ProposalStatus::Pending);
+}
+
+/// Pagination: offset and limit work correctly.
+#[test]
+fn test_list_proposal_ids_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+    let mut signers = soroban_sdk::Vec::new(&env);
+    signers.push_back(admin.clone());
+
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+    client.set_role(&admin, &admin, &Role::Treasurer);
+
+    // Create 5 proposals
+    for i in 1u32..=5 {
+        client.propose_transfer(
+            &admin, &recipient, &token, &(i as i128 * 100),
+            &Symbol::new(&env, "p"), &Priority::Normal,
+            &soroban_sdk::Vec::new(&env), &ConditionLogic::And, &0i128,
+        );
+    }
+
+    // First page: offset=0, limit=2 → IDs 1,2
+    let page1 = client.list_proposal_ids(&0u64, &2u64);
+    assert_eq!(page1.len(), 2);
+    assert_eq!(page1.get(0).unwrap(), 1);
+    assert_eq!(page1.get(1).unwrap(), 2);
+
+    // Second page: offset=2, limit=2 → IDs 3,4
+    let page2 = client.list_proposal_ids(&2u64, &2u64);
+    assert_eq!(page2.len(), 2);
+    assert_eq!(page2.get(0).unwrap(), 3);
+    assert_eq!(page2.get(1).unwrap(), 4);
+
+    // Third page: offset=4, limit=2 → ID 5 only
+    let page3 = client.list_proposal_ids(&4u64, &2u64);
+    assert_eq!(page3.len(), 1);
+    assert_eq!(page3.get(0).unwrap(), 5);
+
+    // Offset beyond total → empty
+    let page4 = client.list_proposal_ids(&10u64, &2u64);
+    assert_eq!(page4.len(), 0);
+}


### PR DESCRIPTION
Adds list_proposal_ids and list_proposals so UI clients can render the proposals page in a single contract call, without reconstructing state from isolated IDs or crawling events.

Problem

The contract had get_proposal(id) and a few filtered ID helpers (by priority, by tag), but no general enumeration flow. Frontends had no clean way to get "all proposals" or page through them.

Changes

storage.rs

Added get_proposal_ids_paginated(env, offset, limit) -> Vec<u64> Scans the sequential ID space 1..next_id, skips any storage gaps, applies offset/limit. Limit is capped at 100 internally to bound gas per call.
lib.rs

Added list_proposal_ids(env, offset, limit) -> Vec<u64> Returns proposal IDs in ascending creation order (oldest first). Deterministic, paginated, empty-safe. Limit capped at 100.
Added list_proposals(env, offset, limit) -> Vec<Proposal> Returns full Proposal objects for the same page. Limit capped at 50 to account for larger per-object serialization cost. Proposals that fail to load are silently skipped.
Ordering

Both endpoints return results in ascending ID order — lowest ID (oldest proposal) first. This is deterministic and stable across calls.

Pagination

page 1: list_proposal_ids(offset=0,  limit=10)
page 2: list_proposal_ids(offset=10, limit=10)
list_proposals works identically.

test.rs
 — 5 new tests:

test_list_proposal_ids_empty — empty result before any proposals exist
test_list_proposals_empty — empty result for full-object variant
test_list_proposal_ids_ascending_order — IDs returned oldest-first, strictly increasing
test_list_proposals_returns_full_objects — correct fields on returned objects
test_list_proposal_ids_pagination — offset/limit paging verified across multiple pages
Testing

All checks pass: cargo test, cargo clippy, cargo fmt.

Acceptance Criteria

 Proposal listing endpoint added
 Empty state handled
 Multiple proposals returned consistently
 Ordering documented (ascending by creation ID) and tested
 Endpoint is usable by frontend/SDK consumers
 
 closes #272 