### PR TITLE
fix: reset hit/miss counters when InMemoryCacheAdapter is cleared

### DIFF
--- a/backend/src/shared/cache/cache.adapter.ts
+++ b/backend/src/shared/cache/cache.adapter.ts
@@ -54,6 +54,11 @@ export interface CacheAdapter<T> {
    * Get cache statistics.
    */
   stats(): CacheStats;
+
+  /**
+   * Reset cache statistics without clearing entries.
+   */
+  resetStats?(): void;
 }
 
 export interface CacheStats {
@@ -134,11 +139,20 @@ export class InMemoryCacheAdapter<T> implements CacheAdapter<T> {
   }
 
   /**
+   * Reset cache statistics without clearing entries.
+   */
+  resetStats(): void {
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  /**
    * Clear all entries.
    */
   clear(): void {
     const size = this.cache.size;
     this.cache.clear();
+    this.resetStats();
     this.logger.info("cache cleared", { entries: size });
   }
 


### PR DESCRIPTION
# fix: reset hit/miss counters when InMemoryCacheAdapter is cleared
## Description
This PR addresses stale, misleading observabilty data surfacing from [InMemoryCacheAdapter](cci:2://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/shared/cache/cache.adapter.ts:78:0-191:1). Previously, invoking the `.clear()` function correctly cleaned cache entries but ignored the accumulated `.hits` and `.misses` variables.
This update automatically resets counter metrics to `0` whenever a cache instance is deliberately cleared, and optionally exposes a standalone `resetStats()` procedure to wipe counters without actively evicting live data memory.

Closes #552 

## Changes Made:
- Created a `resetStats()` method within [InMemoryCacheAdapter](cci:2://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/shared/cache/cache.adapter.ts:78:0-191:1) to initialize metric counters back to exactly `0`.
- Altered `.clear()` to subsequently call `.resetStats()` ensuring consistency immediately following cache wipes.
- Optionalized `resetStats` on the `CacheAdapter<T>` interface specification.