### PR TITLE
fix: enforce minimum interval on recurring payment creation

### DIFF
--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -72,6 +72,10 @@ const MIN_ATTACHMENT_LEN: u32 = 46;
 const MAX_ATTACHMENT_LEN: u32 = 128;
 
 /// Reputation adjustments
+/// Minimum interval between recurring payments: 720 ledgers ≈ 1 hour at ~5 s/ledger.
+/// Prevents near-instant repeated draining of the vault.
+const MIN_RECURRING_INTERVAL: u64 = 720;
+
 const REP_EXEC_PROPOSER: u32 = 10;
 const REP_EXEC_APPROVER: u32 = 5;
 const REP_REJECTION_PENALTY: u32 = 20;
@@ -2218,7 +2222,7 @@ impl VaultDAO {
         Self::validate_recipient(&env, &recipient)?;
 
         // Minimum interval check (e.g. 1 hour = 720 ledgers)
-        if interval < 720 {
+        if interval < MIN_RECURRING_INTERVAL {
             return Err(VaultError::IntervalTooShort);
         }
 

--- a/contracts/vault/src/test.rs
+++ b/contracts/vault/src/test.rs
@@ -8638,6 +8638,64 @@ fn test_list_proposal_ids_pagination() {
 }
 
 // ============================================================================
+// Recurring Payment Interval Validation Tests
+// ============================================================================
+
+#[test]
+fn test_schedule_payment_interval_zero_returns_interval_too_short() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let mut signers = Vec::new(&env);
+    signers.push_back(admin.clone());
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+
+    let res = client.try_schedule_payment(
+        &admin,
+        &recipient,
+        &token,
+        &100,
+        &Symbol::new(&env, "pay"),
+        &0u64,
+    );
+    assert_eq!(res, Err(Ok(VaultError::IntervalTooShort)));
+}
+
+#[test]
+fn test_schedule_payment_valid_interval_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let mut signers = Vec::new(&env);
+    signers.push_back(admin.clone());
+    client.initialize(&admin, &default_init_config(&env, signers, 1));
+
+    let res = client.try_schedule_payment(
+        &admin,
+        &recipient,
+        &token,
+        &100,
+        &Symbol::new(&env, "pay"),
+        &720u64,
+    );
+    assert!(res.is_ok());
+}
+
+// ============================================================================
 // Recurring Payment Listing Tests
 // ============================================================================
 


### PR DESCRIPTION
Closes #440

---

## Summary

`VaultError::IntervalTooShort` was defined but the validation in `schedule_payment` used a magic number `720` with no named constant. This PR extracts it into a documented constant and adds tests.

## Changes

### `contracts/vault/src/lib.rs`
- Added `MIN_RECURRING_INTERVAL: u64 = 720` constant with doc comment explaining the 1-hour rationale
- Replaced inline `720` in the interval guard with `MIN_RECURRING_INTERVAL`

### `contracts/vault/src/test.rs`
- `test_schedule_payment_interval_zero_returns_interval_too_short`: interval = 0 → `IntervalTooShort`
- `test_schedule_payment_valid_interval_succeeds`: interval = 720 → `Ok`

## Acceptance Criteria
- ✅ Recurring payments with interval below minimum return `IntervalTooShort`
- ✅ Recurring payments with valid intervals are created successfully
- ✅ Minimum interval constant is clearly documented