### PR TITLE
fix: add exponential backoff to RecurringIndexerService on sync errors

### DIFF
--- a/backend/src/modules/recurring/recurring.service.ts
+++ b/backend/src/modules/recurring/recurring.service.ts
@@ -215,11 +215,16 @@ export class RecurringIndexerService {
     console.log("[recurring-indexer] stopped indexer loop");
   }
 
-  /**
-   * Schedules the next sync execution.
-   */
   private scheduleNextSync(): void {
     if (!this.isRunning) return;
+
+    let delayMs = this.env.eventPollingIntervalMs;
+    if (this.consecutiveErrors > 0) {
+      const MAX_BACKOFF_MS = 5 * 60 * 1000;
+      const backoff = delayMs * Math.pow(2, this.consecutiveErrors);
+      delayMs = Math.min(backoff, MAX_BACKOFF_MS);
+      console.log(`[recurring-indexer] backing off for ${delayMs}ms`);
+    }
 
     this.timer = setTimeout(async () => {
       if (!this.isRunning) return;
@@ -236,7 +241,7 @@ export class RecurringIndexerService {
       } finally {
         this.scheduleNextSync();
       }
-    }, this.env.eventPollingIntervalMs);
+    }, delayMs);
   }
 
   /**


### PR DESCRIPTION
# fix: add exponential backoff to RecurringIndexerService on sync errors
## Description
This PR introduces an exponential backoff pattern to `RecurringIndexerService.scheduleNextSync` to prevent hammering the RPC during extended chain outages. Previously, continuous failures would trigger polling at the maximum configured interval relentlessly. 
The backoff incrementally shifts using a `Math.pow(2, consecutiveErrors)` multiplier and safely caps the maximum retry time to 5 minutes (`MAX_BACKOFF_MS = 5 * 60 * 1000`).

Closes #551 

## Changes Made:
- Added `Math.pow(2, consecutiveErrors)` based delay logic in [scheduleNextSync](cci:1://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/modules/recurring/recurring.service.ts:217:2-239:3).
- Established a `MAX_BACKOFF_MS` cap of 5 minutes to prevent infinite retry delay creep.
- Ensured consecutive errors cleanly shift back to 0 on a successful synchronization cycle.