### PR TITLE
fix: Add WebSocket Server Scaffold for Backend Realtime Features (#334)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,10 @@ import { loadEnv } from "./config/env.js";
 import { startServer } from "./server.js";
 import { createLogger } from "./shared/logging/logger.js";
 import { LifecycleManager } from "./app/lifecycle/lifecycle-manager.js";
+import { RealtimeServer, createRealtimeTopic } from "./modules/realtime/index.js";
+import { InMemoryNotificationQueue } from "./modules/notifications/index.js";
+import { ScheduledJobRunner } from "./modules/jobs/index.js";
+import { randomUUID } from "node:crypto";
 
 function maskContractId(contractId: string): string {
   if (contractId.length <= 10) return contractId;
@@ -27,7 +31,63 @@ const env = loadEnv();
 
 logStartupConfig(env);
 
+const logger = createLogger("vaultdao-backend");
+const realtimeServer = new RealtimeServer({
+  onConnected: (connectionId) => {
+    logger.info("realtime connection opened", { connectionId });
+  },
+  onDisconnected: (connectionId) => {
+    logger.info("realtime connection closed", { connectionId });
+  },
+});
+const notificationQueue = new InMemoryNotificationQueue();
+const jobRunner = new ScheduledJobRunner();
+
+const notificationTopic = createRealtimeTopic("notification", "events");
+const unsubscribeNotificationBridge = notificationQueue.subscribe((event) => {
+  realtimeServer.broadcast(notificationTopic, event);
+});
+
+jobRunner.register({
+  name: "notification-queue-heartbeat",
+  intervalMs: 60_000,
+  runOnStart: false,
+  run: async () => {
+    await notificationQueue.publish({
+      id: randomUUID(),
+      topic: notificationTopic,
+      source: "jobs.notification-queue-heartbeat",
+      createdAt: new Date().toISOString(),
+      payload: {
+        queueDepth: notificationQueue.size(),
+      },
+    });
+  },
+});
+
+realtimeServer.start();
+jobRunner.start();
+
 // Start server and integrate with lifecycle management
 const server = startServer(env);
 const lifecycle = new LifecycleManager(server);
+lifecycle.onShutdown({
+  name: "scheduled-job-runner",
+  handler: () => {
+    jobRunner.stop();
+  },
+});
+lifecycle.onShutdown({
+  name: "notification-queue",
+  handler: () => {
+    unsubscribeNotificationBridge();
+    notificationQueue.shutdown();
+  },
+});
+lifecycle.onShutdown({
+  name: "realtime-server",
+  handler: () => {
+    realtimeServer.stop();
+  },
+});
 lifecycle.initialize();

--- a/backend/src/modules/jobs/index.ts
+++ b/backend/src/modules/jobs/index.ts
@@ -7,3 +7,4 @@
 
 export * from "./recurring/index.js";
 export * from "./job.manager.js";
+export * from "./scheduled-job-runner.js";

--- a/backend/src/modules/jobs/scheduled-job-runner.test.ts
+++ b/backend/src/modules/jobs/scheduled-job-runner.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ScheduledJobRunner } from "./scheduled-job-runner.js";
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+test("ScheduledJobRunner", async (t) => {
+  await t.test("starts and stops interval jobs", async () => {
+    const runner = new ScheduledJobRunner();
+    let count = 0;
+
+    runner.register({
+      name: "tick",
+      intervalMs: 10,
+      runOnStart: false,
+      run: () => {
+        count += 1;
+      },
+    });
+
+    runner.start();
+    await wait(35);
+    runner.stop();
+
+    assert.equal(runner.isRunning(), false);
+    assert.ok(count >= 2, `expected at least 2 runs, received ${count}`);
+  });
+
+  await t.test("isolates job failures so other jobs continue", async () => {
+    const runner = new ScheduledJobRunner();
+    let healthyRuns = 0;
+
+    runner.register({
+      name: "failing",
+      intervalMs: 10,
+      runOnStart: true,
+      run: () => {
+        throw new Error("expected failure");
+      },
+    });
+
+    runner.register({
+      name: "healthy",
+      intervalMs: 10,
+      runOnStart: true,
+      run: () => {
+        healthyRuns += 1;
+      },
+    });
+
+    runner.start();
+    await wait(40);
+    runner.stop();
+
+    assert.ok(healthyRuns >= 2, `expected healthy job to run at least twice, received ${healthyRuns}`);
+  });
+});

--- a/backend/src/modules/jobs/scheduled-job-runner.ts
+++ b/backend/src/modules/jobs/scheduled-job-runner.ts
@@ -1,0 +1,104 @@
+import { createLogger } from "../../shared/logging/logger.js";
+
+export interface ScheduledJobContext {
+  readonly now: () => Date;
+}
+
+export interface ScheduledJob {
+  readonly name: string;
+  readonly intervalMs: number;
+  readonly runOnStart?: boolean;
+  run(context: ScheduledJobContext): Promise<void> | void;
+}
+
+export class ScheduledJobRunner {
+  private readonly logger = createLogger("scheduled-job-runner");
+  private readonly jobs = new Map<string, ScheduledJob>();
+  private readonly handles = new Map<string, NodeJS.Timeout>();
+  private started = false;
+
+  public register(job: ScheduledJob): void {
+    if (job.intervalMs < 1) {
+      throw new Error(`Job ${job.name} intervalMs must be >= 1`);
+    }
+
+    if (this.jobs.has(job.name)) {
+      this.logger.warn("scheduled job already registered", { job: job.name });
+      return;
+    }
+
+    this.jobs.set(job.name, job);
+    this.logger.info("scheduled job registered", {
+      job: job.name,
+      intervalMs: job.intervalMs,
+    });
+
+    if (this.started) {
+      this.startJob(job);
+    }
+  }
+
+  public start(): void {
+    if (this.started) {
+      this.logger.warn("scheduled job runner already started");
+      return;
+    }
+
+    this.started = true;
+    for (const job of this.jobs.values()) {
+      this.startJob(job);
+    }
+
+    this.logger.info("scheduled job runner started", {
+      jobCount: this.jobs.size,
+    });
+  }
+
+  public stop(): void {
+    for (const handle of this.handles.values()) {
+      clearInterval(handle);
+    }
+
+    this.handles.clear();
+    this.started = false;
+    this.logger.info("scheduled job runner stopped");
+  }
+
+  public isRunning(): boolean {
+    return this.started;
+  }
+
+  public getRegisteredJobNames(): string[] {
+    return Array.from(this.jobs.keys());
+  }
+
+  private startJob(job: ScheduledJob): void {
+    if (job.runOnStart ?? true) {
+      void this.runJobSafely(job);
+    }
+
+    const handle = setInterval(() => {
+      void this.runJobSafely(job);
+    }, job.intervalMs);
+
+    this.handles.set(job.name, handle);
+  }
+
+  private async runJobSafely(job: ScheduledJob): Promise<void> {
+    const startedAt = Date.now();
+
+    try {
+      await Promise.resolve(job.run({ now: () => new Date() }));
+      this.logger.info("scheduled job completed", {
+        job: job.name,
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (err) {
+      this.logger.warn("scheduled job failed", {
+        job: job.name,
+        durationMs: Date.now() - startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/backend/src/modules/notifications/in-memory-notification-queue.ts
+++ b/backend/src/modules/notifications/in-memory-notification-queue.ts
@@ -1,0 +1,54 @@
+import { createLogger } from "../../shared/logging/logger.js";
+import type {
+  NotificationConsumer,
+  NotificationEvent,
+  NotificationQueue,
+  NotificationUnsubscribe,
+} from "./notification.types.js";
+
+export class InMemoryNotificationQueue implements NotificationQueue {
+  private readonly logger = createLogger("notification-queue");
+  private readonly consumers = new Set<NotificationConsumer>();
+  private readonly events: NotificationEvent[] = [];
+
+  public async publish(event: NotificationEvent): Promise<void> {
+    this.events.push(event);
+
+    const deliveries = Array.from(this.consumers).map(async (consumer) => {
+      try {
+        await Promise.resolve(consumer(event));
+      } catch (err) {
+        this.logger.warn("notification consumer failed", {
+          eventId: event.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    });
+
+    await Promise.all(deliveries);
+  }
+
+  public subscribe(handler: NotificationConsumer): NotificationUnsubscribe {
+    this.consumers.add(handler);
+    this.logger.info("notification consumer subscribed", {
+      total: this.consumers.size,
+    });
+
+    return () => {
+      this.consumers.delete(handler);
+      this.logger.info("notification consumer unsubscribed", {
+        total: this.consumers.size,
+      });
+    };
+  }
+
+  public size(): number {
+    return this.events.length;
+  }
+
+  public shutdown(): void {
+    this.consumers.clear();
+    this.events.length = 0;
+    this.logger.info("notification queue shut down");
+  }
+}

--- a/backend/src/modules/notifications/index.ts
+++ b/backend/src/modules/notifications/index.ts
@@ -1,0 +1,2 @@
+export * from "./notification.types.js";
+export * from "./in-memory-notification-queue.js";

--- a/backend/src/modules/notifications/notification.types.ts
+++ b/backend/src/modules/notifications/notification.types.ts
@@ -1,0 +1,26 @@
+export interface NotificationEvent<TPayload = Record<string, unknown>> {
+  readonly id: string;
+  readonly topic: string;
+  readonly source: string;
+  readonly createdAt: string;
+  readonly payload: TPayload;
+}
+
+export type NotificationConsumer = (
+  event: NotificationEvent,
+) => Promise<void> | void;
+
+export type NotificationUnsubscribe = () => void;
+
+export interface NotificationPublisher {
+  publish(event: NotificationEvent): Promise<void>;
+}
+
+export interface NotificationSubscriber {
+  subscribe(handler: NotificationConsumer): NotificationUnsubscribe;
+}
+
+export interface NotificationQueue extends NotificationPublisher, NotificationSubscriber {
+  size(): number;
+  shutdown(): void;
+}

--- a/backend/src/modules/realtime/index.ts
+++ b/backend/src/modules/realtime/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./realtime-server.js";
+export * from "./subscriptions/index.js";

--- a/backend/src/modules/realtime/realtime-server.ts
+++ b/backend/src/modules/realtime/realtime-server.ts
@@ -1,0 +1,148 @@
+import { createLogger } from "../../shared/logging/logger.js";
+import {
+  createRealtimeTopic,
+  createTopicBroadcaster,
+  SubscriptionRegistry,
+  type RealtimeTopic,
+} from "./subscriptions/index.js";
+import type {
+  RealtimeConnection,
+  RealtimeConnectionLifecycleHooks,
+  RealtimeEnvelope,
+} from "./types.js";
+
+export class RealtimeServer {
+  private readonly logger = createLogger("realtime-server");
+  private readonly connections = new Map<string, RealtimeConnection>();
+  private readonly subscriptions = new SubscriptionRegistry();
+  private readonly broadcaster = createTopicBroadcaster(
+    this.subscriptions,
+    (clientId, message) => this.deliver(clientId, message),
+  );
+  private readonly hooks: RealtimeConnectionLifecycleHooks;
+  private started = false;
+
+  constructor(hooks: RealtimeConnectionLifecycleHooks = {}) {
+    this.hooks = hooks;
+  }
+
+  public start(): void {
+    if (this.started) {
+      this.logger.warn("realtime server already started");
+      return;
+    }
+
+    this.started = true;
+    this.logger.info("realtime server scaffold started");
+  }
+
+  public stop(): void {
+    if (!this.started) return;
+
+    const connectedIds = Array.from(this.connections.keys());
+    for (const connectionId of connectedIds) {
+      this.unregisterConnection(connectionId, "server shutdown");
+    }
+
+    this.started = false;
+    this.logger.info("realtime server scaffold stopped");
+  }
+
+  public registerConnection(connection: RealtimeConnection): void {
+    this.connections.set(connection.id, connection);
+    this.hooks.onConnected?.(connection.id);
+
+    connection.send({
+      type: "hello",
+      ts: new Date().toISOString(),
+      payload: {
+        connectionId: connection.id,
+        status: "connected",
+      },
+    });
+
+    this.logger.info("connection registered", { connectionId: connection.id });
+  }
+
+  public unregisterConnection(connectionId: string, reason = "client disconnected"): void {
+    const connection = this.connections.get(connectionId);
+    if (!connection) return;
+
+    this.subscriptions.unsubscribeAll(connectionId);
+    this.connections.delete(connectionId);
+    this.hooks.onDisconnected?.(connectionId);
+
+    connection.close?.(1000, reason);
+    this.logger.info("connection unregistered", { connectionId, reason });
+  }
+
+  public subscribe(connectionId: string, topic: RealtimeTopic): boolean {
+    if (!this.connections.has(connectionId)) {
+      this.logger.warn("subscribe attempted for unknown connection", { connectionId, topic });
+      return false;
+    }
+
+    const added = this.subscriptions.subscribe(connectionId, topic);
+    if (!added) return false;
+
+    this.hooks.onSubscribed?.(connectionId, topic);
+    this.deliver(connectionId, {
+      type: "subscribed",
+      topic,
+      ts: new Date().toISOString(),
+      payload: { topic },
+    });
+
+    return true;
+  }
+
+  public unsubscribe(connectionId: string, topic: RealtimeTopic): boolean {
+    const removed = this.subscriptions.unsubscribe(connectionId, topic);
+    if (!removed) return false;
+
+    this.hooks.onUnsubscribed?.(connectionId, topic);
+    this.deliver(connectionId, {
+      type: "unsubscribed",
+      topic,
+      ts: new Date().toISOString(),
+      payload: { topic },
+    });
+
+    return true;
+  }
+
+  public broadcast(topic: RealtimeTopic, payload: unknown): number {
+    return this.broadcaster.broadcast(topic, {
+      type: "event",
+      topic,
+      payload,
+      ts: new Date().toISOString(),
+    });
+  }
+
+  public createTopic(namespace: "proposal" | "activity" | "system" | "notification" | "custom", key: string): RealtimeTopic {
+    return createRealtimeTopic(namespace, key);
+  }
+
+  public getConnectionCount(): number {
+    return this.connections.size;
+  }
+
+  public getSubscriptions(connectionId: string): ReadonlySet<RealtimeTopic> {
+    return this.subscriptions.getTopics(connectionId);
+  }
+
+  private deliver(connectionId: string, message: RealtimeEnvelope): void {
+    const connection = this.connections.get(connectionId);
+    if (!connection) return;
+
+    try {
+      connection.send(message);
+    } catch (err) {
+      this.logger.warn("failed to deliver realtime message", {
+        connectionId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/backend/src/modules/realtime/subscriptions/broadcast.ts
+++ b/backend/src/modules/realtime/subscriptions/broadcast.ts
@@ -1,0 +1,20 @@
+import type { RealtimeEnvelope } from "../types.js";
+import type { RealtimeTopic } from "./topics.js";
+import type { SubscriptionRegistry } from "./subscription-registry.js";
+
+export interface TopicBroadcaster {
+  broadcast(topic: RealtimeTopic, message: RealtimeEnvelope): number;
+}
+
+export function createTopicBroadcaster(
+  registry: SubscriptionRegistry,
+  deliver: (clientId: string, message: RealtimeEnvelope) => void,
+): TopicBroadcaster {
+  return {
+    broadcast(topic, message) {
+      return registry.broadcast(topic, (clientId) => {
+        deliver(clientId, message);
+      });
+    },
+  };
+}

--- a/backend/src/modules/realtime/subscriptions/index.ts
+++ b/backend/src/modules/realtime/subscriptions/index.ts
@@ -1,0 +1,3 @@
+export * from "./topics.js";
+export * from "./subscription-registry.js";
+export * from "./broadcast.js";

--- a/backend/src/modules/realtime/subscriptions/subscription-registry.test.ts
+++ b/backend/src/modules/realtime/subscriptions/subscription-registry.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SubscriptionRegistry } from "./subscription-registry.js";
+import { createRealtimeTopic } from "./topics.js";
+
+test("SubscriptionRegistry", async (t) => {
+  await t.test("tracks subscribe and unsubscribe per client/topic", () => {
+    const registry = new SubscriptionRegistry();
+    const topic = createRealtimeTopic("proposal", "created");
+
+    assert.equal(registry.subscribe("client-1", topic), true);
+    assert.equal(registry.subscribe("client-1", topic), false);
+    assert.deepEqual(Array.from(registry.getTopics("client-1")), [topic]);
+    assert.deepEqual(Array.from(registry.getSubscribers(topic)), ["client-1"]);
+
+    assert.equal(registry.unsubscribe("client-1", topic), true);
+    assert.equal(registry.unsubscribe("client-1", topic), false);
+    assert.equal(registry.getTopics("client-1").size, 0);
+    assert.equal(registry.getSubscribers(topic).size, 0);
+  });
+
+  await t.test("broadcast reaches only topic subscribers", () => {
+    const registry = new SubscriptionRegistry();
+    const topicA = createRealtimeTopic("activity", "ledger-update");
+    const topicB = createRealtimeTopic("system", "health");
+
+    registry.subscribe("client-a", topicA);
+    registry.subscribe("client-b", topicA);
+    registry.subscribe("client-c", topicB);
+
+    const recipients: string[] = [];
+    const delivered = registry.broadcast(topicA, (clientId) => {
+      recipients.push(clientId);
+    });
+
+    assert.equal(delivered, 2);
+    assert.deepEqual(new Set(recipients), new Set(["client-a", "client-b"]));
+  });
+
+  await t.test("unsubscribeAll removes all client subscriptions", () => {
+    const registry = new SubscriptionRegistry();
+    const topicA = createRealtimeTopic("notification", "queue");
+    const topicB = createRealtimeTopic("custom", "audit-feed");
+
+    registry.subscribe("client-z", topicA);
+    registry.subscribe("client-z", topicB);
+
+    const removed = registry.unsubscribeAll("client-z");
+    assert.equal(removed, 2);
+    assert.equal(registry.getTopics("client-z").size, 0);
+    assert.equal(registry.getSubscribers(topicA).size, 0);
+    assert.equal(registry.getSubscribers(topicB).size, 0);
+  });
+});

--- a/backend/src/modules/realtime/subscriptions/subscription-registry.ts
+++ b/backend/src/modules/realtime/subscriptions/subscription-registry.ts
@@ -1,0 +1,80 @@
+import type { RealtimeTopic } from "./topics.js";
+
+function getOrCreate<TKey, TValue>(
+  map: Map<TKey, Set<TValue>>,
+  key: TKey,
+): Set<TValue> {
+  const existing = map.get(key);
+  if (existing) return existing;
+
+  const created = new Set<TValue>();
+  map.set(key, created);
+  return created;
+}
+
+export class SubscriptionRegistry {
+  private readonly byTopic = new Map<RealtimeTopic, Set<string>>();
+  private readonly byClient = new Map<string, Set<RealtimeTopic>>();
+
+  public subscribe(clientId: string, topic: RealtimeTopic): boolean {
+    const clientTopics = getOrCreate(this.byClient, clientId);
+    if (clientTopics.has(topic)) return false;
+
+    clientTopics.add(topic);
+    getOrCreate(this.byTopic, topic).add(clientId);
+    return true;
+  }
+
+  public unsubscribe(clientId: string, topic: RealtimeTopic): boolean {
+    const clientTopics = this.byClient.get(clientId);
+    if (!clientTopics || !clientTopics.has(topic)) return false;
+
+    clientTopics.delete(topic);
+    if (clientTopics.size === 0) {
+      this.byClient.delete(clientId);
+    }
+
+    const subscribers = this.byTopic.get(topic);
+    if (!subscribers) return true;
+
+    subscribers.delete(clientId);
+    if (subscribers.size === 0) {
+      this.byTopic.delete(topic);
+    }
+
+    return true;
+  }
+
+  public unsubscribeAll(clientId: string): number {
+    const topics = this.byClient.get(clientId);
+    if (!topics) return 0;
+
+    const topicList = Array.from(topics);
+    for (const topic of topicList) {
+      this.unsubscribe(clientId, topic);
+    }
+
+    return topicList.length;
+  }
+
+  public getSubscribers(topic: RealtimeTopic): ReadonlySet<string> {
+    return this.byTopic.get(topic) ?? new Set<string>();
+  }
+
+  public getTopics(clientId: string): ReadonlySet<RealtimeTopic> {
+    return this.byClient.get(clientId) ?? new Set<RealtimeTopic>();
+  }
+
+  public broadcast(topic: RealtimeTopic, send: (clientId: string) => void): number {
+    const subscribers = this.byTopic.get(topic);
+    if (!subscribers || subscribers.size === 0) return 0;
+
+    let delivered = 0;
+    for (const clientId of subscribers) {
+      send(clientId);
+      delivered += 1;
+    }
+
+    return delivered;
+  }
+}

--- a/backend/src/modules/realtime/subscriptions/topics.ts
+++ b/backend/src/modules/realtime/subscriptions/topics.ts
@@ -1,0 +1,23 @@
+const TOPIC_NAMESPACES = ["proposal", "activity", "system", "notification", "custom"] as const;
+
+export type TopicNamespace = (typeof TOPIC_NAMESPACES)[number];
+export type RealtimeTopic = `${TopicNamespace}.${string}`;
+
+function normalizeSegment(segment: string): string {
+  return segment.trim().toLowerCase().replace(/\s+/g, "-");
+}
+
+export function createRealtimeTopic(namespace: TopicNamespace, key: string): RealtimeTopic {
+  const normalizedKey = normalizeSegment(key);
+  if (normalizedKey.length === 0) {
+    throw new Error("Topic key cannot be empty");
+  }
+  return `${namespace}.${normalizedKey}`;
+}
+
+export function isRealtimeTopic(value: string): value is RealtimeTopic {
+  const [namespace, ...rest] = value.split(".");
+  if (rest.length === 0) return false;
+  if (!TOPIC_NAMESPACES.includes(namespace as TopicNamespace)) return false;
+  return rest.join(".").trim().length > 0;
+}

--- a/backend/src/modules/realtime/types.ts
+++ b/backend/src/modules/realtime/types.ts
@@ -1,0 +1,28 @@
+import type { RealtimeTopic } from "./subscriptions/topics.js";
+
+export type RealtimeMessageType =
+  | "hello"
+  | "event"
+  | "subscribed"
+  | "unsubscribed"
+  | "error";
+
+export interface RealtimeEnvelope<TPayload = unknown> {
+  readonly type: RealtimeMessageType;
+  readonly topic?: RealtimeTopic;
+  readonly payload?: TPayload;
+  readonly ts: string;
+}
+
+export interface RealtimeConnection {
+  readonly id: string;
+  send(message: RealtimeEnvelope): void;
+  close?(code?: number, reason?: string): void;
+}
+
+export interface RealtimeConnectionLifecycleHooks {
+  onConnected?(connectionId: string): void;
+  onDisconnected?(connectionId: string): void;
+  onSubscribed?(connectionId: string, topic: RealtimeTopic): void;
+  onUnsubscribed?(connectionId: string, topic: RealtimeTopic): void;
+}


### PR DESCRIPTION
## PR Title
feat: scaffold backend realtime transport, notification queue, and scheduled jobs

## Description
This PR introduces foundational backend scaffolding for future realtime and keeper-style capabilities.  
It adds a modular realtime layer, a lightweight notification queue, and a safe scheduled job runner, then wires all of them into application lifecycle startup and shutdown.

## What this PR includes
- Realtime server scaffold with clean lifecycle methods:
1. start and stop hooks
2. connection register and unregister flow
3. basic connection lifecycle callbacks

- Topic subscription model for realtime broadcasts:
1. predictable topic naming with namespaces
2. subscribe and unsubscribe behavior
3. subscription registry for client-to-topic and topic-to-client mapping
4. reusable broadcast entrypoint

- Notification queue scaffold:
1. typed notification event payload model
2. publish and subscribe interfaces
3. in-memory queue implementation for MVP
4. safe consumer error isolation so one bad consumer does not crash processing

- Scheduled job runner scaffold:
1. register, start, and stop lifecycle
2. interval-based scheduling
3. safe per-job failure handling with logging
4. no runner-wide crash from one failing job

- Startup integration path:
1. realtime, notifications, and jobs are initialized during backend startup
2. graceful shutdown hooks stop all scaffolds cleanly
3. notification-to-realtime bridge prepared for future fanout

## Why this approach
- Keeps infrastructure lightweight and modular
- Avoids coupling to frontend-specific message assumptions
- Establishes clean extension points for future notifications, live feeds, and keeper tasks
- Makes subscription logic and scheduler behavior testable from day one

## Validation
- Typecheck passed
- Existing backend tests passed
- Added tests for:
1. subscription registry bookkeeping and broadcast routing
2. scheduled job runner lifecycle and failure isolation

## Closes
- Closes #334
- Closes #335
- Closes #336
- Closes #337

If you want, I can also provide a shorter version optimized for GitHub’s default PR template style.