### PR TITLE
feat: add shared query parameter validation helpers

### DIFF
--- a/backend/src/shared/errors/handleError.ts
+++ b/backend/src/shared/errors/handleError.ts
@@ -49,7 +49,7 @@ export function handleError(
 
 // Type guard/middleware factory
 export function createErrorMiddleware(env: BackendEnv) {
-  return (error: unknown, req: Request, res: Response, next: NextFunction) => {
+  return (error: unknown, req: Request, res: Response, _next: NextFunction) => {
     handleError(error, req, res, env);
   };
 }

--- a/backend/src/shared/http/validateQuery.test.ts
+++ b/backend/src/shared/http/validateQuery.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Request, Response } from "express";
+
+import {
+  DEFAULT_PAGINATION_LIMIT,
+  MAX_PAGINATION_LIMIT,
+  parsePaginationParams,
+  validateEnum,
+  validatePagination,
+} from "./validateQuery.js";
+
+function mockResponse(): {
+  res: Response;
+  getStatus: () => number | undefined;
+  getBody: () => unknown;
+} {
+  const state: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      state.status = code;
+      return this;
+    },
+    set() {
+      return this;
+    },
+    json(b: unknown) {
+      state.body = b;
+    },
+  };
+  return {
+    res: res as unknown as Response,
+    getStatus: () => state.status,
+    getBody: () => state.body,
+  };
+}
+
+test("parsePaginationParams defaults offset 0 and limit 20", () => {
+  const r = parsePaginationParams({});
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.value.offset, 0);
+    assert.equal(r.value.limit, DEFAULT_PAGINATION_LIMIT);
+  }
+});
+
+test("parsePaginationParams rejects non-numeric offset", () => {
+  const r = parsePaginationParams({ offset: "x" });
+  assert.equal(r.ok, false);
+});
+
+test("parsePaginationParams rejects negative offset", () => {
+  const r = parsePaginationParams({ offset: "-1" });
+  assert.equal(r.ok, false);
+});
+
+test("parsePaginationParams rejects non-numeric limit", () => {
+  const r = parsePaginationParams({ limit: "bad" });
+  assert.equal(r.ok, false);
+});
+
+test("parsePaginationParams rejects limit below 1", () => {
+  const r = parsePaginationParams({ limit: "0" });
+  assert.equal(r.ok, false);
+});
+
+test("parsePaginationParams caps limit at MAX_PAGINATION_LIMIT", () => {
+  const r = parsePaginationParams({ limit: "500" });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.value.limit, MAX_PAGINATION_LIMIT);
+  }
+});
+
+test("parsePaginationParams accepts valid integers", () => {
+  const r = parsePaginationParams({ offset: "10", limit: "15" });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.value.offset, 10);
+    assert.equal(r.value.limit, 15);
+  }
+});
+
+test("validatePagination sends 400 on invalid offset", () => {
+  const { res, getStatus, getBody } = mockResponse();
+  const req = { query: { offset: "nope" } } as unknown as Request;
+  const out = validatePagination(req, res);
+  assert.equal(out, null);
+  assert.equal(getStatus(), 400);
+  const body = getBody() as { success: boolean; error: { message: string } };
+  assert.equal(body.success, false);
+  assert.match(body.error.message, /offset/i);
+});
+
+test("validateEnum returns undefined when param omitted", () => {
+  const { res } = mockResponse();
+  const req = { query: {} } as unknown as Request;
+  const v = validateEnum(req, res, "status", ["a", "b"] as const);
+  assert.equal(v, undefined);
+});
+
+test("validateEnum returns 400 and null for invalid value", () => {
+  const { res, getStatus } = mockResponse();
+  const req = { query: { status: "c" } } as unknown as Request;
+  const v = validateEnum(req, res, "status", ["a", "b"] as const);
+  assert.equal(v, null);
+  assert.equal(getStatus(), 400);
+});
+
+test("validateEnum returns value when valid", () => {
+  const { res } = mockResponse();
+  const req = { query: { status: "a" } } as unknown as Request;
+  const v = validateEnum(req, res, "status", ["a", "b"] as const);
+  assert.equal(v, "a");
+});

--- a/backend/src/shared/http/validateQuery.ts
+++ b/backend/src/shared/http/validateQuery.ts
@@ -1,0 +1,120 @@
+import type { Request, Response } from "express";
+
+import { error } from "./response.js";
+
+/** Default `limit` when the query param is omitted. */
+export const DEFAULT_PAGINATION_LIMIT = 20;
+
+/** Maximum allowed `limit` after parsing (explicit values above this are capped). */
+export const MAX_PAGINATION_LIMIT = 100;
+
+export interface PaginationQuery {
+  offset: number;
+  limit: number;
+}
+
+function getFirstQueryString(
+  query: Request["query"],
+  key: string
+): string | undefined {
+  const v = query[key];
+  if (v === undefined) return undefined;
+  if (Array.isArray(v)) {
+    const first = v[0];
+    return typeof first === "string" ? first : undefined;
+  }
+  return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * Parses `offset` and `limit` from `req.query` (no side effects).
+ * - `offset` defaults to 0; must be a non-negative integer when present.
+ * - `limit` defaults to {@link DEFAULT_PAGINATION_LIMIT}; when present must be an integer ≥ 1, capped at {@link MAX_PAGINATION_LIMIT}.
+ */
+export function parsePaginationParams(
+  query: Request["query"]
+): { ok: true; value: PaginationQuery } | { ok: false; message: string } {
+  const offsetRaw = getFirstQueryString(query, "offset");
+  const limitRaw = getFirstQueryString(query, "limit");
+
+  let offset: number;
+  if (offsetRaw === undefined || offsetRaw === "") {
+    offset = 0;
+  } else {
+    const n = Number(offsetRaw);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
+      return {
+        ok: false,
+        message: `Invalid offset: expected a non-negative integer, received "${offsetRaw}"`,
+      };
+    }
+    if (n < 0) {
+      return {
+        ok: false,
+        message: "Invalid offset: must be greater than or equal to 0",
+      };
+    }
+    offset = n;
+  }
+
+  let limit: number;
+  if (limitRaw === undefined || limitRaw === "") {
+    limit = DEFAULT_PAGINATION_LIMIT;
+  } else {
+    const n = Number(limitRaw);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
+      return {
+        ok: false,
+        message: `Invalid limit: expected a positive integer, received "${limitRaw}"`,
+      };
+    }
+    if (n < 1) {
+      return {
+        ok: false,
+        message: "Invalid limit: must be at least 1",
+      };
+    }
+    limit = Math.min(n, MAX_PAGINATION_LIMIT);
+  }
+
+  return { ok: true, value: { offset, limit } };
+}
+
+/**
+ * Validates pagination query params and responds with **400** on failure.
+ * @returns `{ offset, limit }` or `null` if a response was already sent.
+ */
+export function validatePagination(
+  req: Request,
+  res: Response
+): PaginationQuery | null {
+  const parsed = parsePaginationParams(req.query);
+  if (!parsed.ok) {
+    error(res, { message: parsed.message, status: 400 });
+    return null;
+  }
+  return parsed.value;
+}
+
+/**
+ * Validates an optional enum query param. Omits → `undefined`. Invalid → **400** and `null`.
+ */
+export function validateEnum<T extends string>(
+  req: Request,
+  res: Response,
+  param: string,
+  allowed: readonly T[]
+): T | undefined | null {
+  const raw = getFirstQueryString(req.query, param);
+  if (raw === undefined || raw === "") {
+    return undefined;
+  }
+  if (!allowed.includes(raw as T)) {
+    error(res, {
+      message: `Invalid ${param}: must be one of: ${allowed.join(", ")}`,
+      status: 400,
+    });
+    return null;
+  }
+  return raw as T;
+}


### PR DESCRIPTION
## Summary

Adds **shared Express helpers** to parse and validate common **query parameters** (`offset`, `limit`, optional enums) with consistent **400** responses via the existing `error()` helper—so future routes (proposals, recurring, snapshots) don’t each reimplement validation.

## Changes

### `backend/src/shared/http/validateQuery.ts`

- **`parsePaginationParams(query)`** — pure parser (no response):
  - Defaults: **`offset = 0`**, **`limit = 20`** when omitted
  - **`limit`** capped at **100** when a higher value is passed
  - Rejects non-integers, non-numeric strings, negative **`offset`**, **`limit` &lt; 1**
- **`validatePagination(req, res)`** — returns **`{ offset, limit }`** or **`null`** after sending **400** with a clear message
- **`validateEnum(req, res, param, allowed[])`** — optional param: missing → **`undefined`**; invalid → **400** + **`null`**; valid → value
- Exported constants: **`DEFAULT_PAGINATION_LIMIT`**, **`MAX_PAGINATION_LIMIT`**
closes #471 
### Tests

- **`validateQuery.test.ts`** — parsing, cap, negative/non-numeric cases, `validatePagination` / `validateEnum` behavior

### Other

- **`handleError.ts`** — rename unused middleware **`next`** → **`_next`** for `noUnusedParameters`

## Acceptance

- [x] Non-numeric **`offset`** / **`limit`** → **400**
- [x] Negative **`offset`** (or invalid **`limit`**) → **400**
- [x] Valid values returned as **numbers**; defaults **0** / **20**; **`limit`** capped at **100**

## Verify

```bash
cd backend && npm run build && node --test dist/shared/http/validateQuery.test.js