### PR TITLE
feat: wire SnapshotService into EventPollingService for live updates

### DIFF
--- a/backend/src/modules/events/events.service.ts
+++ b/backend/src/modules/events/events.service.ts
@@ -4,6 +4,8 @@ import type { CursorStorage } from "./cursor/index.js";
 import { EventNormalizer } from "./normalizers/index.js";
 import type { ProposalActivityConsumer } from "../proposals/consumer.js";
 import type { EventWebSocketServer } from "../websocket/websocket.server.js";
+import type { SnapshotService } from "../snapshots/snapshot.service.js";
+import { SnapshotNormalizer } from "../snapshots/normalizer.js";
 
 /** Maximum backoff delay: 5 minutes */
 const MAX_BACKOFF_MS = 5 * 60 * 1000;
@@ -46,6 +48,7 @@ export class EventPollingService {
     private readonly storage: CursorStorage,
     private readonly proposalConsumer?: ProposalActivityConsumer,
     private readonly wsServer?: EventWebSocketServer,
+    private readonly snapshotService?: SnapshotService,
   ) {}
 
   /**
@@ -189,6 +192,16 @@ export class EventPollingService {
       // Proposal events → proposalConsumer
       if (this.proposalConsumer && PROPOSAL_TOPICS.has(topic)) {
         await this.proposalConsumer.process(normalized);
+        return;
+      }
+
+      // Snapshot events → snapshotService
+      if (this.snapshotService && SnapshotNormalizer.isSnapshotEvent(normalized.type as any)) {
+        try {
+          await this.snapshotService.processEvent(normalized as any);
+        } catch (error) {
+          console.error(`[events-service] error processing snapshot event "${topic}":`, error);
+        }
         return;
       }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -86,6 +86,7 @@ export function startServer(
     new FileCursorAdapter(),
     proposalActivityConsumer,
     wsServer,
+    snapshotService,
   );
   runtime.eventPollingService = eventPollingService;
 


### PR DESCRIPTION
# [PR 4] feat: wire SnapshotService into EventPollingService for live updates
## Description
This PR wires in the `SnapshotService` interface internally into the [EventPollingService](cci:2://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/modules/events/events.service.ts:39:0-225:1) dependency cycle via dependency injection to authorize dynamic snapshot updates directly from live events.
Previously, `SnapshotService` handled offline data exclusively from manual replays. We now intelligently filter propagating events with `SnapshotNormalizer.isSnapshotEvent`, selectively broadcasting initialized thresholds or roles dynamically without halting polling execution when nested integration failures occur.

Closes #553 

## Changes Made:
- Injected `SnapshotService` globally down the instantiation stack beginning in [server.ts](cci:7://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/server.ts:0:0-0:0).
- Integrated `SnapshotNormalizer.isSnapshotEvent()` boolean validation gate into [processEvent](cci:1://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/modules/events/events.service.ts:182:2-213:3) hook inside [EventPollingService](cci:2://file:///home/edohwares/Desktop/Room/drips/VaultDAO/backend/src/modules/events/events.service.ts:39:0-225:1).
- Added insulated error trapping specifically surrounding `snapshotService.processEvent(normalized)` to safeguard the primary polling lifecycle.