### PR TITLE
feat: add shared SorobanRpcClient abstraction

### DIFF
--- a/backend/src/shared/rpc/soroban-rpc.client.ts
+++ b/backend/src/shared/rpc/soroban-rpc.client.ts
@@ -1,0 +1,153 @@
+import type { ContractEvent } from "../../modules/events/events.types.js";
+import type {
+  GetContractDataParams,
+  GetContractDataResult,
+  GetEventsParams,
+  GetEventsResult,
+  RpcRequest,
+  RpcResponse,
+  SorobanRpcClientConfig,
+} from "./soroban-rpc.types.js";
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 500;
+
+/** Errors that warrant a retry: network failures and 5xx responses. */
+function isTransient(err: unknown): boolean {
+  if (err instanceof SorobanRpcError) return err.status >= 500;
+  // fetch throws TypeError on network failure / abort
+  return err instanceof TypeError;
+}
+
+export class SorobanRpcError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = "SorobanRpcError";
+  }
+}
+
+/**
+ * Thin, injectable Soroban JSON-RPC client.
+ *
+ * - Uses the global `fetch` — no extra dependencies.
+ * - Retries transient errors (5xx / network timeout) with linear back-off.
+ * - Mockable in tests: pass a fake `fetchFn` via the constructor.
+ */
+export class SorobanRpcClient {
+  private readonly url: string;
+  private readonly timeoutMs: number;
+  private readonly maxRetries: number;
+  private readonly retryDelayMs: number;
+  private readonly fetchFn: typeof fetch;
+  private requestId = 0;
+
+  constructor(
+    config: SorobanRpcClientConfig,
+    fetchFn: typeof fetch = globalThis.fetch,
+  ) {
+    this.url = config.url;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.retryDelayMs = config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    this.fetchFn = fetchFn;
+  }
+
+  /**
+   * Fetch contract events from the Soroban RPC.
+   * Maps the raw RPC shape to the internal `ContractEvent` type.
+   */
+  async getContractEvents(params: GetEventsParams): Promise<ContractEvent[]> {
+    const result = await this.call<GetEventsParams, GetEventsResult>(
+      "getEvents",
+      params,
+    );
+
+    return result.events.map((raw) => ({
+      id: raw.id,
+      contractId: raw.contractId,
+      topic: raw.topic,
+      value: raw.value,
+      ledger: raw.ledger,
+      ledgerClosedAt: raw.ledgerClosedAt,
+    }));
+  }
+
+  /**
+   * Fetch ledger entries (contract data) from the Soroban RPC.
+   */
+  async getContractData(
+    params: GetContractDataParams,
+  ): Promise<GetContractDataResult> {
+    return this.call<GetContractDataParams, GetContractDataResult>(
+      "getLedgerEntries",
+      params,
+    );
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────────
+
+  private async call<P, R>(method: string, params: P): Promise<R> {
+    const body: RpcRequest<P> = {
+      jsonrpc: "2.0",
+      id: ++this.requestId,
+      method,
+      params,
+    };
+
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      if (attempt > 0) {
+        await sleep(this.retryDelayMs * attempt);
+      }
+
+      try {
+        const response = await this.fetchWithTimeout(body);
+
+        if (!response.ok) {
+          throw new SorobanRpcError(
+            `RPC HTTP error: ${response.status} ${response.statusText}`,
+            response.status,
+          );
+        }
+
+        const json = (await response.json()) as RpcResponse<R>;
+
+        if (json.error) {
+          // JSON-RPC application errors are not retried
+          throw new SorobanRpcError(
+            `RPC error ${json.error.code}: ${json.error.message}`,
+            400,
+          );
+        }
+
+        return json.result as R;
+      } catch (err) {
+        lastError = err;
+        if (!isTransient(err) || attempt === this.maxRetries) break;
+      }
+    }
+
+    throw lastError;
+  }
+
+  private fetchWithTimeout(body: RpcRequest<unknown>): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    return this.fetchFn(this.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timer));
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/backend/src/shared/rpc/soroban-rpc.types.ts
+++ b/backend/src/shared/rpc/soroban-rpc.types.ts
@@ -1,0 +1,73 @@
+// ─── JSON-RPC envelope ────────────────────────────────────────────────────────
+
+export interface RpcRequest<P = unknown> {
+  readonly jsonrpc: "2.0";
+  readonly id: number;
+  readonly method: string;
+  readonly params: P;
+}
+
+export interface RpcResponse<R = unknown> {
+  readonly jsonrpc: "2.0";
+  readonly id: number;
+  readonly result?: R;
+  readonly error?: { readonly code: number; readonly message: string };
+}
+
+// ─── getEvents ────────────────────────────────────────────────────────────────
+
+export interface GetEventsParams {
+  readonly startLedger: number;
+  readonly filters: ReadonlyArray<{
+    readonly type: "contract";
+    readonly contractIds: string[];
+    readonly topics?: string[][];
+  }>;
+  readonly pagination?: { readonly limit?: number; readonly cursor?: string };
+}
+
+export interface RawContractEvent {
+  readonly id: string;
+  readonly type: string;
+  readonly ledger: number;
+  readonly ledgerClosedAt: string;
+  readonly contractId: string;
+  readonly topic: string[];
+  readonly value: { readonly xdr: string };
+  readonly pagingToken: string;
+}
+
+export interface GetEventsResult {
+  readonly events: RawContractEvent[];
+  readonly latestLedger: number;
+}
+
+// ─── getLedgerEntries ─────────────────────────────────────────────────────────
+
+export interface GetContractDataParams {
+  readonly keys: string[];
+}
+
+export interface LedgerEntry {
+  readonly key: string;
+  readonly xdr: string;
+  readonly lastModifiedLedgerSeq: number;
+  readonly liveUntilLedgerSeq?: number;
+}
+
+export interface GetContractDataResult {
+  readonly entries: LedgerEntry[] | null;
+  readonly latestLedger: number;
+}
+
+// ─── Client config ────────────────────────────────────────────────────────────
+
+export interface SorobanRpcClientConfig {
+  readonly url: string;
+  /** Request timeout in ms (default: 10_000) */
+  readonly timeoutMs?: number;
+  /** Max retry attempts on transient errors (default: 3) */
+  readonly maxRetries?: number;
+  /** Base delay between retries in ms (default: 500) */
+  readonly retryDelayMs?: number;
+}


### PR DESCRIPTION
## What

Introduces a shared, injectable Soroban JSON-RPC client to eliminate 
the duplicated HTTP logic that EventPollingService and 
RecurringIndexerService would otherwise each need to implement.

## Files

- backend/src/shared/rpc/soroban-rpc.types.ts — typed request/response
interfaces for getEvents and getLedgerEntries, plus the client config
interface
- backend/src/shared/rpc/soroban-rpc.client.ts — SorobanRpcClient 
class with getContractEvents() and getContractData() methods

## Details

- Uses fetch only — no new dependencies
- Timeout via AbortController, configurable via timeoutMs (default 10s
)
- Retries transient errors (5xx HTTP status, network TypeError) up to 
maxRetries (default 3) with linear back-off; JSON-RPC application 
errors are not retried
- getContractEvents maps the raw RPC shape directly to the existing 
internal ContractEvent type
- fetchFn is a constructor parameter (defaults to globalThis.fetch), 
making the client fully mockable in unit tests without patching 
globals

## Usage

ts
const rpc = new SorobanRpcClient({ url: env.sorobanRpcUrl });
// inject into EventPollingService / RecurringIndexerService via constructor


Closes #484 