### PR TITLE
fix: mask contractId in health and status API responses

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,16 +2,12 @@ import type { BackendEnv } from "./config/env.js";
 import { loadEnv } from "./config/env.js";
 import { startServer } from "./server.js";
 import { createLogger } from "./shared/logging/logger.js";
+import { maskContractId } from "./shared/utils/mask.js";
 import { LifecycleManager } from "./app/lifecycle/lifecycle-manager.js";
 import { RealtimeServer, createRealtimeTopic } from "./modules/realtime/index.js";
 import { InMemoryNotificationQueue } from "./modules/notifications/index.js";
 import { ScheduledJobRunner } from "./modules/jobs/index.js";
 import { randomUUID } from "node:crypto";
-
-function maskContractId(contractId: string): string {
-  if (contractId.length <= 10) return contractId;
-  return `${contractId.slice(0, 6)}...${contractId.slice(-6)}`;
-}
 
 function logStartupConfig(env: BackendEnv) {
   const logger = createLogger("vaultdao-backend");

--- a/backend/src/modules/health/health.service.test.ts
+++ b/backend/src/modules/health/health.service.test.ts
@@ -42,7 +42,20 @@ test("builds a status payload", () => {
 
   assert.equal(payload.service, "vaultdao-backend");
   assert.equal(payload.environment, "test");
+  assert.equal(payload.contractId, "CDTEST");
   assert.match(payload.rpcUrl, /soroban-testnet/);
+});
+
+test("health and status mask contractId in production", () => {
+  const longId =
+    "CDO4B7X6FUM2YUH2BNVQKSHSM5M7XED3SFEHVYJ4V47PVML2P5FCHQ4";
+  const prodEnv = { ...mockEnv, nodeEnv: "production", contractId: longId };
+
+  const health = buildHealthPayload(prodEnv, mockRuntime as any);
+  const status = buildStatusPayload(prodEnv, mockRuntime as any);
+
+  assert.equal(health.contractId, `${longId.slice(0, 6)}...${longId.slice(-6)}`);
+  assert.equal(status.contractId, health.contractId);
 });
 
 test("builds a readiness payload with dependency checks", () => {

--- a/backend/src/modules/health/health.service.ts
+++ b/backend/src/modules/health/health.service.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import type { BackendEnv } from "../../config/env.js";
 import type { BackendRuntime } from "../../server.js";
+import { publicContractIdForApi } from "../../shared/utils/mask.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = join(__filename, "..");
@@ -56,7 +57,7 @@ export function buildHealthPayload(env: BackendEnv, runtime: BackendRuntime) {
     build: packageMetadata.build,
     environment: env.nodeEnv,
     network: env.stellarNetwork,
-    contractId: env.contractId,
+    contractId: publicContractIdForApi(env.contractId, env.nodeEnv),
     timestamp: new Date().toISOString(),
     eventPolling: runtime.eventPollingService.getStatus(),
   };
@@ -68,6 +69,7 @@ export function buildStatusPayload(env: BackendEnv, runtime: BackendRuntime) {
     version: VERSION,
     build: packageMetadata.build,
     environment: env.nodeEnv,
+    contractId: publicContractIdForApi(env.contractId, env.nodeEnv),
     rpcUrl: env.sorobanRpcUrl,
     horizonUrl: env.horizonUrl,
     websocketUrl: env.websocketUrl,

--- a/backend/src/shared/errors/handleError.ts
+++ b/backend/src/shared/errors/handleError.ts
@@ -49,7 +49,7 @@ export function handleError(
 
 // Type guard/middleware factory
 export function createErrorMiddleware(env: BackendEnv) {
-  return (error: unknown, req: Request, res: Response, next: NextFunction) => {
+  return (error: unknown, req: Request, res: Response, _next: NextFunction) => {
     handleError(error, req, res, env);
   };
 }

--- a/backend/src/shared/utils/mask.test.ts
+++ b/backend/src/shared/utils/mask.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { maskContractId, publicContractIdForApi } from "./mask.js";
+
+const LONG_ID =
+  "CDO4B7X6FUM2YUH2BNVQKSHSM5M7XED3SFEHVYJ4V47PVML2P5FCHQ4";
+
+test("maskContractId shortens long IDs", () => {
+  assert.equal(
+    maskContractId(LONG_ID),
+    `${LONG_ID.slice(0, 6)}...${LONG_ID.slice(-6)}`,
+  );
+});
+
+test("maskContractId leaves short IDs unchanged", () => {
+  assert.equal(maskContractId("CDTEST"), "CDTEST");
+});
+
+test("publicContractIdForApi returns full ID outside production", () => {
+  assert.equal(publicContractIdForApi(LONG_ID, "development"), LONG_ID);
+  assert.equal(publicContractIdForApi(LONG_ID, "test"), LONG_ID);
+});
+
+test("publicContractIdForApi masks in production", () => {
+  assert.equal(publicContractIdForApi(LONG_ID, "production"), maskContractId(LONG_ID));
+});

--- a/backend/src/shared/utils/mask.ts
+++ b/backend/src/shared/utils/mask.ts
@@ -1,0 +1,27 @@
+/**
+ * Soroban / Stellar contract ID masking for logs and public APIs.
+ */
+
+/**
+ * Shortens a contract ID for safe display (e.g. logs, production health JSON).
+ * IDs with length ≤10 are returned unchanged.
+ */
+export function maskContractId(contractId: string): string {
+  if (contractId.length <= 10) return contractId;
+  return `${contractId.slice(0, 6)}...${contractId.slice(-6)}`;
+}
+
+/**
+ * Contract ID exposed in public HTTP responses (`/health`, `/api/v1/status`, etc.).
+ * - **Non-production** (`development`, `test`, …): full value for local debugging.
+ * - **production**: masked via {@link maskContractId}.
+ */
+export function publicContractIdForApi(
+  contractId: string,
+  nodeEnv: string,
+): string {
+  if (nodeEnv === "production") {
+    return maskContractId(contractId);
+  }
+  return contractId;
+}


### PR DESCRIPTION
## Summary

Stops exposing the **full Soroban contract ID** on public **`GET /health`** and **`GET /api/v1/status`** responses. Masking applies in **production** only; **development** and **test** still return the full ID for debugging.

## Changes

- **`backend/src/shared/utils/mask.ts`**
  - `maskContractId()` — shared shortening (same rules as before: length ≤10 unchanged).
  - `publicContractIdForApi(contractId, nodeEnv)` — full ID when `nodeEnv !== "production"`, masked when `production`.
- **`buildHealthPayload` / `buildStatusPayload`** — use `publicContractIdForApi` for `contractId`; status payload now includes `contractId` with the same rules.
- **`index.ts`** — startup logging imports `maskContractId` from the shared module (removed duplicate).
- **Tests** — `mask.test.ts` + health tests for test vs production behavior.
- **`handleError.ts`** — rename unused Express `next` → `_next` for `noUnusedParameters`.

## Acceptance

- [x] Production health/status show **masked** contract ID (long IDs).
- [x] Non-production (e.g. development, test) show **full** contract ID.
- [x] Helper is **reusable** from `shared/utils/mask.ts`.
closes #470 
## Verify

```bash
cd backend && npm run build && node --test dist/shared/utils/mask.test.js dist/modules/health/health.service.test.js