### PR TITLE
feat: standardise API route versioning under /api/v1 prefix

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -190,8 +190,13 @@ pnpm test
 # Pick a Foundation task from ROADMAP.md
 ```
 
+## API Versioning
+
+All business logic routes are strictly versioned under the `/api/v1/` prefix (e.g., `/api/v1/status`). 
+The `/health` and `/ready` validation endpoints are kept at the root level (`/health`, `/ready`) to maintain compatibility with standard Kubernetes probe paths.
+
 ## Current Endpoints
 
-- `GET /health`
-- `GET /ready` 
+- `GET /health` (root)
+- `GET /ready` (root)
 - `GET /api/v1/status`

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response, NextFunction } from "express";
 import type { BackendEnv } from "./config/env.js";
 import type { BackendRuntime } from "./server.js";
-import { createHealthRouter } from "./modules/health/health.routes.js";
+import { createHealthRouter, createStatusRouter } from "./modules/health/health.routes.js";
 import { createSnapshotRouter } from "./modules/snapshots/snapshots.routes.js";
 import { createProposalsRouter } from "./modules/proposals/proposals.routes.js";
 import { createRecurringRouter } from "./modules/recurring/recurring.routes.js";
@@ -87,20 +87,33 @@ export function createApp(env: BackendEnv, runtime: BackendRuntime) {
   const authMiddleware = createAuthMiddleware(env.apiKey);
 
   app.use(createHealthRouter(env, runtime));
-  app.use(authMiddleware, createSnapshotRouter(runtime.snapshotService));
-  app.use(
-    "/api/v1/proposals",
+  
+  const v1Router = express.Router();
+  
+  v1Router.use("/status", createStatusRouter(env, runtime));
+  
+  v1Router.use(
+    "/snapshots",
     authMiddleware,
-    createProposalsRouter(runtime.proposalActivityAggregator),
+    createSnapshotRouter(runtime.snapshotService)
   );
-  app.use(
-    "/api/v1/recurring",
+  
+  v1Router.use(
+    "/proposals",
     authMiddleware,
-    createRecurringRouter(runtime.recurringIndexerService),
+    createProposalsRouter(runtime.proposalActivityAggregator)
+  );
+  
+  v1Router.use(
+    "/recurring",
+    authMiddleware,
+    createRecurringRouter(runtime.recurringIndexerService)
   );
 
-  app.use((_request, response) => {
-    error(response, { message: "Not Found", status: 404 });
+  app.use("/api/v1", v1Router);
+
+  app.use((_request: Request, response: Response) => {
+    error(response as any, { message: "Not Found", status: 404 });
   });
 
   return app;

--- a/backend/src/modules/health/health.routes.ts
+++ b/backend/src/modules/health/health.routes.ts
@@ -13,7 +13,12 @@ export function createHealthRouter(env: BackendEnv, runtime: BackendRuntime) {
 
   router.get("/health", getHealthController(env, runtime));
   router.get("/ready", getReadinessController(env, runtime));
-  router.get("/api/v1/status", getStatusController(env, runtime));
 
+  return router;
+}
+
+export function createStatusRouter(env: BackendEnv, runtime: BackendRuntime) {
+  const router = Router();
+  router.get("/status", getStatusController(env, runtime));
   return router;
 }

--- a/backend/src/modules/snapshots/snapshots.routes.ts
+++ b/backend/src/modules/snapshots/snapshots.routes.ts
@@ -6,10 +6,10 @@ export function createSnapshotRouter(service: SnapshotService) {
   const router = Router();
   const ctrl = createSnapshotControllers(service);
 
-  router.get("/api/v1/snapshots/:contractId", ctrl.getSnapshot);
-  router.get("/api/v1/snapshots/:contractId/signers", ctrl.getSigners);
-  router.get("/api/v1/snapshots/:contractId/roles", ctrl.getRoles);
-  router.get("/api/v1/snapshots/:contractId/stats", ctrl.getStats);
+  router.get("/:contractId", ctrl.getSnapshot);
+  router.get("/:contractId/signers", ctrl.getSigners);
+  router.get("/:contractId/roles", ctrl.getRoles);
+  router.get("/:contractId/stats", ctrl.getStats);
 
   return router;
 }


### PR DESCRIPTION
# feat: standardise API route versioning under /api/v1 prefix
## Description
This PR standardizes the API route map to resolve inconsistent prefixing across modules. All business API routes (snapshots, proposals, recurring, status) are now consistently mounted under an `/api/v1/` express router inside [app.ts](cci:7://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/app.ts:0:0-0:0). 
The `/health` and `/ready` validation endpoints are deliberately preserved at the root level to maintain compatibility with standard Kubernetes probe paths. The versioning strategy guidelines are also documented in [backend/README.md](cci:7://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/README.md:0:0-0:0).


Closes #483 