### PR TITLE
feat: add pagination to ProposalActivityAggregator.getAllProposals

### DIFF
--- a/backend/src/modules/proposals/aggregator.test.ts
+++ b/backend/src/modules/proposals/aggregator.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  GET_ALL_PROPOSALS_MAX_LIMIT,
+  ProposalActivityAggregator,
+} from "./aggregator.js";
+import {
+  ProposalActivityRecord,
+  ProposalActivityType,
+} from "./types.js";
+
+function makeCreatedRecord(
+  proposalId: string,
+  timestamp: string
+): ProposalActivityRecord {
+  return {
+    activityId: `${proposalId}-${timestamp}`,
+    proposalId,
+    type: ProposalActivityType.CREATED,
+    timestamp,
+    metadata: {
+      id: "e1",
+      contractId: "CCONTRACT",
+      ledger: 1,
+      ledgerClosedAt: timestamp,
+      transactionHash: "abc",
+      eventIndex: 0,
+    },
+    data: {
+      activityType: ProposalActivityType.CREATED,
+      proposer: "GPROPOSER",
+      recipient: "GRECIPIENT",
+      token: "native",
+      amount: "1",
+      insuranceAmount: "0",
+    },
+  };
+}
+
+test("getAllProposals({ offset: 0, limit: 20 }) returns at most 20 items", () => {
+  const agg = new ProposalActivityAggregator();
+  for (let i = 0; i < 25; i++) {
+    const ts = new Date(Date.UTC(2026, 0, 1 + i, 12, 0, 0)).toISOString();
+    agg.addRecord(makeCreatedRecord(`p${i}`, ts));
+  }
+
+  const page = agg.getAllProposals({ offset: 0, limit: 20 });
+  assert.equal(page.items.length, 20);
+  assert.equal(page.total, 25);
+  assert.equal(page.offset, 0);
+  assert.equal(page.limit, 20);
+});
+
+test("total reflects full count regardless of pagination", () => {
+  const agg = new ProposalActivityAggregator();
+  for (let i = 0; i < 10; i++) {
+    const ts = new Date(Date.UTC(2026, 1, 1 + i)).toISOString();
+    agg.addRecord(makeCreatedRecord(`q${i}`, ts));
+  }
+
+  const first = agg.getAllProposals({ offset: 0, limit: 3 });
+  assert.equal(first.total, 10);
+  assert.equal(first.items.length, 3);
+
+  const second = agg.getAllProposals({ offset: 9, limit: 5 });
+  assert.equal(second.total, 10);
+  assert.equal(second.items.length, 1);
+});
+
+test("limit is capped at GET_ALL_PROPOSALS_MAX_LIMIT (100)", () => {
+  const agg = new ProposalActivityAggregator();
+  for (let i = 0; i < 120; i++) {
+    const ts = new Date(Date.UTC(2026, 2, 1, 0, 0, i)).toISOString();
+    agg.addRecord(makeCreatedRecord(`r${i}`, ts));
+  }
+
+  const page = agg.getAllProposals({ offset: 0, limit: 500 });
+  assert.equal(page.limit, GET_ALL_PROPOSALS_MAX_LIMIT);
+  assert.equal(page.items.length, GET_ALL_PROPOSALS_MAX_LIMIT);
+  assert.equal(page.total, 120);
+});
+
+test("sorting applies before pagination (newest first)", () => {
+  const agg = new ProposalActivityAggregator();
+  agg.addRecord(makeCreatedRecord("old", "2025-01-01T00:00:00.000Z"));
+  agg.addRecord(makeCreatedRecord("new", "2026-06-01T00:00:00.000Z"));
+  agg.addRecord(makeCreatedRecord("mid", "2026-01-01T00:00:00.000Z"));
+
+  const page = agg.getAllProposals({ offset: 0, limit: 2 });
+  assert.equal(page.items[0].proposalId, "new");
+  assert.equal(page.items[1].proposalId, "mid");
+});

--- a/backend/src/modules/proposals/aggregator.ts
+++ b/backend/src/modules/proposals/aggregator.ts
@@ -11,6 +11,31 @@ import {
   ProposalActivityType,
 } from "./types.js";
 
+/** Maximum page size for {@link ProposalActivityAggregator.getAllProposals}. */
+export const GET_ALL_PROPOSALS_MAX_LIMIT = 100;
+
+/**
+ * Pagination input for {@link ProposalActivityAggregator.getAllProposals}.
+ */
+export interface GetAllProposalsParams {
+  offset?: number;
+  limit?: number;
+}
+
+/**
+ * Paginated result: items are sorted by latest activity (newest first).
+ * `total` is the full number of proposals tracked, before slicing.
+ */
+export interface GetAllProposalsResult {
+  items: Array<{
+    proposalId: string;
+    latestActivity: ProposalActivityRecord;
+  }>;
+  total: number;
+  offset: number;
+  limit: number;
+}
+
 /**
  * Statistics for proposal activity over a time period.
  */
@@ -214,9 +239,10 @@ export class ProposalActivityAggregator {
   }
 
   /**
-   * Gets all proposals with their latest status.
+   * Returns all proposals sorted by latest activity (newest first), without pagination.
+   * Used internally after sorting; prefer {@link getAllProposals} for API surfaces.
    */
-  public getAllProposals(): Array<{
+  private getAllProposalsSorted(): Array<{
     proposalId: string;
     latestActivity: ProposalActivityRecord;
   }> {
@@ -236,6 +262,27 @@ export class ProposalActivityAggregator {
   }
 
   /**
+   * Gets proposals with their latest status, sorted by latest activity (newest first),
+   * then paginated. `total` is the unfiltered proposal count.
+   */
+  public getAllProposals(params?: GetAllProposalsParams): GetAllProposalsResult {
+    const sorted = this.getAllProposalsSorted();
+    const total = sorted.length;
+
+    const offset = Math.max(0, Math.floor(params?.offset ?? 0));
+
+    let limit = params?.limit ?? GET_ALL_PROPOSALS_MAX_LIMIT;
+    if (!Number.isFinite(limit) || limit < 1) {
+      limit = 1;
+    }
+    limit = Math.min(Math.floor(limit), GET_ALL_PROPOSALS_MAX_LIMIT);
+
+    const items = sorted.slice(offset, offset + limit);
+
+    return { items, total, offset, limit };
+  }
+
+  /**
    * Gets proposals by status.
    */
   public getProposalsByStatus(
@@ -244,7 +291,7 @@ export class ProposalActivityAggregator {
     proposalId: string;
     latestActivity: ProposalActivityRecord;
   }> {
-    return this.getAllProposals().filter(
+    return this.getAllProposalsSorted().filter(
       (p) => p.latestActivity.type === status
     );
   }

--- a/backend/src/modules/proposals/index.ts
+++ b/backend/src/modules/proposals/index.ts
@@ -35,7 +35,13 @@ export * from "./types.js";
 // Core components
 export { ProposalActivityConsumer, createProposalConsumer } from "./consumer.js";
 export { ProposalActivityAggregator, createProposalAggregator } from "./aggregator.js";
-export type { ProposalActivityStats, ActivityBucket } from "./aggregator.js";
+export type {
+  ProposalActivityStats,
+  ActivityBucket,
+  GetAllProposalsParams,
+  GetAllProposalsResult,
+} from "./aggregator.js";
+export { GET_ALL_PROPOSALS_MAX_LIMIT } from "./aggregator.js";
 
 // Transforms
 export { ProposalEventTransformer, transformEventBatch, isProposalEvent } from "./transforms.js";

--- a/backend/src/shared/errors/handleError.ts
+++ b/backend/src/shared/errors/handleError.ts
@@ -49,7 +49,7 @@ export function handleError(
 
 // Type guard/middleware factory
 export function createErrorMiddleware(env: BackendEnv) {
-  return (error: unknown, req: Request, res: Response, next: NextFunction) => {
+  return (error: unknown, req: Request, res: Response, _next: NextFunction) => {
     handleError(error, req, res, env);
   };
 }


### PR DESCRIPTION
## Summary

Adds **pagination** to `ProposalActivityAggregator.getAllProposals()` so callers don’t load every proposal in one response. Sorting by **latest activity (newest first)** happens **before** slicing. Returns a **`{ items, total, offset, limit }`** envelope with **`total`** as the full proposal count (unfiltered / pre-slice).

## Changes

- **`getAllProposals(params?)`** — optional `offset` / `limit`; **`limit` capped at 100** (`GET_ALL_PROPOSALS_MAX_LIMIT`); default **`limit` = 100**, **`offset` = 0**; invalid/non-finite `limit` &lt; 1 clamped to **1**.
- **`getAllProposalsSorted()`** (private) — shared sorted list for pagination and **`getProposalsByStatus`** (no longer calls the paginated API).
- **Exports** — `GetAllProposalsParams`, `GetAllProposalsResult`, `GET_ALL_PROPOSALS_MAX_LIMIT` from `modules/proposals/index.ts`.
- **Tests** — `aggregator.test.ts` (node:test): page size, `total` across pages, cap at 100, sort order.
- **Build** — rename unused `next` → `_next` in `handleError.ts` (TS `noUnusedLocals`).

## Acceptance criteria

- [x] `getAllProposals({ offset: 0, limit: 20 })` returns **at most 20** items  
- [x] **`total`** = full count regardless of page  
- [x] **`limit`** capped at **100**
closes #469 
## How to verify

```bash
cd backend && npm install && npm run build && node --test dist/modules/proposals/aggregator.test.js