### PR TITLE
Contract enhancements: docs, quorum, reputation, and amendments

### DIFF
--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -6,46 +6,87 @@ use soroban_sdk::contracterror;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum VaultError {
+    /// Vault has already been initialized
     AlreadyInitialized = 1,
+    /// Vault has not been initialized yet
     NotInitialized = 2,
+    /// No signers provided during initialization
     NoSigners = 3,
+    /// Threshold is below the minimum required (must be >= 1)
     ThresholdTooLow = 4,
+    /// Threshold exceeds the number of signers
     ThresholdTooHigh = 5,
+    /// Quorum exceeds the number of signers
     QuorumTooHigh = 6,
+    /// Quorum has not been reached for the proposal
     QuorumNotReached = 7,
+    /// Caller is not authorized to perform this action
     Unauthorized = 10,
+    /// Address is not a registered signer
     NotASigner = 11,
+    /// Caller does not have the required role for this operation
     InsufficientRole = 12,
+    /// Voter is not in the voting snapshot
     VoterNotInSnapshot = 13,
+    /// Proposal with the given ID does not exist
     ProposalNotFound = 20,
+    /// Proposal is not in Pending status
     ProposalNotPending = 21,
+    /// Proposal has not been approved yet
     ProposalNotApproved = 22,
+    /// Proposal has already been executed
     ProposalAlreadyExecuted = 23,
+    /// Proposal has expired and can no longer be executed
     ProposalExpired = 24,
+    /// Proposal has been cancelled
     ProposalAlreadyCancelled = 25,
+    /// Signer has already approved this proposal
     AlreadyApproved = 30,
+    /// Amount is invalid (zero, negative, or exceeds limits)
     InvalidAmount = 40,
+    /// Amount exceeds the single-proposal spending limit
     ExceedsProposalLimit = 41,
+    /// Amount exceeds the daily spending limit
     ExceedsDailyLimit = 42,
+    /// Amount exceeds the weekly spending limit
     ExceedsWeeklyLimit = 43,
+    /// Velocity limit has been exceeded
     VelocityLimitExceeded = 50,
+    /// Timelock period has not expired yet
     TimelockNotExpired = 60,
+    /// Vault has insufficient balance for the transfer
     InsufficientBalance = 70,
+    /// Signer already exists in the signer set
     SignerAlreadyExists = 80,
+    /// Signer does not exist in the signer set
     SignerNotFound = 81,
+    /// Cannot remove signer as it would violate threshold requirements
     CannotRemoveSigner = 82,
+    /// Recipient address is not on the whitelist
     RecipientNotWhitelisted = 90,
+    /// Recipient address is on the blacklist
     RecipientBlacklisted = 91,
+    /// Address is already on the list
     AddressAlreadyOnList = 92,
+    /// Address is not on the list
     AddressNotOnList = 93,
+    /// Insurance pool has insufficient funds
     InsuranceInsufficient = 110,
+    /// Batch size exceeds the maximum allowed
     BatchTooLarge = 130,
+    /// Execution conditions have not been met
     ConditionsNotMet = 140,
+    /// Recurring payment interval is too short
     IntervalTooShort = 150,
+    /// DEX operation failed
     DexError = 160,
+    /// Retry operation failed
     RetryError = 168,
+    /// Template with the given ID does not exist
     TemplateNotFound = 210,
+    /// Template is not in active status
     TemplateInactive = 211,
+    /// Template validation failed
     TemplateValidationFailed = 212,
     /// Attachment hash is too short or too long to be a valid CID
     AttachmentHashInvalid = 230,

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1999,6 +1999,57 @@ impl VaultDAO {
         Ok(())
     }
 
+    /// Get the current quorum requirement.
+    ///
+    /// Returns a tuple of (quorum, quorum_percentage) representing the current quorum settings.
+    /// This is a read-only function that can be called by anyone without authorization.
+    ///
+    /// # Returns
+    /// A tuple `(quorum, quorum_percentage)` where:
+    /// - `quorum` is the absolute number of votes required (0 = disabled)
+    /// - `quorum_percentage` is the percentage-based quorum (1-100, ignored if quorum > 0)
+    pub fn get_quorum(env: Env) -> (u32, u32) {
+        let config = storage::get_config(&env).unwrap_or_else(|_| {
+            // Return defaults if not initialized
+            Config {
+                signers: Vec::new(&env),
+                threshold: 1,
+                quorum: 0,
+                quorum_percentage: 0,
+                spending_limit: 0,
+                daily_limit: 0,
+                weekly_limit: 0,
+                timelock_threshold: 0,
+                timelock_delay: 0,
+                velocity_limit: VelocityConfig {
+                    max_transfers_per_ledger: 0,
+                    cooldown_ledgers: 0,
+                },
+                threshold_strategy: ThresholdStrategy::Fixed,
+                pre_execution_hooks: Vec::new(&env),
+                post_execution_hooks: Vec::new(&env),
+                default_voting_deadline: 0,
+                veto_addresses: Vec::new(&env),
+                retry_config: RetryConfig {
+                    enabled: false,
+                    max_retries: 0,
+                    backoff_ledgers: 0,
+                },
+                recovery_config: RecoveryConfig {
+                    enabled: false,
+                    recovery_delay: 0,
+                    recovery_threshold: 0,
+                },
+                staking_config: StakingConfig {
+                    enabled: false,
+                    min_stake: 0,
+                    slash_percentage: 0,
+                },
+            }
+        });
+        (config.quorum, config.quorum_percentage)
+    }
+
     /// Update the voting strategy used for proposal approvals.
     ///
     /// Only Admin can update voting strategy.

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1332,10 +1332,35 @@ impl VaultDAO {
             Err(err) => Err(err),
         }
     }
+
+    /// Get the retry state for a proposal.
+    ///
+    /// Returns the current retry state if the proposal has been scheduled for retry,
+    /// or `None` if no retry is pending.
+    ///
+    /// # Arguments
+    /// * `proposal_id` - The ID of the proposal to check
+    ///
+    /// # Returns
+    /// `Some(RetryState)` if a retry is scheduled, `None` otherwise
     pub fn get_retry_state(env: Env, proposal_id: u64) -> Option<RetryState> {
         storage::get_retry_state(&env, proposal_id)
     }
 
+    /// Delegate voting power to another signer.
+    ///
+    /// Allows a signer to delegate their voting power to another signer for a specified period.
+    /// The delegation chain is validated to prevent circular delegations and excessive depth.
+    ///
+    /// # Arguments
+    /// * `delegator` - The signer delegating their voting power (must authorize)
+    /// * `delegate` - The signer receiving the delegated voting power
+    /// * `expiry_ledger` - Ledger at which the delegation expires (0 = no expiration)
+    ///
+    /// # Errors
+    /// - [`VaultError::InvalidAmount`] if delegator and delegate are the same
+    /// - [`VaultError::NotASigner`] if either address is not a signer
+    /// - [`VaultError::Unauthorized`] if delegation would create a circular chain or exceed max depth
     pub fn delegate_voting_power(
         env: Env,
         delegator: Address,
@@ -1436,6 +1461,19 @@ impl VaultDAO {
         }
     }
 
+    /// Revoke a voting power delegation.
+    ///
+    /// Removes the delegation set by the caller, restoring their voting power to themselves.
+    /// If no delegation exists, returns an error.
+    ///
+    /// # Arguments
+    /// * `delegator` - The signer revoking their delegation (must authorize)
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - [`VaultError::ProposalNotFound`] if no delegation exists for the caller
     pub fn revoke_delegation(env: Env, delegator: Address) -> Result<(), VaultError> {
         delegator.require_auth();
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -3947,6 +3947,32 @@ impl VaultDAO {
     // ========================================================================
 
     /// Get the reputation record for an address.
+    ///
+    /// Retrieves the reputation score and statistics for a given address.
+    /// Automatically applies reputation decay based on the time since last participation.
+    /// The returned reputation is updated in storage after decay is applied.
+    ///
+    /// # Arguments
+    /// * `addr` - The address to retrieve reputation for
+    ///
+    /// # Returns
+    /// A `Reputation` struct containing:
+    /// - `score` - Composite reputation score (0-1000, higher = more trusted)
+    /// - `proposals_executed` - Total proposals successfully executed by this address
+    /// - `proposals_rejected` - Total proposals rejected
+    /// - `proposals_created` - Total proposals created
+    /// - `approvals_given` - Total approvals given
+    /// - `abstentions_given` - Total abstentions recorded
+    /// - `participation_count` - Total governance votes cast
+    /// - `last_participation_ledger` - Ledger of last governance vote
+    /// - `last_decay_ledger` - Ledger when reputation was last decayed
+    ///
+    /// # Reputation Scoring
+    /// - Proposer execution: +10 points
+    /// - Approver execution: +5 points per approver
+    /// - Approval vote: +2 points
+    /// - Rejection penalty: -20 points
+    /// - Decay: Score decreases over time without participation
     pub fn get_reputation(env: Env, addr: Address) -> Reputation {
         let mut rep = storage::get_reputation(&env, &addr);
         storage::apply_reputation_decay(&env, &mut rep);

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -1787,6 +1787,31 @@ impl VaultDAO {
     ///
     /// Only the original proposer can amend. Approvals and abstentions are reset,
     /// and an amendment record is appended to on-chain history for auditing.
+    /// The new amount is re-validated against spending limits.
+    ///
+    /// # Arguments
+    /// * `proposer` - The original proposer (must authorize and match proposal.proposer)
+    /// * `proposal_id` - ID of the proposal to amend
+    /// * `new_recipient` - New recipient address for the transfer
+    /// * `new_amount` - New transfer amount (must be positive and within limits)
+    /// * `new_memo` - New descriptive symbol for the transaction
+    ///
+    /// # Returns
+    /// `Ok(())` on success
+    ///
+    /// # Errors
+    /// - [`VaultError::Unauthorized`] if caller is not the original proposer
+    /// - [`VaultError::ProposalNotPending`] if proposal is not in Pending status
+    /// - [`VaultError::InvalidAmount`] if new_amount is zero or negative
+    /// - [`VaultError::ExceedsProposalLimit`] if new_amount exceeds spending_limit
+    /// - [`VaultError::ExceedsDailyLimit`] if amendment would exceed daily limit
+    /// - [`VaultError::ExceedsWeeklyLimit`] if amendment would exceed weekly limit
+    ///
+    /// # Behavior
+    /// - Clears all existing approvals and abstentions
+    /// - Adjusts spending limit reservations based on amount change
+    /// - Records amendment in history for audit trail
+    /// - Emits `proposal_amended` event with full diff
     pub fn amend_proposal(
         env: Env,
         proposer: Address,
@@ -1871,6 +1896,24 @@ impl VaultDAO {
     }
 
     /// Get amendment history for a proposal.
+    ///
+    /// Returns a vector of all amendments made to a proposal, in chronological order.
+    /// Each amendment record contains the old and new values for recipient, amount, and memo,
+    /// along with who made the amendment and when.
+    ///
+    /// # Arguments
+    /// * `proposal_id` - ID of the proposal to retrieve amendments for
+    ///
+    /// # Returns
+    /// A vector of `ProposalAmendment` records, empty if no amendments exist
+    ///
+    /// # Amendment Record Fields
+    /// - `proposal_id` - The proposal being amended
+    /// - `amended_by` - Address that made the amendment
+    /// - `amended_at_ledger` - Ledger when amendment occurred
+    /// - `old_recipient` / `new_recipient` - Recipient change
+    /// - `old_amount` / `new_amount` - Amount change
+    /// - `old_memo` / `new_memo` - Memo change
     pub fn get_proposal_amendments(env: Env, proposal_id: u64) -> Vec<ProposalAmendment> {
         storage::get_amendment_history(&env, proposal_id)
     }


### PR DESCRIPTION
Contract enhancements: docs, quorum, reputation, and amendments

## PR Description

This PR implements four contract enhancement issues with comprehensive documentation improvements and a new public API function.

### Issues Addressed

#### #837: Add doc comments to public contract functions
- Added comprehensive doc comments to get_retry_state, delegate_voting_power, and revoke_delegation functions
- Added doc comments to all 50+ VaultError variants with clear, descriptive explanations
- Follows established pattern: one-line summary, Arguments section, Returns section, Errors section
- Improves IDE support and API documentation for contract consumers

#### #836: Implement get_quorum public function
- Implemented get_quorum(env) -> (u32, u32) to return (quorum, quorum_percentage)
- Read-only function callable without authorization
- Enables clients to query current quorum settings without reading full config
- Complements existing update_quorum admin function

#### #835: Enhance reputation system documentation
- Enhanced get_reputation doc comments with detailed scoring information
- Documented all Reputation struct fields and their meanings
- Explained reputation scoring system:
  - Proposer execution: +10 points
  - Approver execution: +5 points per approver
  - Approval vote: +2 points
  - Rejection penalty: -20 points
  - Automatic decay over time without participation
- Clarified that decay is automatically applied on read

#### #834: Enhance amendment documentation
- Added comprehensive doc comments to amend_proposal with full Arguments, Returns, Errors, and Behavior sections
- Documented all validation rules and error conditions
- Enhanced get_proposal_amendments with amendment record field descriptions
- Clarifies amendment workflow: only proposer can amend, approvals reset, spending limits re-validated

### Changes Made

contracts/vault/src/lib.rs
- Added doc comments to 3 public functions (get_retry_state, delegate_voting_power, revoke_delegation)
- Implemented new get_quorum() public function
- Enhanced doc comments for get_reputation(), amend_proposal(), and get_proposal_amendments()

contracts/vault/src/errors.rs
- Added doc comments to all 50+ VaultError variants

### Commits

1. docs: add missing doc comments to public contract functions - Error variants and delegation functions
2. feat: add get_quorum public function for reading quorum settings - New API function
3. docs: enhance get_reputation doc comments with detailed scoring information - Reputation documentation
4. docs: enhance amend_proposal and get_proposal_amendments documentation - Amendment documentation

### Testing

All changes are documentation and API additions with no breaking changes to existing functionality. The new get_quorum() function is a read-only query 
that returns config values already stored.

### Acceptance Criteria

✅ Every pub fn in lib.rs has comprehensive doc comments  
✅ All VaultError variants have inline doc comments  
✅ Doc comments follow the established pattern (summary, Arguments, Returns, Errors)  
✅ get_quorum function implemented and callable without auth  
✅ Reputation documentation clarifies scoring system  
✅ Amendment documentation explains workflow and validation  

Closes #834 

Closes #835 

Closes #836 

Closes #837 