### PR TITLE
[#255] Complete Role Management Contract Wiring

### DIFF
--- a/frontend/src/components/RoleManagement.tsx
+++ b/frontend/src/components/RoleManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Shield, UserPlus, Search, Users } from 'lucide-react';
 import { useVaultContract } from '../hooks/useVaultContract';
 import { useToast } from '../hooks/useToast';
@@ -29,6 +29,7 @@ const RoleManagement: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [newAddress, setNewAddress] = useState('');
   const [selectedRole, setSelectedRole] = useState<number>(0);
+  const [isRefreshingRoles, setIsRefreshingRoles] = useState(false);
   const [confirmModal, setConfirmModal] = useState<{
     isOpen: boolean;
     type: 'assign' | 'change' | 'revoke';
@@ -37,11 +38,8 @@ const RoleManagement: React.FC = () => {
     newRole?: number;
   }>({ isOpen: false, type: 'assign' });
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
+    setIsRefreshingRoles(true);
     try {
       const role = await getUserRole();
       setCurrentUserRole(role);
@@ -52,20 +50,28 @@ const RoleManagement: React.FC = () => {
       }
     } catch (error) {
       console.error('Failed to load role data:', error);
+      notify("config_updated", "Failed to load role assignments", "error");
+    } finally {
+      setIsRefreshingRoles(false);
     }
-  };
+  }, [getAllRoles, getUserRole, notify]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const validateStellarAddress = (addr: string): boolean => {
     return /^G[A-Z0-9]{55}$/.test(addr);
   };
 
   const handleAssignRole = () => {
-    if (!validateStellarAddress(newAddress)) {
+    const normalizedAddress = newAddress.trim().toUpperCase();
+    if (!validateStellarAddress(normalizedAddress)) {
       notify("config_updated", "Invalid Stellar address format", "error");
       return;
     }
 
-    const existing = roleAssignments.find(r => r.address === newAddress);
+    const existing = roleAssignments.find(r => r.address === normalizedAddress);
     if (existing) {
       notify("config_updated", "Address already has a role. Use Change Role instead.", "info");
       return;
@@ -74,7 +80,7 @@ const RoleManagement: React.FC = () => {
     setConfirmModal({
       isOpen: true,
       type: 'assign',
-      address: newAddress,
+      address: normalizedAddress,
       newRole: selectedRole
     });
   };
@@ -105,10 +111,10 @@ const RoleManagement: React.FC = () => {
       if (!address) return;
 
       if (type === 'revoke') {
-        await setRole?.();
+        await setRole?.(address, 0);
         notify('config_updated', 'Role revoked successfully', 'success');
       } else {
-        await setRole?.();
+        await setRole?.(address, confirmModal.newRole ?? 0);
         notify('config_updated', `Role ${type === 'assign' ? 'assigned' : 'changed'} successfully`, 'success');
       }
 
@@ -210,10 +216,10 @@ const RoleManagement: React.FC = () => {
         </div>
         <button
           onClick={handleAssignRole}
-          disabled={loading || !newAddress}
+          disabled={loading || isRefreshingRoles || !newAddress.trim()}
           className="mt-4 w-full md:w-auto px-6 py-2.5 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-700 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-colors min-h-[44px]"
         >
-          Assign Role
+          {loading ? 'Submitting...' : 'Assign Role'}
         </button>
       </div>
 
@@ -236,7 +242,9 @@ const RoleManagement: React.FC = () => {
           </div>
         </div>
 
-        {filteredAssignments.length === 0 ? (
+        {isRefreshingRoles ? (
+          <p className="text-center text-gray-400 py-8">Loading role assignments...</p>
+        ) : filteredAssignments.length === 0 ? (
           <p className="text-center text-gray-400 py-8">No role assignments found.</p>
         ) : (
           <div className="overflow-x-auto">
@@ -265,12 +273,14 @@ const RoleManagement: React.FC = () => {
                       <div className="flex justify-end gap-2">
                         <button
                           onClick={() => handleChangeRole(assignment.address, assignment.role)}
+                          disabled={loading}
                           className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg transition-colors min-h-[36px] min-w-[36px]"
                         >
                           Change
                         </button>
                         <button
                           onClick={() => handleRevokeRole(assignment.address, assignment.role)}
+                          disabled={loading}
                           className="px-3 py-1.5 bg-red-600/20 hover:bg-red-600/30 text-red-400 text-sm rounded-lg transition-colors min-h-[36px] min-w-[36px]"
                         >
                           Revoke

--- a/frontend/src/hooks/useVaultContract.ts
+++ b/frontend/src/hooks/useVaultContract.ts
@@ -80,6 +80,11 @@ export interface VaultConfig {
     isCurrentUserSigner: boolean;
 }
 
+export interface RoleAssignment {
+    address: string;
+    role: number;
+}
+
 interface StellarBalance {
     asset_type: string;
     balance: string;
@@ -178,6 +183,23 @@ function parseBigIntString(value: unknown): string {
 function parseSignerAddresses(value: unknown): string[] {
     if (!Array.isArray(value)) return [];
     return value.map((item) => addressToNative(item)).filter((item) => item.length > 0);
+}
+
+function parseRoleAssignments(value: unknown): RoleAssignment[] {
+    if (!Array.isArray(value)) return [];
+    return value
+        .map((item) => {
+            if (item == null || typeof item !== 'object') return null;
+            const record = item as Record<string, unknown>;
+            const addressValue = record.address ?? record.addr;
+            const roleValue = record.role;
+            const address = addressToNative(addressValue);
+            const role = parseNumericValue(roleValue);
+            if (!address || !isValidStellarAddress(address)) return null;
+            if (![0, 1, 2].includes(role)) return null;
+            return { address, role };
+        })
+        .filter((assignment): assignment is RoleAssignment => assignment != null);
 }
 
 interface RawEvent {
@@ -382,7 +404,7 @@ export const useVaultContract = () => {
 
         // Fallback: derive signer count from Horizon account data
         let fallbackSignerCount = 0;
-        let fallbackThreshold = 0;
+        const fallbackThreshold = 0;
         try {
             const accountInfo = await server.getAccount(env.contractId) as unknown as { signers?: Array<unknown> };
             fallbackSignerCount = Array.isArray(accountInfo.signers) ? accountInfo.signers.length : 0;
@@ -1398,10 +1420,99 @@ export const useVaultContract = () => {
                 }
             } catch { /* ignore */ }
         },
-        getAllRoles: async () => [],
-        setRole: async () => { },
+        getAllRoles: async (): Promise<RoleAssignment[]> => {
+            const result = await readContractValue('get_role_assignments');
+            return parseRoleAssignments(result);
+        },
+        setRole: async (targetAddress: string, nextRole: number): Promise<string> => {
+            if (!isConnected || !address) throw new Error("Wallet not connected");
+            const normalizedAddress = targetAddress.trim();
+            if (!isValidStellarAddress(normalizedAddress)) {
+                throw new Error('Invalid Stellar address');
+            }
+            if (![0, 1, 2].includes(nextRole)) {
+                throw new Error('Invalid role selected');
+            }
+
+            setLoading(true);
+            try {
+                const account = await server.getAccount(address);
+                const tx = new TransactionBuilder(account, { fee: "100" })
+                    .setNetworkPassphrase(env.networkPassphrase)
+                    .setTimeout(30)
+                    .addOperation(Operation.invokeHostFunction({
+                        func: xdr.HostFunction.hostFunctionTypeInvokeContract(
+                            new xdr.InvokeContractArgs({
+                                contractAddress: Address.fromString(env.contractId).toScAddress(),
+                                functionName: "set_role",
+                                args: [
+                                    new Address(address).toScVal(),
+                                    new Address(normalizedAddress).toScVal(),
+                                    nativeToScVal(BigInt(nextRole), { type: "u32" }),
+                                ],
+                            })
+                        ),
+                        auth: [],
+                    }))
+                    .build();
+                const simulation = await server.simulateTransaction(tx);
+                if (SorobanRpc.Api.isSimulationError(simulation)) throw new Error(`Simulation Failed: ${simulation.error}`);
+                const preparedTx = SorobanRpc.assembleTransaction(tx, simulation).build();
+                const signedXdr = await signTransaction(preparedTx.toXDR(), { network: env.stellarNetwork });
+                const response = await server.sendTransaction(TransactionBuilder.fromXDR(signedXdr as string, env.networkPassphrase));
+                return response.hash;
+            } catch (e: unknown) {
+                throw parseError(e);
+            } finally {
+                setLoading(false);
+            }
+        },
         getUserRole,
-        assignRole: async () => { },
+        assignRole: async (targetAddress: string, nextRole: number): Promise<string> => {
+            return await (async () => {
+                if (!isConnected || !address) throw new Error("Wallet not connected");
+                const normalizedAddress = targetAddress.trim();
+                if (!isValidStellarAddress(normalizedAddress)) {
+                    throw new Error('Invalid Stellar address');
+                }
+                if (![0, 1, 2].includes(nextRole)) {
+                    throw new Error('Invalid role selected');
+                }
+
+                setLoading(true);
+                try {
+                    const account = await server.getAccount(address);
+                    const tx = new TransactionBuilder(account, { fee: "100" })
+                        .setNetworkPassphrase(env.networkPassphrase)
+                        .setTimeout(30)
+                        .addOperation(Operation.invokeHostFunction({
+                            func: xdr.HostFunction.hostFunctionTypeInvokeContract(
+                                new xdr.InvokeContractArgs({
+                                    contractAddress: Address.fromString(env.contractId).toScAddress(),
+                                    functionName: "set_role",
+                                    args: [
+                                        new Address(address).toScVal(),
+                                        new Address(normalizedAddress).toScVal(),
+                                        nativeToScVal(BigInt(nextRole), { type: "u32" }),
+                                    ],
+                                })
+                            ),
+                            auth: [],
+                        }))
+                        .build();
+                    const simulation = await server.simulateTransaction(tx);
+                    if (SorobanRpc.Api.isSimulationError(simulation)) throw new Error(`Simulation Failed: ${simulation.error}`);
+                    const preparedTx = SorobanRpc.assembleTransaction(tx, simulation).build();
+                    const signedXdr = await signTransaction(preparedTx.toXDR(), { network: env.stellarNetwork });
+                    const response = await server.sendTransaction(TransactionBuilder.fromXDR(signedXdr as string, env.networkPassphrase));
+                    return response.hash;
+                } catch (e: unknown) {
+                    throw parseError(e);
+                } finally {
+                    setLoading(false);
+                }
+            })();
+        },
         updateSpendingLimits,
         getProposals,
     };


### PR DESCRIPTION
## Summary
- Wire `RoleManagement` to on-chain role assignment endpoints by implementing `getAllRoles` and `setRole` in `useVaultContract`.
- Add strict Stellar address/role validation and normalize role assignment payloads before rendering.
- Update role mutation UX to pass real parameters for assign/change/revoke and refresh role assignments after every mutation.

## Validation
- `npm run build` (frontend)
- `cargo test` (contracts/vault)

Closes #255