### PR TITLE
[720] Implement real Soroban RPC polling in EventPollingService.poll() replacing the mock stub

### DIFF
--- a/backend/src/modules/events/events.service.test.ts
+++ b/backend/src/modules/events/events.service.test.ts
@@ -5,6 +5,8 @@ import type { BackendEnv } from "../../config/env.js";
 import type { CursorStorage } from "./cursor/index.js";
 import type { EventCursor } from "./cursor/cursor.types.js";
 import { EventPollingService } from "./events.service.js";
+import { SorobanRpcClient } from "../../shared/rpc/soroban-rpc.client.js";
+import type { RawContractEvent } from "../../shared/rpc/soroban-rpc.types.js";
 
 function createTestEnv(overrides: Partial<BackendEnv> = {}): BackendEnv {
   return {
@@ -57,9 +59,94 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// ─── RPC mock helpers ────────────────────────────────────────────────────────
+
+/**
+ * Build a fake `fetch` function that responds to Soroban JSON-RPC calls.
+ * Each invocation pops the next response from the queue; the last entry is
+ * reused once the queue is exhausted.
+ */
+function buildMockFetch(handlers: {
+  getLatestLedger?: () => { sequence: number };
+  getEvents?: (params: unknown) => {
+    events: RawContractEvent[];
+    latestLedger: number;
+  };
+}): typeof fetch {
+  return async (
+    _url: RequestInfo | URL,
+    options?: RequestInit,
+  ): Promise<Response> => {
+    const body = JSON.parse((options?.body ?? "{}") as string) as {
+      id: number;
+      method: string;
+      params?: unknown;
+    };
+
+    let result: unknown = {};
+    if (body.method === "getLatestLedger" && handlers.getLatestLedger) {
+      result = handlers.getLatestLedger();
+    } else if (body.method === "getEvents" && handlers.getEvents) {
+      result = handlers.getEvents(body.params);
+    }
+
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: body.id, result }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+}
+
+/** Factory for a no-op RPC client (returns empty events, latestLedger=100). */
+function createNoOpRpcClient(latestLedger = 100): SorobanRpcClient {
+  return new SorobanRpcClient(
+    { url: "https://soroban-testnet.stellar.org" },
+    buildMockFetch({
+      getLatestLedger: () => ({ sequence: latestLedger }),
+      getEvents: () => ({ events: [], latestLedger }),
+    }),
+  );
+}
+
+/** Build a minimal valid {@link RawContractEvent}. */
+function makeRawEvent(overrides: Partial<RawContractEvent> = {}): RawContractEvent {
+  return {
+    id: "event-1",
+    type: "contract",
+    ledger: 100,
+    ledgerClosedAt: "2026-01-01T00:00:00Z",
+    contractId: "CDTEST",
+    topic: ["proposal_created"],
+    value: { xdr: "AAAA" },
+    pagingToken: "event-1",
+    ...overrides,
+  };
+}
+
+/**
+ * Convenience factory: creates an EventPollingService with a no-op RPC mock
+ * unless a specific rpcClient is provided.
+ */
+function createSvc(
+  storage: CursorStorage,
+  envOverrides: Partial<BackendEnv> = {},
+  rpcClient: SorobanRpcClient = createNoOpRpcClient(),
+): EventPollingService {
+  return new EventPollingService(
+    createTestEnv(envOverrides),
+    storage,
+    undefined,
+    undefined,
+    undefined,
+    rpcClient,
+  );
+}
+
+// ─── Existing tests (updated to use createSvc / mock RPC) ───────────────────
+
 test("getStatus before start: idle state", () => {
   const storage = new MemoryCursorStorage();
-  const svc = new EventPollingService(createTestEnv(), storage);
+  const svc = createSvc(storage);
 
   const s = svc.getStatus();
   assert.equal(s.isPolling, false);
@@ -69,10 +156,7 @@ test("getStatus before start: idle state", () => {
 
 test("start() with polling disabled does not run loop", async () => {
   const storage = new MemoryCursorStorage();
-  const svc = new EventPollingService(
-    createTestEnv({ eventPollingEnabled: false }),
-    storage,
-  );
+  const svc = createSvc(storage, { eventPollingEnabled: false });
 
   await svc.start();
   assert.equal(svc.getStatus().isPolling, false);
@@ -85,7 +169,7 @@ test("start() loads cursor from storage and sets lastLedgerPolled", async () => 
     updatedAt: "2026-01-01T00:00:00.000Z",
   };
 
-  const svc = new EventPollingService(createTestEnv(), storage);
+  const svc = createSvc(storage);
   await svc.start();
 
   assert.equal(svc.getStatus().isPolling, true);
@@ -95,7 +179,7 @@ test("start() loads cursor from storage and sets lastLedgerPolled", async () => 
 
 test("start() with no cursor uses default ledger 0", async () => {
   const storage = new MemoryCursorStorage();
-  const svc = new EventPollingService(createTestEnv(), storage);
+  const svc = createSvc(storage);
   await svc.start();
 
   assert.equal(svc.getStatus().lastLedgerPolled, 0);
@@ -105,7 +189,7 @@ test("start() with no cursor uses default ledger 0", async () => {
 
 test("stop() clears timer and sets isPolling false", async () => {
   const storage = new MemoryCursorStorage();
-  const svc = new EventPollingService(createTestEnv(), storage);
+  const svc = createSvc(storage);
   await svc.start();
   assert.equal(svc.getStatus().isPolling, true);
 
@@ -115,7 +199,7 @@ test("stop() clears timer and sets isPolling false", async () => {
 
 test("stop() is idempotent when not running", () => {
   const storage = new MemoryCursorStorage();
-  const svc = new EventPollingService(createTestEnv(), storage);
+  const svc = createSvc(storage);
   svc.stop();
   svc.stop();
   assert.equal(svc.getStatus().isPolling, false);
@@ -125,7 +209,7 @@ test("poll failure increments consecutiveErrors then recovers on success", async
   const storage = new MemoryCursorStorage();
   storage.failSaveRemaining = 1;
 
-  const svc = new EventPollingService(createTestEnv(), storage);
+  const svc = createSvc(storage);
   await svc.start();
 
   await delay(15);
@@ -152,7 +236,8 @@ test("getStatus exposes lastLedgerPolled after poll advances cursor", async () =
     updatedAt: "2026-01-01T00:00:00.000Z",
   };
 
-  const svc = new EventPollingService(createTestEnv(), storage);
+  // Mock returns latestLedger=50, which is >10, satisfying the assertion below.
+  const svc = createSvc(storage, {}, createNoOpRpcClient(50));
   await svc.start();
 
   await delay(25);
@@ -168,7 +253,7 @@ test("getStatus exposes lastLedgerPolled after poll advances cursor", async () =
 test("Event Deduplication", async (t) => {
   await t.test("processedEventIds set is cleared on start()", async () => {
     const storage = new MemoryCursorStorage();
-    const svc = new EventPollingService(createTestEnv(), storage);
+    const svc = createSvc(storage);
 
     // Access private field for testing
     const serviceAny = svc as any;
@@ -189,7 +274,7 @@ test("Event Deduplication", async (t) => {
     "processedEventIds maintains bounded size (max 1000)",
     async () => {
       const storage = new MemoryCursorStorage();
-      const svc = new EventPollingService(createTestEnv(), storage);
+      const svc = createSvc(storage);
       const serviceAny = svc as any;
 
       // Add more than MAX_PROCESSED_IDS entries
@@ -213,7 +298,7 @@ test("Event Deduplication", async (t) => {
 
   await t.test("duplicate events are skipped", async () => {
     const storage = new MemoryCursorStorage();
-    const svc = new EventPollingService(createTestEnv(), storage);
+    const svc = createSvc(storage);
     const serviceAny = svc as any;
 
     // Simulate processed event
@@ -233,7 +318,7 @@ test("Event Deduplication", async (t) => {
 
   await t.test("new events are added to processedEventIds", async () => {
     const storage = new MemoryCursorStorage();
-    const svc = new EventPollingService(createTestEnv(), storage);
+    const svc = createSvc(storage);
     const serviceAny = svc as any;
 
     const eventId = "event-new-123";
@@ -249,7 +334,7 @@ test("Event Deduplication", async (t) => {
     "FIFO eviction removes oldest entry when set is full",
     async () => {
       const storage = new MemoryCursorStorage();
-      const svc = new EventPollingService(createTestEnv(), storage);
+      const svc = createSvc(storage);
       const serviceAny = svc as any;
 
       // Fill set to capacity
@@ -293,7 +378,7 @@ test("Event Deduplication Properties", async (t) => {
     async () => {
       for (let iteration = 0; iteration < 10; iteration++) {
         const storage = new MemoryCursorStorage();
-        const svc = new EventPollingService(createTestEnv(), storage);
+        const svc = createSvc(storage);
         const serviceAny = svc as any;
 
         // Generate random event IDs
@@ -322,7 +407,7 @@ test("Event Deduplication Properties", async (t) => {
     async () => {
       for (let iteration = 0; iteration < 10; iteration++) {
         const storage = new MemoryCursorStorage();
-        const svc = new EventPollingService(createTestEnv(), storage);
+        const svc = createSvc(storage);
         const serviceAny = svc as any;
 
         // Generate random event IDs
@@ -350,7 +435,7 @@ test("Event Deduplication Properties", async (t) => {
     async () => {
       for (let iteration = 0; iteration < 5; iteration++) {
         const storage = new MemoryCursorStorage();
-        const svc = new EventPollingService(createTestEnv(), storage);
+        const svc = createSvc(storage);
         const serviceAny = svc as any;
 
         // Add many more entries than capacity
@@ -380,7 +465,7 @@ test("Event Deduplication Properties", async (t) => {
     async () => {
       for (let iteration = 0; iteration < 5; iteration++) {
         const storage = new MemoryCursorStorage();
-        const svc = new EventPollingService(createTestEnv(), storage);
+        const svc = createSvc(storage);
         const serviceAny = svc as any;
 
         // Add some IDs
@@ -404,7 +489,7 @@ test("Event Deduplication Properties", async (t) => {
     async () => {
       for (let iteration = 0; iteration < 5; iteration++) {
         const storage = new MemoryCursorStorage();
-        const svc = new EventPollingService(createTestEnv(), storage);
+        const svc = createSvc(storage);
         const serviceAny = svc as any;
 
         // Simulate first poll: events 1-100
@@ -441,3 +526,205 @@ test("Event Deduplication Properties", async (t) => {
     },
   );
 });
+
+// ─── Real Soroban RPC polling tests ─────────────────────────────────────────
+
+test("RPC Polling", async (t) => {
+  await t.test(
+    "poll() initialises cursor via getLatestLedger when lastLedgerPolled===0",
+    async () => {
+      const storage = new MemoryCursorStorage();
+      // No pre-existing cursor → lastLedgerPolled starts at 0
+      let latestLedgerCalled = false;
+      const rpc = new SorobanRpcClient(
+        { url: "https://soroban-testnet.stellar.org" },
+        buildMockFetch({
+          getLatestLedger: () => {
+            latestLedgerCalled = true;
+            return { sequence: 777 };
+          },
+          getEvents: () => ({ events: [], latestLedger: 777 }),
+        }),
+      );
+      const svc = createSvc(storage, {}, rpc);
+      await svc.start();
+
+      // Let one poll fire
+      await delay(25);
+      svc.stop();
+
+      assert.ok(latestLedgerCalled, "getLatestLedger should be called on first poll");
+      assert.equal(
+        svc.getStatus().lastLedgerPolled,
+        777,
+        "cursor should be initialised at the ledger returned by getLatestLedger",
+      );
+      assert.equal(storage.cursor?.lastLedger, 777);
+    },
+  );
+
+  await t.test(
+    "poll() calls getEventsPage with startLedger = lastLedgerPolled + 1",
+    async () => {
+      const storage = new MemoryCursorStorage();
+      storage.cursor = { lastLedger: 100, updatedAt: new Date().toISOString() };
+
+      let capturedStartLedger: number | undefined;
+      const rpc = new SorobanRpcClient(
+        { url: "https://soroban-testnet.stellar.org" },
+        buildMockFetch({
+          getEvents: (params) => {
+            const p = params as { startLedger?: number };
+            capturedStartLedger = p.startLedger;
+            return { events: [], latestLedger: 110 };
+          },
+        }),
+      );
+      const svc = createSvc(storage, {}, rpc);
+      await svc.start();
+
+      await delay(25);
+      svc.stop();
+
+      assert.equal(
+        capturedStartLedger,
+        101,
+        "startLedger should be lastLedgerPolled + 1",
+      );
+    },
+  );
+
+  await t.test(
+    "poll() advances lastLedgerPolled to latestLedger from RPC response",
+    async () => {
+      const storage = new MemoryCursorStorage();
+      storage.cursor = { lastLedger: 200, updatedAt: new Date().toISOString() };
+
+      const rpc = createNoOpRpcClient(250);
+      const svc = createSvc(storage, {}, rpc);
+      await svc.start();
+
+      await delay(25);
+      svc.stop();
+
+      assert.equal(
+        svc.getStatus().lastLedgerPolled,
+        250,
+        "lastLedgerPolled should advance to latestLedger from RPC",
+      );
+      assert.equal(storage.cursor?.lastLedger, 250);
+    },
+  );
+
+  await t.test("poll() processes returned events through handleBatch", async () => {
+    const storage = new MemoryCursorStorage();
+    storage.cursor = { lastLedger: 300, updatedAt: new Date().toISOString() };
+
+    const event = makeRawEvent({ id: "evt-abc", ledger: 301 });
+    const rpc = new SorobanRpcClient(
+      { url: "https://soroban-testnet.stellar.org" },
+      buildMockFetch({
+        getEvents: () => ({ events: [event], latestLedger: 310 }),
+      }),
+    );
+    const svc = createSvc(storage, {}, rpc);
+    await svc.start();
+
+    await delay(25);
+    svc.stop();
+
+    // The event should have been added to processedEventIds
+    const serviceAny = svc as any;
+    assert.ok(
+      serviceAny.processedEventIds.has("evt-abc"),
+      "event id should be tracked after processing",
+    );
+  });
+
+  await t.test("poll() handles empty events response without error", async () => {
+    const storage = new MemoryCursorStorage();
+    storage.cursor = { lastLedger: 400, updatedAt: new Date().toISOString() };
+
+    const rpc = createNoOpRpcClient(410);
+    const svc = createSvc(storage, {}, rpc);
+    await svc.start();
+
+    await delay(25);
+    svc.stop();
+
+    assert.equal(svc.getStatus().errors, 0, "no errors on empty page");
+    assert.equal(svc.getStatus().lastLedgerPolled, 410);
+  });
+
+  await t.test("poll() paginates when a full page is returned", async () => {
+    const storage = new MemoryCursorStorage();
+    storage.cursor = { lastLedger: 500, updatedAt: new Date().toISOString() };
+
+    // Build 200 events (a full page) for the first call, 0 for the second.
+    const EVENTS_PAGE_LIMIT = 200;
+    let callCount = 0;
+    const rpc = new SorobanRpcClient(
+      { url: "https://soroban-testnet.stellar.org" },
+      buildMockFetch({
+        getEvents: (params) => {
+          callCount++;
+          const p = params as { pagination?: { cursor?: string } };
+          if (!p.pagination?.cursor) {
+            // First page — full, triggers next page request
+            const events = Array.from({ length: EVENTS_PAGE_LIMIT }, (_, i) =>
+              makeRawEvent({
+                id: `evt-${i}`,
+                pagingToken: `token-${i}`,
+                ledger: 501 + i,
+              }),
+            );
+            return { events, latestLedger: 550 };
+          }
+          // Second page — empty, stops pagination
+          return { events: [], latestLedger: 550 };
+        },
+      }),
+    );
+    const svc = createSvc(storage, {}, rpc);
+    await svc.start();
+
+    await delay(35);
+    svc.stop();
+
+    assert.ok(callCount >= 2, `expected at least 2 getEvents calls for pagination, got ${callCount}`);
+    assert.equal(svc.getStatus().lastLedgerPolled, 550);
+  });
+
+  await t.test("poll() deduplicates events across polls", async () => {
+    const storage = new MemoryCursorStorage();
+    storage.cursor = { lastLedger: 600, updatedAt: new Date().toISOString() };
+
+    let pollCount = 0;
+    const sharedEvent = makeRawEvent({ id: "shared-event", ledger: 601 });
+    const rpc = new SorobanRpcClient(
+      { url: "https://soroban-testnet.stellar.org" },
+      buildMockFetch({
+        getEvents: () => {
+          pollCount++;
+          // Return the same event on every poll
+          return { events: [sharedEvent], latestLedger: 610 };
+        },
+      }),
+    );
+    const svc = createSvc(storage, {}, rpc);
+    await svc.start();
+
+    // Let two polls fire
+    await delay(35);
+    svc.stop();
+
+    // processedEventIds should contain the event exactly once
+    const serviceAny = svc as any;
+    assert.ok(
+      serviceAny.processedEventIds.has("shared-event"),
+      "event should be in processedEventIds",
+    );
+    assert.ok(pollCount >= 2, "should have polled at least twice to test deduplication");
+  });
+});
+

--- a/backend/src/modules/events/events.service.ts
+++ b/backend/src/modules/events/events.service.ts
@@ -8,9 +8,13 @@ import type { EventWebSocketServer } from "../websocket/websocket.server.js";
 import type { SnapshotService } from "../snapshots/snapshot.service.js";
 import { SnapshotNormalizer } from "../snapshots/normalizer.js";
 import { TimeoutError } from "../../shared/http/fetchWithTimeout.js";
+import { SorobanRpcClient } from "../../shared/rpc/soroban-rpc.client.js";
 
 /** Maximum backoff delay: 5 minutes */
 const MAX_BACKOFF_MS = 5 * 60 * 1000;
+
+/** Maximum number of events to request per RPC page. */
+const EVENTS_PAGE_LIMIT = 200;
 
 /** Contract topics that should be forwarded to the proposal consumer. */
 const PROPOSAL_TOPICS = new Set([
@@ -48,6 +52,7 @@ export class EventPollingService {
   private consecutiveErrors: number = 0;
   private processedEventIds: Set<string> = new Set();
   private readonly MAX_PROCESSED_IDS = 1000;
+  private readonly rpcClient: SorobanRpcClient;
 
   constructor(
     private readonly env: BackendEnv,
@@ -55,7 +60,10 @@ export class EventPollingService {
     private readonly proposalConsumer?: ProposalActivityConsumer,
     private readonly wsServer?: EventWebSocketServer,
     private readonly snapshotService?: SnapshotService,
-  ) {}
+    rpcClient?: SorobanRpcClient,
+  ) {
+    this.rpcClient = rpcClient ?? new SorobanRpcClient({ url: env.sorobanRpcUrl });
+  }
 
   /**
    * Starts the polling loop if enabled in config.
@@ -158,31 +166,79 @@ export class EventPollingService {
 
   /**
    * Performs the actual RPC call to find new events.
+   *
+   * On the very first run (`lastLedgerPolled === 0`) the service has no
+   * starting point, so it fetches the current chain head and persists it as
+   * the initial cursor without processing any historical events.
+   *
+   * On subsequent runs it pages through all events in the range
+   * `[lastLedgerPolled + 1, latestLedger]` using cursor-based pagination,
+   * then advances the cursor to `latestLedger`.
    */
   private async poll(): Promise<void> {
-    // Placeholder for RPC call to get events
-    // Example (future implementation):
-    // const results = await this.rpcService.getContractEvents({
-    //   startLedger: this.lastLedgerPolled + 1,
-    //   contractIds: [this.env.contractId],
-    // });
-
-    // For now, we mock the polling activity
-    const mockEvents: ContractEvent[] = [];
-
-    if (mockEvents.length > 0) {
-      await this.handleBatch(mockEvents);
+    // ── First-run initialisation ─────────────────────────────────────────────
+    if (this.lastLedgerPolled === 0) {
+      const latestLedger = await this.rpcClient.getLatestLedger();
+      this.logger.info(`initializing polling cursor at ledger ${latestLedger}`);
+      await this.storage.saveCursor({
+        lastLedger: latestLedger,
+        updatedAt: new Date().toISOString(),
+      });
+      this.lastLedgerPolled = latestLedger;
+      return;
     }
 
-    // Advance the "last polled" pointer (simulation)
-    // Normally this would be updated based on the last event's ledger or the RPC's newest ledger.
-    this.lastLedgerPolled += 1;
+    // ── Paginated event fetch ────────────────────────────────────────────────
+    const startLedger = this.lastLedgerPolled + 1;
+    const allEvents: ContractEvent[] = [];
+    let cursor: string | undefined;
+    let latestLedger = this.lastLedgerPolled;
 
-    // Persist new cursor
+    do {
+      const result = await this.rpcClient.getEventsPage({
+        startLedger,
+        filters: [
+          {
+            type: "contract",
+            contractIds: [this.env.contractId],
+          },
+        ],
+        pagination: {
+          limit: EVENTS_PAGE_LIMIT,
+          ...(cursor !== undefined ? { cursor } : {}),
+        },
+      });
+
+      latestLedger = result.latestLedger;
+
+      allEvents.push(
+        ...result.events.map((raw) => ({
+          id: raw.id,
+          contractId: raw.contractId,
+          topic: raw.topic,
+          value: raw.value,
+          ledger: raw.ledger,
+          ledgerClosedAt: raw.ledgerClosedAt,
+        })),
+      );
+
+      // Continue paginating when the page was full — there may be more events.
+      cursor =
+        result.events.length === EVENTS_PAGE_LIMIT
+          ? result.events[result.events.length - 1].pagingToken
+          : undefined;
+    } while (cursor !== undefined);
+
+    if (allEvents.length > 0) {
+      await this.handleBatch(allEvents);
+    }
+
+    // Advance cursor to the latest ledger reported by the RPC.
     await this.storage.saveCursor({
-      lastLedger: this.lastLedgerPolled,
+      lastLedger: latestLedger,
       updatedAt: new Date().toISOString(),
     });
+    this.lastLedgerPolled = latestLedger;
   }
 
   /**

--- a/backend/src/shared/rpc/soroban-rpc.client.ts
+++ b/backend/src/shared/rpc/soroban-rpc.client.ts
@@ -100,6 +100,15 @@ export class SorobanRpcClient {
     return result.sequence;
   }
 
+  /**
+   * Fetch a raw page of contract events from the Soroban RPC, including
+   * `latestLedger` and per-event `pagingToken` needed for cursor-based
+   * pagination.
+   */
+  async getEventsPage(params: GetEventsParams): Promise<GetEventsResult> {
+    return this.call<GetEventsParams, GetEventsResult>("getEvents", params);
+  }
+
   // ─── Internal ──────────────────────────────────────────────────────────────
 
   private async call<P, R>(method: string, params?: P): Promise<R> {


### PR DESCRIPTION
﻿Closes #720

## Summary

Replaces the poll() stub in EventPollingService with a real paginated Soroban JSON-RPC implementation.

## Changes

### backend/src/shared/rpc/soroban-rpc.client.ts
- Added getEventsPage(params) method returning raw GetEventsResult (events + latestLedger + per-event pagingToken) required for cursor-based pagination.

### backend/src/modules/events/events.service.ts
- Injected SorobanRpcClient as an optional 6th constructor parameter (defaults to new SorobanRpcClient({ url: env.sorobanRpcUrl })).
- Replaced mock poll() with a real implementation:
  - First run (lastLedgerPolled === 0): calls getLatestLedger() to anchor the cursor without processing historical events, then returns early.
  - Subsequent runs: paginates through all events in [lastLedgerPolled + 1, latestLedger] using getEventsPage() with EVENTS_PAGE_LIMIT = 200, maps raw events to ContractEvent, passes them through the existing handleBatch() pipeline, then advances the persisted cursor to latestLedger.

### backend/src/modules/events/events.service.test.ts
- Added buildMockFetch, createNoOpRpcClient, makeRawEvent, and createSvc helpers.
- Updated all existing tests to use createSvc (mock RPC) so they stay unit tests with no network I/O.
- Added RPC Polling test suite (7 tests):
  - First-run initialisation via getLatestLedger
  - startLedger derived as lastLedgerPolled + 1
  - Cursor advancement to latestLedger from RPC response
  - Events forwarded through handleBatch
  - Empty-page handling without errors
  - Multi-page pagination (full page triggers second request)
  - Cross-poll deduplication via processedEventIds

## Test Results
28 tests | 28 pass | 0 fail
