### PR TITLE
[#256] Implement Recipient List Persistence for Whitelist and Blacklist Management

### DIFF
--- a/frontend/src/components/RecipientListManagement.tsx
+++ b/frontend/src/components/RecipientListManagement.tsx
@@ -9,7 +9,7 @@ interface RecipientListManagementProps {
 
 export default function RecipientListManagement({ onClose }: RecipientListManagementProps) {
     const { getListMode, setListMode, addToWhitelist, removeFromWhitelist,
-        addToBlacklist, removeFromBlacklist } = useVaultContract();
+        addToBlacklist, removeFromBlacklist, getWhitelistAddresses, getBlacklistAddresses } = useVaultContract();
     const { notify } = useToast();
 
     const [mode, setModeState] = useState<ListMode>('Disabled');
@@ -22,16 +22,22 @@ export default function RecipientListManagement({ onClose }: RecipientListManage
     const [showImportModal, setShowImportModal] = useState(false);
 
     useEffect(() => {
-        loadListMode();
+        loadRecipientLists();
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const loadListMode = async () => {
+    const loadRecipientLists = async () => {
         try {
-            const currentMode = await getListMode();
+            const [currentMode, whitelist, blacklist] = await Promise.all([
+                getListMode(),
+                getWhitelistAddresses(),
+                getBlacklistAddresses(),
+            ]);
             setModeState(currentMode as ListMode);
+            setWhitelistAddresses(whitelist);
+            setBlacklistAddresses(blacklist);
         } catch (error) {
-            console.error('Failed to load list mode:', error);
+            console.error('Failed to load recipient lists:', error);
         }
     };
 
@@ -57,12 +63,22 @@ export default function RecipientListManagement({ onClose }: RecipientListManage
         setIsLoading(true);
         try {
             if (mode === 'Whitelist') {
-                await addToWhitelist(newAddress);
-                setWhitelistAddresses([...whitelistAddresses, newAddress]);
+                const nextAddress = newAddress.trim();
+                if (!nextAddress) {
+                    notify('config_updated', 'Please enter a valid address', 'error');
+                    return;
+                }
+                await addToWhitelist(nextAddress);
+                setWhitelistAddresses((prev) => (prev.includes(nextAddress) ? prev : [...prev, nextAddress]));
                 notify('config_updated', 'Address added to whitelist', 'success');
             } else if (mode === 'Blacklist') {
-                await addToBlacklist(newAddress);
-                setBlacklistAddresses([...blacklistAddresses, newAddress]);
+                const nextAddress = newAddress.trim();
+                if (!nextAddress) {
+                    notify('config_updated', 'Please enter a valid address', 'error');
+                    return;
+                }
+                await addToBlacklist(nextAddress);
+                setBlacklistAddresses((prev) => (prev.includes(nextAddress) ? prev : [...prev, nextAddress]));
                 notify('config_updated', 'Address added to blacklist', 'success');
             }
             setNewAddress('');
@@ -101,23 +117,25 @@ export default function RecipientListManagement({ onClose }: RecipientListManage
             return;
         }
 
-        addresses.forEach(async (addr) => {
-            try {
+        Promise.allSettled(
+            addresses.map(async (addr) => {
                 if (mode === 'Whitelist') {
                     await addToWhitelist(addr);
-                    setWhitelistAddresses(prev => [...prev, addr]);
                 } else if (mode === 'Blacklist') {
                     await addToBlacklist(addr);
-                    setBlacklistAddresses(prev => [...prev, addr]);
                 }
-            } catch (error) {
-                console.error(`Failed to add ${addr}:`, error);
-            }
+            }),
+        ).then(async () => {
+            const [whitelist, blacklist] = await Promise.all([
+                getWhitelistAddresses(),
+                getBlacklistAddresses(),
+            ]);
+            setWhitelistAddresses(whitelist);
+            setBlacklistAddresses(blacklist);
+            notify('config_updated', `Imported ${addresses.length} addresses`, 'success');
+            setCsvImportText('');
+            setShowImportModal(false);
         });
-
-        notify('config_updated', `Imported ${addresses.length} addresses`, 'success');
-        setCsvImportText('');
-        setShowImportModal(false);
     };
 
     const handleExportCSV = () => {

--- a/frontend/src/hooks/useVaultContract.ts
+++ b/frontend/src/hooks/useVaultContract.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import {
     xdr,
     Address,
@@ -35,6 +35,13 @@ import {
 const EVENTS_PAGE_SIZE = 20;
 
 const server = new SorobanRpc.Server(env.sorobanRpcUrl);
+
+const RECIPIENT_LIST_STORAGE_PREFIX = 'vault_recipient_lists';
+const normalizeRecipientAddress = (recipient: string): string => recipient.trim();
+const dedupeRecipients = (addresses: string[]): string[] => {
+    const normalized = addresses.map(normalizeRecipientAddress).filter((address) => address.length > 0);
+    return Array.from(new Set(normalized));
+};
 
 // Recurring Payment Types
 export interface RecurringPayment {
@@ -194,11 +201,42 @@ interface RawEvent {
 
 export const useVaultContract = () => {
     const { address, isConnected, signTransaction } = useWallet();
+    const recipientStorageKey = `${RECIPIENT_LIST_STORAGE_PREFIX}_${env.contractId}`;
+    const loadRecipientState = useCallback((): { mode: ListMode; whitelist: string[]; blacklist: string[] } => {
+        try {
+            const stored = localStorage.getItem(recipientStorageKey);
+            if (!stored) {
+                return { mode: 'Disabled', whitelist: [], blacklist: [] };
+            }
+            const parsed = JSON.parse(stored) as { mode?: ListMode; whitelist?: string[]; blacklist?: string[] };
+            const mode: ListMode = parsed.mode === 'Whitelist' || parsed.mode === 'Blacklist' ? parsed.mode : 'Disabled';
+            return {
+                mode,
+                whitelist: dedupeRecipients(Array.isArray(parsed.whitelist) ? parsed.whitelist : []),
+                blacklist: dedupeRecipients(Array.isArray(parsed.blacklist) ? parsed.blacklist : []),
+            };
+        } catch {
+            return { mode: 'Disabled', whitelist: [], blacklist: [] };
+        }
+    }, [recipientStorageKey]);
+
+    const initialRecipientState = loadRecipientState();
     const [loading, setLoading] = useState(false);
-    const [recipientListMode, setRecipientListMode] = useState<ListMode>('Disabled');
-    const [whitelistAddresses, setWhitelistAddresses] = useState<string[]>([]);
-    const [blacklistAddresses, setBlacklistAddresses] = useState<string[]>([]);
+    const [recipientListMode, setRecipientListMode] = useState<ListMode>(initialRecipientState.mode);
+    const [whitelistAddresses, setWhitelistAddresses] = useState<string[]>(initialRecipientState.whitelist);
+    const [blacklistAddresses, setBlacklistAddresses] = useState<string[]>(initialRecipientState.blacklist);
     const [proposalComments, setProposalComments] = useState<Record<string, Comment[]>>({});
+
+    useEffect(() => {
+        localStorage.setItem(
+            recipientStorageKey,
+            JSON.stringify({
+                mode: recipientListMode,
+                whitelist: dedupeRecipients(whitelistAddresses),
+                blacklist: dedupeRecipients(blacklistAddresses),
+            }),
+        );
+    }, [recipientListMode, whitelistAddresses, blacklistAddresses, recipientStorageKey]);
 
     const readContractValue = useCallback(async (functionName: string, args: xdr.ScVal[] = []): Promise<unknown> => {
         const source = address ?? env.contractId;
@@ -925,12 +963,28 @@ export const useVaultContract = () => {
 
     const getListMode = useCallback(async (): Promise<ListMode> => recipientListMode, [recipientListMode]);
     const setListMode = useCallback(async (mode: ListMode): Promise<void> => { setRecipientListMode(mode); }, []);
-    const addToWhitelist = useCallback(async (recipient: string): Promise<void> => { setWhitelistAddresses((prev) => (prev.includes(recipient) ? prev : [...prev, recipient])); }, []);
-    const removeFromWhitelist = useCallback(async (recipient: string): Promise<void> => { setWhitelistAddresses((prev) => prev.filter((a) => a !== recipient)); }, []);
-    const addToBlacklist = useCallback(async (recipient: string): Promise<void> => { setBlacklistAddresses((prev) => (prev.includes(recipient) ? prev : [...prev, recipient])); }, []);
-    const removeFromBlacklist = useCallback(async (recipient: string): Promise<void> => { setBlacklistAddresses((prev) => prev.filter((a) => a !== recipient)); }, []);
+    const addToWhitelist = useCallback(async (recipient: string): Promise<void> => {
+        const normalized = normalizeRecipientAddress(recipient);
+        if (!normalized) return;
+        setWhitelistAddresses((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
+    }, []);
+    const removeFromWhitelist = useCallback(async (recipient: string): Promise<void> => {
+        const normalized = normalizeRecipientAddress(recipient);
+        setWhitelistAddresses((prev) => prev.filter((a) => a !== normalized));
+    }, []);
+    const addToBlacklist = useCallback(async (recipient: string): Promise<void> => {
+        const normalized = normalizeRecipientAddress(recipient);
+        if (!normalized) return;
+        setBlacklistAddresses((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
+    }, []);
+    const removeFromBlacklist = useCallback(async (recipient: string): Promise<void> => {
+        const normalized = normalizeRecipientAddress(recipient);
+        setBlacklistAddresses((prev) => prev.filter((a) => a !== normalized));
+    }, []);
     const isWhitelisted = useCallback(async (recipient: string): Promise<boolean> => whitelistAddresses.includes(recipient), [whitelistAddresses]);
     const isBlacklisted = useCallback(async (recipient: string): Promise<boolean> => blacklistAddresses.includes(recipient), [blacklistAddresses]);
+    const getWhitelistAddresses = useCallback(async (): Promise<string[]> => [...whitelistAddresses], [whitelistAddresses]);
+    const getBlacklistAddresses = useCallback(async (): Promise<string[]> => [...blacklistAddresses], [blacklistAddresses]);
 
     /**
      * Derive proposals from on-chain events.
@@ -1214,7 +1268,7 @@ export const useVaultContract = () => {
         addComment, editComment, getProposalComments,
         getListMode, setListMode,
         addToWhitelist, removeFromWhitelist, addToBlacklist, removeFromBlacklist,
-        isWhitelisted, isBlacklisted,
+        isWhitelisted, isBlacklisted, getWhitelistAddresses, getBlacklistAddresses,
         getVaultConfig,
         getTokenBalances,
         getPortfolioValue,


### PR DESCRIPTION
## Summary
- Persist recipient list mode, whitelist, and blacklist in `useVaultContract` using a contract-scoped localStorage fallback key.
- Add deduped, normalized recipient mutations and read APIs so list operations stay idempotent across refreshes.
- Update `RecipientListManagement` to load persisted lists on mount and keep UI state synchronized after add/remove/CSV import mutations.

## Test plan
- [x] `npm run backend:typecheck`
- [x] `npm run backend:test`
- [x] `npm --prefix frontend run build`
- [ ] `cargo test` (running)

Closes #256
