### PR TITLE
feat: real-time proposal streaming and distributed rate limiting

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -101,3 +101,21 @@ CURSOR_STORAGE_TYPE=file
 # Path to the SQLite database file (used if CURSOR_STORAGE_TYPE=database)
 # Type: string | Default: ./vaultdao.sqlite
 DATABASE_PATH=./vaultdao.sqlite
+
+# ------------------------------------------------------------------------------
+# 5. Rate Limiting
+# ------------------------------------------------------------------------------
+
+# Toggle Redis-backed rate limiting (falls back to in-memory when false or Redis unavailable)
+# Type: boolean | Default: true
+RATE_LIMIT_ENABLED=true
+
+# Redis connection string for distributed rate limiting
+# Type: url | Optional — omit to use in-memory fallback
+# Example: redis://localhost:6379
+RATE_LIMIT_REDIS_URL=
+
+# Per-endpoint request limits (requests per minute)
+RATE_LIMIT_PROPOSALS_PER_MIN=100
+RATE_LIMIT_EXECUTE_PER_MIN=10
+RATE_LIMIT_DEFAULT_PER_MIN=60

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "express": "^5.1.0",
+        "ioredis": "^5.6.1",
         "ws": "^8.20.0"
       },
       "devDependencies": {
@@ -462,6 +463,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -645,6 +652,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -700,6 +716,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1084,6 +1109,30 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1097,6 +1146,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -1290,6 +1351,27 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -1444,6 +1526,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "express": "^5.1.0",
+    "ioredis": "^5.6.1",
     "ws": "^8.20.0"
   },
   "devDependencies": {

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -19,6 +19,15 @@ export interface BackendEnv {
   readonly apiKey?: string;
   readonly cursorStorageType: "file" | "database";
   readonly databasePath: string;
+  // Rate limiting
+  readonly rateLimitEnabled?: boolean;
+  readonly rateLimitRedisUrl?: string;
+  /** Max requests per minute for /api/v1/proposals */
+  readonly rateLimitProposalsPerMin?: number;
+  /** Max requests per minute for /api/v1/execute */
+  readonly rateLimitExecutePerMin?: number;
+  /** Default max requests per minute for all other endpoints */
+  readonly rateLimitDefaultPerMin?: number;
 }
 
 const DEFAULT_CONTRACT_ID =
@@ -45,7 +54,10 @@ function readString(name: string, fallback: string): string {
 function readCommaSeparatedString(name: string, fallback: string[]): string[] {
   const value = readValue(name);
   if (!value) return fallback;
-  return value.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
 }
 
 function readPort(name: string, fallback: number, issues: string[]): number {
@@ -54,7 +66,9 @@ function readPort(name: string, fallback: number, issues: string[]): number {
 
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
-    issues.push(`${name} must be an integer between 1 and 65535. Received "${value}".`);
+    issues.push(
+      `${name} must be an integer between 1 and 65535. Received "${value}".`,
+    );
     return fallback;
   }
 
@@ -143,18 +157,55 @@ export function loadEnv(): BackendEnv {
   );
   const contractId = readString("CONTRACT_ID", DEFAULT_CONTRACT_ID);
   const websocketUrl = readString("VITE_WS_URL", "ws://localhost:8080");
-  const eventPollingIntervalMs = readPort("EVENT_POLLING_INTERVAL_MS", 10000, issues);
-  const eventPollingEnabled = readString("EVENT_POLLING_ENABLED", "true") === "true";
-  const duePaymentsJobEnabled = readString("DUE_PAYMENTS_JOB_ENABLED", "true") === "true";
-  const duePaymentsJobIntervalMs = readPort("DUE_PAYMENTS_JOB_INTERVAL_MS", 60000, issues);
-  const cursorCleanupJobEnabled = readString("CURSOR_CLEANUP_JOB_ENABLED", "true") === "true";
-  const cursorCleanupJobIntervalMs = readPort("CURSOR_CLEANUP_JOB_INTERVAL_MS", 86400000, issues);
+  const eventPollingIntervalMs = readPort(
+    "EVENT_POLLING_INTERVAL_MS",
+    10000,
+    issues,
+  );
+  const eventPollingEnabled =
+    readString("EVENT_POLLING_ENABLED", "true") === "true";
+  const duePaymentsJobEnabled =
+    readString("DUE_PAYMENTS_JOB_ENABLED", "true") === "true";
+  const duePaymentsJobIntervalMs = readPort(
+    "DUE_PAYMENTS_JOB_INTERVAL_MS",
+    60000,
+    issues,
+  );
+  const cursorCleanupJobEnabled =
+    readString("CURSOR_CLEANUP_JOB_ENABLED", "true") === "true";
+  const cursorCleanupJobIntervalMs = readPort(
+    "CURSOR_CLEANUP_JOB_INTERVAL_MS",
+    86400000,
+    issues,
+  );
   const cursorRetentionDays = readPort("CURSOR_RETENTION_DAYS", 30, issues);
-  const corsOrigin = readCommaSeparatedString("CORS_ORIGIN", nodeEnv === "production" ? [] : ["*"]);
+  const corsOrigin = readCommaSeparatedString(
+    "CORS_ORIGIN",
+    nodeEnv === "production" ? [] : ["*"],
+  );
   const requestBodyLimit = readString("REQUEST_BODY_LIMIT", "10kb");
   const apiKey = readValue("API_KEY");
-  const cursorStorageType = readString("CURSOR_STORAGE_TYPE", "file") as "file" | "database";
+  const cursorStorageType = readString("CURSOR_STORAGE_TYPE", "file") as
+    | "file"
+    | "database";
   const databasePath = readString("DATABASE_PATH", "./vaultdao.sqlite");
+  const rateLimitEnabled = readString("RATE_LIMIT_ENABLED", "true") === "true";
+  const rateLimitRedisUrl = readValue("RATE_LIMIT_REDIS_URL");
+  const rateLimitProposalsPerMin = readPort(
+    "RATE_LIMIT_PROPOSALS_PER_MIN",
+    100,
+    issues,
+  );
+  const rateLimitExecutePerMin = readPort(
+    "RATE_LIMIT_EXECUTE_PER_MIN",
+    10,
+    issues,
+  );
+  const rateLimitDefaultPerMin = readPort(
+    "RATE_LIMIT_DEFAULT_PER_MIN",
+    60,
+    issues,
+  );
 
   validateRequiredString("HOST", host, issues);
   validateAllowedValue("NODE_ENV", nodeEnv, ALLOWED_NODE_ENVS, issues);
@@ -213,5 +264,10 @@ export function loadEnv(): BackendEnv {
     apiKey,
     cursorStorageType,
     databasePath,
+    rateLimitEnabled,
+    rateLimitRedisUrl,
+    rateLimitProposalsPerMin,
+    rateLimitExecutePerMin,
+    rateLimitDefaultPerMin,
   };
 }

--- a/backend/src/modules/proposals/consumer.ts
+++ b/backend/src/modules/proposals/consumer.ts
@@ -62,6 +62,8 @@ export class ProposalActivityConsumer {
   private pendingFlush: boolean = false;
   private readonly metrics?: MetricsRegistry;
   private readonly notificationQueue?: NotificationPublisher;
+  /** Optional hook called after each activity record is produced — used to broadcast to realtime rooms. */
+  private readonly onActivity?: (record: ProposalActivityRecord) => void;
 
   // Persistence failure tracking
   private retryBuffer: ProposalActivityRecord[] = [];
@@ -77,6 +79,8 @@ export class ProposalActivityConsumer {
     initialBackoffMs?: number;
     metricsRegistry?: MetricsRegistry;
     notificationQueue?: NotificationPublisher;
+    /** Broadcast hook — called synchronously after each record is produced. */
+    onActivity?: (record: ProposalActivityRecord) => void;
   }) {
     this.batchSize = options?.batchSize ?? DEFAULT_BATCH_SIZE;
     this.flushIntervalMs =
@@ -85,6 +89,7 @@ export class ProposalActivityConsumer {
     this.initialBackoffMs = options?.initialBackoffMs ?? 1000;
     this.metrics = options?.metricsRegistry;
     this.notificationQueue = options?.notificationQueue;
+    this.onActivity = options?.onActivity;
   }
 
   /**
@@ -156,6 +161,9 @@ export class ProposalActivityConsumer {
 
     this.buffer.push(record);
     console.debug("[proposal-consumer] buffered record:", record.activityId);
+
+    // Broadcast to realtime rooms immediately
+    this.onActivity?.(record);
 
     // Persist via persistence if configured
     if (this.persistence) {
@@ -285,7 +293,9 @@ export class ProposalActivityConsumer {
   /**
    * Publishes notifications for key events.
    */
-  private async publishNotification(record: ProposalActivityRecord): Promise<void> {
+  private async publishNotification(
+    record: ProposalActivityRecord,
+  ): Promise<void> {
     if (!this.notificationQueue) return;
 
     let payload: any = null;
@@ -333,7 +343,10 @@ export class ProposalActivityConsumer {
           payload,
         });
       } catch (err) {
-        console.error("[proposal-consumer] failed to publish notification:", err);
+        console.error(
+          "[proposal-consumer] failed to publish notification:",
+          err,
+        );
       }
     }
   }
@@ -450,28 +463,33 @@ export class ProposalActivityConsumer {
         // // Notify batch consumers
         // for (const consumer of this.batchConsumers) { try { await consumer(records); } catch (error) { ... } }
         //
-        // This means if persistence fails, consumers are NOT notified. 
+        // This means if persistence fails, consumers are NOT notified.
         // I will follow this pattern: only notify if saveBatch succeeded (or if no persistence configured).
 
         if (!this.persistence || records.length > 0) {
-          // If we had no persistence, or we had persistence but records were cleared from this.buffer 
+          // If we had no persistence, or we had persistence but records were cleared from this.buffer
           // (meaning it didn't throw before we caught it and moved to retryBuffer)
-          
+
           // Wait, if persistence exists and saveBatch(records) SUCCEEDS, records are NOT in retryBuffer.
           // If it FAILS, they ARE in retryBuffer.
-          
+
           // Check if 'records' were successfully persisted (not in retryBuffer)
           // Actually, 'records' is a local copy. I should check if they were added to retryBuffer.
-          const persistedSuccessfully = !this.retryBuffer.some(r => records.includes(r));
-          
+          const persistedSuccessfully = !this.retryBuffer.some((r) =>
+            records.includes(r),
+          );
+
           if (persistedSuccessfully) {
-             for (const consumer of this.batchConsumers) {
-               try {
-                 await consumer(records);
-               } catch (error) {
-                 console.error("[proposal-consumer] batch consumer error during flush:", error);
-               }
-             }
+            for (const consumer of this.batchConsumers) {
+              try {
+                await consumer(records);
+              } catch (error) {
+                console.error(
+                  "[proposal-consumer] batch consumer error during flush:",
+                  error,
+                );
+              }
+            }
           }
         }
       }
@@ -608,7 +626,9 @@ export class ProposalActivityConsumer {
 
       default:
         // This should be unreachable if PROPOSAL_ACTIVITY_TYPE_MAP is correctly configured
-        console.warn(`[proposal-consumer] unhandled activity type: ${activityType}`);
+        console.warn(
+          `[proposal-consumer] unhandled activity type: ${activityType}`,
+        );
         return {
           activityType: activityType as any,
         } as any;
@@ -677,6 +697,7 @@ export function createProposalConsumer(options?: {
   flushIntervalMs?: number;
   metricsRegistry?: MetricsRegistry;
   notificationQueue?: NotificationPublisher;
+  onActivity?: (record: ProposalActivityRecord) => void;
 }): ProposalActivityConsumer {
   return new ProposalActivityConsumer(options);
 }

--- a/backend/src/modules/realtime/realtime-server.ts
+++ b/backend/src/modules/realtime/realtime-server.ts
@@ -1,8 +1,11 @@
+import { randomUUID } from "node:crypto";
+import { WebSocket, WebSocketServer } from "ws";
+import type { IncomingMessage, Server } from "node:http";
 import { createLogger } from "../../shared/logging/logger.js";
 import {
   createRealtimeTopic,
-  createTopicBroadcaster,
   SubscriptionRegistry,
+  createTopicBroadcaster,
   type RealtimeTopic,
 } from "./subscriptions/index.js";
 import type {
@@ -11,77 +14,187 @@ import type {
   RealtimeEnvelope,
 } from "./types.js";
 
+const logger = createLogger("realtime-server");
+
+const HEARTBEAT_INTERVAL_MS = 30_000;
+const HEARTBEAT_DEADLINE_MS = 60_000; // dead if no pong within 2 ticks
+
+// ---------------------------------------------------------------------------
+// Internal connection wrapper
+// ---------------------------------------------------------------------------
+
+interface LiveConnection extends RealtimeConnection {
+  ws: WebSocket;
+  lastPong: number;
+}
+
+// ---------------------------------------------------------------------------
+// RealtimeServer
+// ---------------------------------------------------------------------------
+
 export class RealtimeServer {
-  private readonly logger = createLogger("realtime-server");
-  private readonly connections = new Map<string, RealtimeConnection>();
+  private readonly connections = new Map<string, LiveConnection>();
   private readonly subscriptions = new SubscriptionRegistry();
   private readonly broadcaster = createTopicBroadcaster(
     this.subscriptions,
     (clientId, message) => this.deliver(clientId, message),
   );
   private readonly hooks: RealtimeConnectionLifecycleHooks;
+  private wss: WebSocketServer | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private started = false;
 
   constructor(hooks: RealtimeConnectionLifecycleHooks = {}) {
     this.hooks = hooks;
   }
 
-  public start(): void {
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  public start(server: Server): void {
     if (this.started) {
-      this.logger.warn("realtime server already started");
+      logger.warn("realtime server already started");
       return;
     }
 
+    this.wss = new WebSocketServer({ server });
+    this.wss.on("connection", (ws, req) => this.handleConnection(ws, req));
+
+    this.heartbeatTimer = setInterval(
+      () => this.runHeartbeat(),
+      HEARTBEAT_INTERVAL_MS,
+    );
+
     this.started = true;
-    this.logger.info("realtime server scaffold started");
+    logger.info("realtime server started");
   }
 
   public stop(): void {
     if (!this.started) return;
 
-    const connectedIds = Array.from(this.connections.keys());
-    for (const connectionId of connectedIds) {
-      this.unregisterConnection(connectionId, "server shutdown");
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
     }
 
+    for (const id of Array.from(this.connections.keys())) {
+      this.unregisterConnection(id, "server shutdown");
+    }
+
+    this.wss?.close();
+    this.wss = null;
     this.started = false;
-    this.logger.info("realtime server scaffold stopped");
+    logger.info("realtime server stopped");
   }
 
-  public registerConnection(connection: RealtimeConnection): void {
-    this.connections.set(connection.id, connection);
-    this.hooks.onConnected?.(connection.id);
+  // ---------------------------------------------------------------------------
+  // Connection handling
+  // ---------------------------------------------------------------------------
 
-    connection.send({
+  private handleConnection(ws: WebSocket, req: IncomingMessage): void {
+    // Auth via ?token= query param
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const token = url.searchParams.get("token");
+    const apiKey = process.env["API_KEY"];
+
+    if (apiKey && token !== apiKey) {
+      ws.close(4401, "Unauthorized");
+      logger.warn("rejected unauthenticated realtime connection");
+      return;
+    }
+
+    const connectionId = randomUUID();
+    const conn: LiveConnection = {
+      id: connectionId,
+      ws,
+      lastPong: Date.now(),
+      send: (msg) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          try {
+            ws.send(JSON.stringify(msg));
+          } catch (err) {
+            logger.warn("send failed", { connectionId, err });
+          }
+        }
+      },
+      close: (code, reason) => ws.close(code, reason),
+    };
+
+    this.connections.set(connectionId, conn);
+    this.hooks.onConnected?.(connectionId);
+
+    // Send hello
+    conn.send({
       type: "hello",
       ts: new Date().toISOString(),
-      payload: {
-        connectionId: connection.id,
-        status: "connected",
-      },
+      payload: { connectionId, status: "connected" },
     });
 
-    this.logger.info("connection registered", { connectionId: connection.id });
+    ws.on("pong", () => {
+      conn.lastPong = Date.now();
+    });
+
+    ws.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        this.handleMessage(connectionId, msg);
+      } catch {
+        logger.warn("unparseable message", { connectionId });
+      }
+    });
+
+    ws.on("close", () =>
+      this.unregisterConnection(connectionId, "client disconnected"),
+    );
+    ws.on("error", (err) => {
+      logger.error("ws error", { connectionId, err });
+      this.unregisterConnection(connectionId, "error");
+    });
+
+    logger.info("connection registered", { connectionId });
   }
 
-  public unregisterConnection(connectionId: string, reason = "client disconnected"): void {
-    const connection = this.connections.get(connectionId);
-    if (!connection) return;
+  private handleMessage(connectionId: string, msg: any): void {
+    if (!msg || typeof msg.type !== "string") return;
 
-    this.subscriptions.unsubscribeAll(connectionId);
-    this.connections.delete(connectionId);
-    this.hooks.onDisconnected?.(connectionId);
-
-    connection.close?.(1000, reason);
-    this.logger.info("connection unregistered", { connectionId, reason });
+    switch (msg.type) {
+      case "subscribe": {
+        const topic = this.parseTopic(msg.topic);
+        if (!topic) return;
+        const added = this.subscribe(connectionId, topic);
+        if (added) {
+          logger.info("subscribed", { connectionId, topic });
+        }
+        break;
+      }
+      case "unsubscribe": {
+        const topic = this.parseTopic(msg.topic);
+        if (!topic) return;
+        this.unsubscribe(connectionId, topic);
+        break;
+      }
+    }
   }
+
+  private parseTopic(raw: unknown): RealtimeTopic | null {
+    if (typeof raw !== "string") return null;
+    // Accept "proposal:123" → "proposal.123" or already-namespaced "proposal.123"
+    const normalized = raw.includes(":") ? raw.replace(":", ".") : raw;
+    try {
+      const [ns, ...rest] = normalized.split(".");
+      return createRealtimeTopic(ns as any, rest.join("."));
+    } catch {
+      return null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Subscription API
+  // ---------------------------------------------------------------------------
 
   public subscribe(connectionId: string, topic: RealtimeTopic): boolean {
-    if (!this.connections.has(connectionId)) {
-      this.logger.warn("subscribe attempted for unknown connection", { connectionId, topic });
-      return false;
-    }
-
+    if (!this.connections.has(connectionId)) return false;
     const added = this.subscriptions.subscribe(connectionId, topic);
     if (!added) return false;
 
@@ -92,7 +205,6 @@ export class RealtimeServer {
       ts: new Date().toISOString(),
       payload: { topic },
     });
-
     return true;
   }
 
@@ -107,10 +219,32 @@ export class RealtimeServer {
       ts: new Date().toISOString(),
       payload: { topic },
     });
-
     return true;
   }
 
+  public unregisterConnection(
+    connectionId: string,
+    reason = "client disconnected",
+  ): void {
+    const conn = this.connections.get(connectionId);
+    if (!conn) return;
+
+    this.subscriptions.unsubscribeAll(connectionId);
+    this.connections.delete(connectionId);
+    this.hooks.onDisconnected?.(connectionId);
+    conn.close?.(1000, reason);
+    logger.info("connection unregistered", { connectionId, reason });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Broadcast
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Broadcast a payload to all subscribers of a topic.
+   * Topic can be given as a RealtimeTopic string ("proposal.123") or
+   * the colon-separated shorthand ("proposal:123").
+   */
   public broadcast(topic: RealtimeTopic, payload: unknown): number {
     return this.broadcaster.broadcast(topic, {
       type: "event",
@@ -120,8 +254,58 @@ export class RealtimeServer {
     });
   }
 
-  public createTopic(namespace: "proposal" | "activity" | "system" | "notification" | "custom", key: string): RealtimeTopic {
-    return createRealtimeTopic(namespace, key);
+  /**
+   * Convenience: broadcast a proposal activity record to both
+   * proposal.<id> and proposal.<contractId> rooms.
+   */
+  public broadcastProposalActivity(record: {
+    proposalId: string;
+    type: string;
+    metadata: { contractId: string };
+    data: unknown;
+  }): void {
+    const proposalTopic = createRealtimeTopic("proposal", record.proposalId);
+    const contractTopic = createRealtimeTopic(
+      "proposal",
+      `contract-${record.metadata.contractId}`,
+    );
+
+    const payload = {
+      proposalId: record.proposalId,
+      status: record.type,
+      contractId: record.metadata.contractId,
+      data: record.data,
+    };
+
+    this.broadcast(proposalTopic, payload);
+    this.broadcast(contractTopic, payload);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Heartbeat
+  // ---------------------------------------------------------------------------
+
+  private runHeartbeat(): void {
+    const deadline = Date.now() - HEARTBEAT_DEADLINE_MS;
+    for (const [id, conn] of this.connections) {
+      if (conn.lastPong < deadline) {
+        logger.warn("terminating dead connection", { connectionId: id });
+        conn.ws.terminate();
+        this.unregisterConnection(id, "heartbeat timeout");
+        continue;
+      }
+      if (conn.ws.readyState === WebSocket.OPEN) {
+        conn.ws.ping();
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private deliver(connectionId: string, message: RealtimeEnvelope): void {
+    this.connections.get(connectionId)?.send(message);
   }
 
   public getConnectionCount(): number {
@@ -132,17 +316,10 @@ export class RealtimeServer {
     return this.subscriptions.getTopics(connectionId);
   }
 
-  private deliver(connectionId: string, message: RealtimeEnvelope): void {
-    const connection = this.connections.get(connectionId);
-    if (!connection) return;
-
-    try {
-      connection.send(message);
-    } catch (err) {
-      this.logger.warn("failed to deliver realtime message", {
-        connectionId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+  public createTopic(
+    namespace: "proposal" | "activity" | "system" | "notification" | "custom",
+    key: string,
+  ): RealtimeTopic {
+    return createRealtimeTopic(namespace, key);
   }
 }

--- a/backend/src/modules/websocket/realtime-streaming.test.ts
+++ b/backend/src/modules/websocket/realtime-streaming.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for WebSocket room-based proposal streaming.
+ *
+ * Covers:
+ *  - RealtimeServer: subscribe, multi-subscriber delivery, connection cleanup, lifecycle hooks
+ *  - ProposalActivityConsumer onActivity hook
+ *
+ * Integration tests (EventWebSocketServer with a live HTTP server) are in
+ * realtime-streaming.integration.test.ts and require better-sqlite3.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { RealtimeServer } from "../realtime/realtime-server.js";
+import { ProposalActivityConsumer } from "../proposals/consumer.js";
+import type { NormalizedEvent } from "../events/types.js";
+import { EventType } from "../events/types.js";
+
+// ---------------------------------------------------------------------------
+// Test-only helper: register a mock connection directly into RealtimeServer
+// ---------------------------------------------------------------------------
+
+function registerMockConnection(
+  server: RealtimeServer,
+  id: string,
+  recv: any[],
+): void {
+  // Access private map directly for testing
+  const conn = {
+    id,
+    ws: {
+      readyState: 1 /* OPEN */,
+      ping: () => {},
+      terminate: () => {},
+      close: () => {},
+    },
+    lastPong: Date.now(),
+    send: (msg: any) => recv.push(msg),
+    close: () => {},
+  };
+  (server as any).connections.set(id, conn);
+  (server as any).hooks.onConnected?.(id);
+  conn.send({
+    type: "hello",
+    ts: new Date().toISOString(),
+    payload: { connectionId: id, status: "connected" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// RealtimeServer unit tests
+// ---------------------------------------------------------------------------
+
+test("RealtimeServer", async (t) => {
+  await t.test("subscribe and deliver to single connection", () => {
+    const server = new RealtimeServer();
+    const received: any[] = [];
+
+    registerMockConnection(server, "conn-1", received);
+    const topic = server.createTopic("proposal", "123");
+    server.subscribe("conn-1", topic);
+    server.broadcast(topic, { status: "CREATED" });
+
+    const events = received.filter((m) => m.type === "event");
+    assert.equal(events.length, 1);
+    assert.equal((events[0].payload as any).status, "CREATED");
+  });
+
+  await t.test(
+    "multi-subscriber delivery — both connections receive broadcast",
+    () => {
+      const server = new RealtimeServer();
+      const recv1: any[] = [];
+      const recv2: any[] = [];
+
+      registerMockConnection(server, "c1", recv1);
+      registerMockConnection(server, "c2", recv2);
+
+      const topic = server.createTopic("proposal", "456");
+      server.subscribe("c1", topic);
+      server.subscribe("c2", topic);
+
+      const count = server.broadcast(topic, { status: "APPROVED" });
+
+      assert.equal(count, 2);
+      assert.equal(recv1.filter((m) => m.type === "event").length, 1);
+      assert.equal(recv2.filter((m) => m.type === "event").length, 1);
+    },
+  );
+
+  await t.test("unregisterConnection cleans up subscriptions", () => {
+    const server = new RealtimeServer();
+    registerMockConnection(server, "c3", []);
+
+    const topic = server.createTopic("proposal", "789");
+    server.subscribe("c3", topic);
+    assert.equal(server.getSubscriptions("c3").size, 1);
+
+    server.unregisterConnection("c3");
+    assert.equal(server.getConnectionCount(), 0);
+    assert.equal(server.getSubscriptions("c3").size, 0);
+
+    // Broadcast to now-empty topic should deliver 0
+    assert.equal(server.broadcast(topic, {}), 0);
+  });
+
+  await t.test(
+    "broadcastProposalActivity delivers to proposal and contract topics",
+    () => {
+      const server = new RealtimeServer();
+      const recv4: any[] = [];
+      const recv5: any[] = [];
+
+      registerMockConnection(server, "c4", recv4);
+      registerMockConnection(server, "c5", recv5);
+
+      // c4 subscribes to proposal topic, c5 to contract topic
+      server.subscribe("c4", server.createTopic("proposal", "10"));
+      server.subscribe("c5", server.createTopic("proposal", "contract-CDTEST"));
+
+      server.broadcastProposalActivity({
+        proposalId: "10",
+        type: "PROPOSAL_EXECUTED",
+        metadata: { contractId: "CDTEST" },
+        data: { amount: "100" },
+      });
+
+      assert.equal(recv4.filter((m) => m.type === "event").length, 1);
+      assert.equal(recv5.filter((m) => m.type === "event").length, 1);
+    },
+  );
+
+  await t.test(
+    "lifecycle hooks are called on connect/disconnect/subscribe",
+    () => {
+      const log: string[] = [];
+      const server = new RealtimeServer({
+        onConnected: (id) => log.push(`connected:${id}`),
+        onDisconnected: (id) => log.push(`disconnected:${id}`),
+        onSubscribed: (id, topic) => log.push(`subscribed:${id}:${topic}`),
+      });
+
+      registerMockConnection(server, "hook-conn", []);
+      const topic = server.createTopic("activity", "ledger");
+      server.subscribe("hook-conn", topic);
+      server.unregisterConnection("hook-conn");
+
+      assert.ok(log.includes("connected:hook-conn"));
+      assert.ok(log.includes(`subscribed:hook-conn:${topic}`));
+      assert.ok(log.includes("disconnected:hook-conn"));
+    },
+  );
+
+  await t.test("subscribe returns false for unknown connection", () => {
+    const server = new RealtimeServer();
+    const topic = server.createTopic("proposal", "999");
+    assert.equal(server.subscribe("ghost", topic), false);
+  });
+
+  await t.test("duplicate subscribe returns false", () => {
+    const server = new RealtimeServer();
+    registerMockConnection(server, "dup", []);
+    const topic = server.createTopic("proposal", "dup");
+    assert.equal(server.subscribe("dup", topic), true);
+    assert.equal(server.subscribe("dup", topic), false);
+  });
+
+  await t.test("unsubscribe stops delivery", () => {
+    const server = new RealtimeServer();
+    const recv: any[] = [];
+    registerMockConnection(server, "unsub", recv);
+
+    const topic = server.createTopic("proposal", "unsub");
+    server.subscribe("unsub", topic);
+    server.unsubscribe("unsub", topic);
+
+    server.broadcast(topic, { status: "VETOED" });
+    assert.equal(recv.filter((m) => m.type === "event").length, 0);
+  });
+
+  await t.test("getConnectionCount reflects active connections", () => {
+    const server = new RealtimeServer();
+    assert.equal(server.getConnectionCount(), 0);
+    registerMockConnection(server, "cnt-1", []);
+    assert.equal(server.getConnectionCount(), 1);
+    registerMockConnection(server, "cnt-2", []);
+    assert.equal(server.getConnectionCount(), 2);
+    server.unregisterConnection("cnt-1");
+    assert.equal(server.getConnectionCount(), 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProposalActivityConsumer — onActivity hook
+// ---------------------------------------------------------------------------
+
+test("ProposalActivityConsumer onActivity hook", async (t) => {
+  await t.test("onActivity is called for each processed event", async () => {
+    const fired: string[] = [];
+    const consumer = new ProposalActivityConsumer({
+      onActivity: (record) => fired.push(record.proposalId),
+    });
+
+    const event: NormalizedEvent = {
+      type: EventType.PROPOSAL_CREATED,
+      metadata: {
+        id: "evt-1",
+        contractId: "CDTEST",
+        ledger: 1,
+        ledgerClosedAt: new Date().toISOString(),
+      },
+      data: {
+        proposalId: "42",
+        proposer: "GABC",
+        recipient: "GXYZ",
+        token: "XLM",
+        amount: "100",
+        insuranceAmount: "0",
+      },
+    };
+
+    await consumer.process(event);
+    assert.deepEqual(fired, ["42"]);
+  });
+
+  await t.test(
+    "onActivity is called before persistence and consumers",
+    async () => {
+      const order: string[] = [];
+      const consumer = new ProposalActivityConsumer({
+        onActivity: () => order.push("broadcast"),
+      });
+      consumer.registerConsumer(async () => {
+        order.push("consumer");
+      });
+
+      const event: NormalizedEvent = {
+        type: EventType.PROPOSAL_APPROVED,
+        metadata: {
+          id: "evt-2",
+          contractId: "CDTEST",
+          ledger: 2,
+          ledgerClosedAt: new Date().toISOString(),
+        },
+        data: {
+          proposalId: "7",
+          approver: "GABC",
+          approvalCount: 2,
+          threshold: 3,
+        },
+      };
+
+      await consumer.process(event);
+      assert.equal(order[0], "broadcast");
+      assert.equal(order[1], "consumer");
+    },
+  );
+
+  await t.test(
+    "onActivity is not required (no error when absent)",
+    async () => {
+      const consumer = new ProposalActivityConsumer();
+      const event: NormalizedEvent = {
+        type: EventType.PROPOSAL_CREATED,
+        metadata: {
+          id: "evt-3",
+          contractId: "CDTEST",
+          ledger: 3,
+          ledgerClosedAt: new Date().toISOString(),
+        },
+        data: {
+          proposalId: "99",
+          proposer: "GABC",
+          recipient: "GXYZ",
+          token: "XLM",
+          amount: "50",
+          insuranceAmount: "0",
+        },
+      };
+
+      await assert.doesNotReject(() => consumer.process(event));
+    },
+  );
+});

--- a/backend/src/modules/websocket/websocket.server.ts
+++ b/backend/src/modules/websocket/websocket.server.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { WebSocketServer, WebSocket } from "ws";
+import type { IncomingMessage } from "node:http";
 import type { Server } from "node:http";
 import { createLogger } from "../../shared/logging/logger.js";
 import type { ContractEvent } from "../events/events.types.js";
@@ -10,27 +11,110 @@ interface ClientSubscription {
   connectionId: string;
   eventTypes?: string[];
   proposalId?: string;
+  /** room IDs this connection has joined (e.g. "proposal:123", "contract:ABC") */
+  rooms: Set<string>;
 }
 
 export class EventWebSocketServer {
   private wss: WebSocketServer;
   private clients: Map<WebSocket, ClientSubscription> = new Map();
+  /** room → set of WebSocket connections */
+  private rooms: Map<string, Set<WebSocket>> = new Map();
 
   constructor(server: Server) {
     this.wss = new WebSocketServer({ server });
     this.init();
   }
 
+  // ---------------------------------------------------------------------------
+  // Room management
+  // ---------------------------------------------------------------------------
+
+  joinRoom(connectionId: string, roomId: string): boolean {
+    const ws = this.findWs(connectionId);
+    if (!ws) return false;
+
+    const sub = this.clients.get(ws)!;
+    if (sub.rooms.has(roomId)) return false;
+
+    sub.rooms.add(roomId);
+    if (!this.rooms.has(roomId)) this.rooms.set(roomId, new Set());
+    this.rooms.get(roomId)!.add(ws);
+    logger.info("joined room", { connectionId, roomId });
+    return true;
+  }
+
+  leaveRoom(connectionId: string, roomId: string): boolean {
+    const ws = this.findWs(connectionId);
+    if (!ws) return false;
+
+    const sub = this.clients.get(ws)!;
+    if (!sub.rooms.has(roomId)) return false;
+
+    sub.rooms.delete(roomId);
+    this.rooms.get(roomId)?.delete(ws);
+    if (this.rooms.get(roomId)?.size === 0) this.rooms.delete(roomId);
+    logger.info("left room", { connectionId, roomId });
+    return true;
+  }
+
+  broadcastToRoom(roomId: string, event: unknown): number {
+    const members = this.rooms.get(roomId);
+    if (!members || members.size === 0) return 0;
+
+    let message: string;
+    try {
+      message = JSON.stringify({
+        type: "room_event",
+        room: roomId,
+        payload: event,
+      });
+    } catch {
+      logger.warn("failed to serialize room event", { roomId });
+      return 0;
+    }
+
+    let count = 0;
+    for (const ws of members) {
+      if (ws.readyState !== WebSocket.OPEN) continue;
+      try {
+        ws.send(message);
+        count++;
+      } catch (err) {
+        const sub = this.clients.get(ws);
+        logger.warn("failed to send room event", {
+          connectionId: sub?.connectionId,
+          roomId,
+          err,
+        });
+      }
+    }
+    return count;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Init
+  // ---------------------------------------------------------------------------
+
   private init() {
-    this.wss.on("connection", (ws: WebSocket) => {
+    this.wss.on("connection", (ws: WebSocket, req: IncomingMessage) => {
+      // Auth via query param: ?token=<API_KEY>
+      const url = new URL(req.url ?? "/", "http://localhost");
+      const token = url.searchParams.get("token");
+      const apiKey = process.env["API_KEY"];
+
+      if (apiKey && token !== apiKey) {
+        ws.close(4401, "Unauthorized");
+        logger.warn("rejected unauthenticated websocket connection");
+        return;
+      }
+
       const connectionId = randomUUID();
       logger.info("client connected", { connectionId });
 
-      // Mark alive so the first heartbeat tick does not immediately terminate it
       (ws as any).isAlive = true;
-      this.clients.set(ws, { connectionId });
+      this.clients.set(ws, { connectionId, rooms: new Set() });
 
-      // Reset liveness on each pong response
       ws.on("pong", () => {
         (ws as any).isAlive = true;
       });
@@ -40,21 +124,34 @@ export class EventWebSocketServer {
           const message = JSON.parse(data.toString());
           if (message.type === "subscribe") {
             this.handleSubscription(ws, message, connectionId);
+          } else if (message.type === "join") {
+            const roomId: string = message.room;
+            if (roomId) {
+              this.joinRoom(connectionId, roomId);
+              ws.send(JSON.stringify({ type: "joined", room: roomId }));
+            }
+          } else if (message.type === "leave") {
+            const roomId: string = message.room;
+            if (roomId) {
+              this.leaveRoom(connectionId, roomId);
+              ws.send(JSON.stringify({ type: "left", room: roomId }));
+            }
           }
         } catch (error) {
-          logger.error("failed to parse client message", { connectionId, error });
+          logger.error("failed to parse client message", {
+            connectionId,
+            error,
+          });
         }
       });
 
       ws.on("close", () => {
-        const sub = this.clients.get(ws);
-        logger.info("client disconnected", { connectionId: sub?.connectionId ?? connectionId });
-        this.clients.delete(ws);
+        this.cleanupConnection(ws, connectionId);
       });
 
       ws.on("error", (error: Error) => {
         logger.error("websocket error", { connectionId, error });
-        this.clients.delete(ws);
+        this.cleanupConnection(ws, connectionId);
       });
     });
 
@@ -72,12 +169,32 @@ export class EventWebSocketServer {
     });
   }
 
-  private handleSubscription(ws: WebSocket, message: any, connectionId: string) {
-    // Support both { type: "subscribe", topics: [...] } and legacy { payload: { eventTypes: [...] } }
-    const topics: string[] | undefined =
-      Array.isArray(message.topics) ? message.topics :
-      Array.isArray(message.payload?.eventTypes) ? message.payload.eventTypes :
-      undefined;
+  private cleanupConnection(ws: WebSocket, connectionId: string): void {
+    const sub = this.clients.get(ws);
+    if (!sub) return;
+
+    // Remove from all rooms
+    for (const roomId of sub.rooms) {
+      this.rooms.get(roomId)?.delete(ws);
+      if (this.rooms.get(roomId)?.size === 0) this.rooms.delete(roomId);
+    }
+
+    this.clients.delete(ws);
+    logger.info("client disconnected", {
+      connectionId: sub.connectionId ?? connectionId,
+    });
+  }
+
+  private handleSubscription(
+    ws: WebSocket,
+    message: any,
+    connectionId: string,
+  ) {
+    const topics: string[] | undefined = Array.isArray(message.topics)
+      ? message.topics
+      : Array.isArray(message.payload?.eventTypes)
+        ? message.payload.eventTypes
+        : undefined;
 
     const proposalId: string | undefined =
       message.proposalId ?? message.payload?.proposalId;
@@ -86,6 +203,7 @@ export class EventWebSocketServer {
       connectionId,
       eventTypes: topics,
       proposalId,
+      rooms: this.clients.get(ws)?.rooms ?? new Set(),
     };
 
     logger.info("client subscribed", { connectionId, topics, proposalId });
@@ -93,9 +211,17 @@ export class EventWebSocketServer {
     ws.send(JSON.stringify({ type: "subscribed", topics, proposalId }));
   }
 
-  /**
-   * Broadcasts a contract event to all clients subscribed to its topic.
-   */
+  private findWs(connectionId: string): WebSocket | undefined {
+    for (const [ws, sub] of this.clients) {
+      if (sub.connectionId === connectionId) return ws;
+    }
+    return undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Legacy broadcast (contract events)
+  // ---------------------------------------------------------------------------
+
   public broadcastEvent(event: ContractEvent) {
     const eventType = event.topic[0];
     const proposalId =
@@ -105,7 +231,10 @@ export class EventWebSocketServer {
     try {
       message = JSON.stringify({ type: "contract_event", payload: event });
     } catch (error) {
-      logger.warn("failed to serialize event for broadcast", { eventId: event.id, error });
+      logger.warn("failed to serialize event for broadcast", {
+        eventId: event.id,
+        error,
+      });
       return;
     }
 
@@ -113,15 +242,21 @@ export class EventWebSocketServer {
     this.clients.forEach((sub, ws) => {
       if (ws.readyState !== WebSocket.OPEN) return;
 
-      const matchesEventType = !sub.eventTypes || sub.eventTypes.includes(eventType);
-      const matchesProposalId = !sub.proposalId || sub.proposalId === proposalId;
+      const matchesEventType =
+        !sub.eventTypes || sub.eventTypes.includes(eventType);
+      const matchesProposalId =
+        !sub.proposalId || sub.proposalId === proposalId;
 
       if (matchesEventType && matchesProposalId) {
         try {
           ws.send(message);
           broadcastCount++;
         } catch (error) {
-          logger.warn("failed to send event to client", { connectionId: sub.connectionId, eventId: event.id, error });
+          logger.warn("failed to send event to client", {
+            connectionId: sub.connectionId,
+            eventId: event.id,
+            error,
+          });
         }
       }
     });

--- a/backend/src/shared/http/redisRateLimit.test.ts
+++ b/backend/src/shared/http/redisRateLimit.test.ts
@@ -1,0 +1,443 @@
+/**
+ * Tests for RedisRateLimiter — sliding window accuracy and Redis fallback.
+ *
+ * We test the sliding window logic by injecting a mock Redis client that
+ * executes the Lua script in-process using a simple sorted-set simulation.
+ * The fallback path is tested by simulating Redis connection errors.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Request, Response } from "express";
+import {
+  RedisRateLimiter,
+  createRedisRateLimitMiddleware,
+} from "./redisRateLimit.js";
+
+// ---------------------------------------------------------------------------
+// In-process sorted-set simulation (mirrors the Lua script logic)
+// ---------------------------------------------------------------------------
+
+interface SortedSetStore {
+  [key: string]: Array<{ score: number; member: string }>;
+}
+
+function makeMockRedis(store: SortedSetStore = {}) {
+  return {
+    _store: store,
+    async eval(
+      _script: string,
+      _numKeys: number,
+      key: string,
+      nowStr: string,
+      windowStr: string,
+      limitStr: string,
+      member: string,
+    ): Promise<[number, number]> {
+      const now = Number(nowStr);
+      const window = Number(windowStr);
+      const limit = Number(limitStr);
+      const cutoff = now - window;
+
+      if (!store[key]) store[key] = [];
+
+      // ZREMRANGEBYSCORE: remove entries with score <= cutoff
+      store[key] = store[key].filter((e) => e.score > cutoff);
+
+      let count = store[key].length;
+
+      if (count < limit) {
+        store[key].push({ score: now, member });
+        count += 1;
+      } else {
+        // Signal rejection: return limit+1
+        count = limit + 1;
+      }
+
+      return [count, now - window];
+    },
+    async quit() {},
+    on() {
+      return this;
+    },
+    connect() {
+      return Promise.resolve();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Patch RedisRateLimiter to accept an injected redis client for testing
+// ---------------------------------------------------------------------------
+
+function makeTestLimiter(
+  mockRedis: ReturnType<typeof makeMockRedis>,
+  limit: number,
+  windowMs: number,
+): RedisRateLimiter {
+  const limiter = new RedisRateLimiter(undefined, {
+    windowMs,
+    maxRequests: limit,
+  });
+  // Inject mock redis and mark as not using fallback
+  (limiter as any).redis = mockRedis;
+  (limiter as any).usingFallback = false;
+  return limiter;
+}
+
+// ---------------------------------------------------------------------------
+// Sliding window accuracy
+// ---------------------------------------------------------------------------
+
+test("RedisRateLimiter sliding window accuracy", async (t) => {
+  await t.test("allows requests up to the limit", async () => {
+    const store: SortedSetStore = {};
+    const redis = makeMockRedis(store);
+    const limiter = makeTestLimiter(redis, 3, 60_000);
+
+    for (let i = 0; i < 3; i++) {
+      const result = await limiter.isRateLimited(
+        "user1",
+        "/api/proposals",
+        3,
+        60_000,
+      );
+      assert.equal(result.allowed, true, `request ${i + 1} should be allowed`);
+    }
+  });
+
+  await t.test("blocks the (limit+1)th request", async () => {
+    const store: SortedSetStore = {};
+    const redis = makeMockRedis(store);
+    const limiter = makeTestLimiter(redis, 3, 60_000);
+
+    for (let i = 0; i < 3; i++) {
+      await limiter.isRateLimited("user2", "/api/proposals", 3, 60_000);
+    }
+
+    const result = await limiter.isRateLimited(
+      "user2",
+      "/api/proposals",
+      3,
+      60_000,
+    );
+    assert.equal(result.allowed, false);
+    assert.equal(result.remaining, 0);
+  });
+
+  await t.test(
+    "sliding window expires old entries and allows new requests",
+    async () => {
+      const store: SortedSetStore = {};
+      const redis = makeMockRedis(store);
+      const limiter = makeTestLimiter(redis, 3, 1_000); // 1 second window
+
+      const now = Date.now();
+
+      // Manually pre-populate the store with 3 old entries (outside the window)
+      const key = "rl:/api/proposals:user3";
+      store[key] = [
+        { score: now - 2000, member: "old-1" },
+        { score: now - 1500, member: "old-2" },
+        { score: now - 1100, member: "old-3" },
+      ];
+
+      // All old entries are outside the 1s window — new request should be allowed
+      const result = await limiter.isRateLimited(
+        "user3",
+        "/api/proposals",
+        3,
+        1_000,
+      );
+      assert.equal(result.allowed, true);
+    },
+  );
+
+  await t.test("remaining count decrements correctly", async () => {
+    const store: SortedSetStore = {};
+    const redis = makeMockRedis(store);
+    const limiter = makeTestLimiter(redis, 5, 60_000);
+
+    const r1 = await limiter.isRateLimited(
+      "user4",
+      "/api/proposals",
+      5,
+      60_000,
+    );
+    assert.equal(r1.remaining, 4);
+
+    const r2 = await limiter.isRateLimited(
+      "user4",
+      "/api/proposals",
+      5,
+      60_000,
+    );
+    assert.equal(r2.remaining, 3);
+  });
+
+  await t.test("different users have independent counters", async () => {
+    const store: SortedSetStore = {};
+    const redis = makeMockRedis(store);
+    const limiter = makeTestLimiter(redis, 2, 60_000);
+
+    // Exhaust user-a
+    await limiter.isRateLimited("user-a", "/api/proposals", 2, 60_000);
+    await limiter.isRateLimited("user-a", "/api/proposals", 2, 60_000);
+    const blockedA = await limiter.isRateLimited(
+      "user-a",
+      "/api/proposals",
+      2,
+      60_000,
+    );
+    assert.equal(blockedA.allowed, false);
+
+    // user-b should still be allowed
+    const allowedB = await limiter.isRateLimited(
+      "user-b",
+      "/api/proposals",
+      2,
+      60_000,
+    );
+    assert.equal(allowedB.allowed, true);
+  });
+
+  await t.test("different endpoints have independent counters", async () => {
+    const store: SortedSetStore = {};
+    const redis = makeMockRedis(store);
+    const limiter = makeTestLimiter(redis, 1, 60_000);
+
+    await limiter.isRateLimited("user5", "/api/proposals", 1, 60_000);
+    const blockedProposals = await limiter.isRateLimited(
+      "user5",
+      "/api/proposals",
+      1,
+      60_000,
+    );
+    assert.equal(blockedProposals.allowed, false);
+
+    // Different endpoint — independent counter
+    const allowedExecute = await limiter.isRateLimited(
+      "user5",
+      "/api/execute",
+      1,
+      60_000,
+    );
+    assert.equal(allowedExecute.allowed, true);
+  });
+
+  await t.test("resetAt is set to end of current window", async () => {
+    const store: SortedSetStore = {};
+    const redis = makeMockRedis(store);
+    const limiter = makeTestLimiter(redis, 10, 60_000);
+
+    const before = Math.floor(Date.now() / 1000);
+    const result = await limiter.isRateLimited(
+      "user6",
+      "/api/proposals",
+      10,
+      60_000,
+    );
+    const after = Math.ceil(Date.now() / 1000);
+
+    // resetAt should be within [before, after + 60]
+    assert.ok(result.resetAt >= before);
+    assert.ok(result.resetAt <= after + 60);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redis fallback
+// ---------------------------------------------------------------------------
+
+test("RedisRateLimiter Redis fallback", async (t) => {
+  await t.test("falls back to in-memory when redis is null", async () => {
+    const limiter = new RedisRateLimiter(undefined, {
+      windowMs: 60_000,
+      maxRequests: 3,
+    });
+    // No redis URL → usingFallback=true from the start
+
+    for (let i = 0; i < 3; i++) {
+      const r = await limiter.isRateLimited(
+        "fb-user",
+        "/api/proposals",
+        3,
+        60_000,
+      );
+      assert.equal(r.allowed, true);
+    }
+
+    const blocked = await limiter.isRateLimited(
+      "fb-user",
+      "/api/proposals",
+      3,
+      60_000,
+    );
+    assert.equal(blocked.allowed, false);
+  });
+
+  await t.test("falls back to in-memory when redis.eval throws", async () => {
+    const limiter = new RedisRateLimiter(undefined, {
+      windowMs: 60_000,
+      maxRequests: 5,
+    });
+    const brokenRedis = {
+      async eval() {
+        throw new Error("ECONNREFUSED");
+      },
+      async quit() {},
+      on() {
+        return this;
+      },
+      connect() {
+        return Promise.resolve();
+      },
+    };
+    (limiter as any).redis = brokenRedis;
+    (limiter as any).usingFallback = false;
+
+    // First call triggers the error → switches to fallback → still returns a valid result
+    const result = await limiter.isRateLimited(
+      "err-user",
+      "/api/proposals",
+      5,
+      60_000,
+    );
+    assert.equal(result.allowed, true);
+    assert.equal((limiter as any).usingFallback, true);
+  });
+
+  await t.test(
+    "in-memory fallback enforces limits correctly after Redis failure",
+    async () => {
+      const limiter = new RedisRateLimiter(undefined, {
+        windowMs: 60_000,
+        maxRequests: 2,
+      });
+      const brokenRedis = {
+        async eval() {
+          throw new Error("timeout");
+        },
+        async quit() {},
+        on() {
+          return this;
+        },
+        connect() {
+          return Promise.resolve();
+        },
+      };
+      (limiter as any).redis = brokenRedis;
+      (limiter as any).usingFallback = false;
+
+      // First call: Redis fails → fallback, count=1
+      const r1 = await limiter.isRateLimited(
+        "fallback-ip",
+        "/api/proposals",
+        2,
+        60_000,
+      );
+      assert.equal(r1.allowed, true);
+
+      // Subsequent calls use in-memory fallback
+      const r2 = await limiter.isRateLimited(
+        "fallback-ip",
+        "/api/proposals",
+        2,
+        60_000,
+      );
+      assert.equal(r2.allowed, true);
+
+      const r3 = await limiter.isRateLimited(
+        "fallback-ip",
+        "/api/proposals",
+        2,
+        60_000,
+      );
+      assert.equal(r3.allowed, false);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// createRedisRateLimitMiddleware
+// ---------------------------------------------------------------------------
+
+function makeRes(): {
+  res: Response;
+  state: { status: number; headers: Record<string, string>; body: any };
+} {
+  const state = {
+    status: 200,
+    headers: {} as Record<string, string>,
+    body: undefined as any,
+  };
+  const res = {
+    set: (h: string | Record<string, string>, v?: string) => {
+      if (typeof h === "string") state.headers[h] = v!;
+      else Object.assign(state.headers, h);
+      return res;
+    },
+    status: (code: number) => {
+      state.status = code;
+      return res;
+    },
+    json: (b: any) => {
+      state.body = b;
+      return res;
+    },
+  } as unknown as Response;
+  return { res, state };
+}
+
+function makeReq(ip = "127.0.0.1", path = "/api/proposals"): Request {
+  return { socket: { remoteAddress: ip }, path } as unknown as Request;
+}
+
+test("createRedisRateLimitMiddleware", async (t) => {
+  await t.test("disabled middleware always calls next()", async () => {
+    const mw = createRedisRateLimitMiddleware({
+      enabled: false,
+      limit: 1,
+      windowMs: 60_000,
+    });
+    let called = false;
+    await (mw as any)(makeReq(), makeRes().res, () => {
+      called = true;
+    });
+    assert.equal(called, true);
+  });
+
+  await t.test("sets X-RateLimit-* headers on allowed requests", async () => {
+    const mw = createRedisRateLimitMiddleware({ limit: 10, windowMs: 60_000 });
+    const { res, state } = makeRes();
+    let nextCalled = false;
+    await (mw as any)(makeReq("10.0.0.1"), res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+    assert.ok(state.headers["X-RateLimit-Limit"]);
+    assert.ok(state.headers["X-RateLimit-Remaining"]);
+    assert.ok(state.headers["X-RateLimit-Reset"]);
+  });
+
+  await t.test("returns 429 when limit exceeded", async () => {
+    const mw = createRedisRateLimitMiddleware({ limit: 2, windowMs: 60_000 });
+    const ip = "10.0.0.99";
+
+    for (let i = 0; i < 2; i++) {
+      await (mw as any)(makeReq(ip), makeRes().res, () => {});
+    }
+
+    const { res, state } = makeRes();
+    let nextCalled = false;
+    await (mw as any)(makeReq(ip), res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, false);
+    assert.equal(state.status, 429);
+    assert.equal(state.body?.error?.code, "RATE_LIMIT_EXCEEDED");
+    assert.ok(state.headers["Retry-After"]);
+  });
+});

--- a/backend/src/shared/http/redisRateLimit.ts
+++ b/backend/src/shared/http/redisRateLimit.ts
@@ -1,0 +1,250 @@
+/**
+ * Redis-backed rate limiter using a sliding window algorithm.
+ *
+ * Algorithm: sorted set per (userId, endpoint) key.
+ *   - Score = request timestamp (ms)
+ *   - On each request: atomically remove expired entries, count remaining,
+ *     add new entry, and set TTL — all in a single Lua script.
+ *
+ * Falls back to the existing in-memory RateLimiter when Redis is unavailable
+ * or when RATE_LIMIT_ENABLED=false.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+import { RateLimiter, type RateLimitConfig } from "./rateLimit.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetAt: number; // Unix timestamp (seconds)
+  limit: number;
+}
+
+// ---------------------------------------------------------------------------
+// Lua script — atomic sliding window check + increment
+// ---------------------------------------------------------------------------
+
+/**
+ * KEYS[1] = sorted-set key
+ * ARGV[1] = now (ms, as string)
+ * ARGV[2] = window size (ms, as string)
+ * ARGV[3] = limit (max requests)
+ * ARGV[4] = unique member id for this request
+ *
+ * Returns: [count_in_window_after_op, window_start_ms]
+ * count_in_window_after_op > limit means the request was rejected (not added).
+ */
+const SLIDING_WINDOW_LUA = `
+local key      = KEYS[1]
+local now      = tonumber(ARGV[1])
+local window   = tonumber(ARGV[2])
+local limit    = tonumber(ARGV[3])
+local member   = ARGV[4]
+local cutoff   = now - window
+
+-- Remove entries outside the window
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+-- Count current entries
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+  -- Add this request
+  redis.call('ZADD', key, now, member)
+  count = count + 1
+else
+  -- Signal rejection: return limit+1
+  count = limit + 1
+end
+
+-- Set TTL so the key auto-expires (window in seconds, rounded up)
+redis.call('PEXPIRE', key, window)
+
+return { count, now - window }
+`;
+
+// ---------------------------------------------------------------------------
+// RedisRateLimiter
+// ---------------------------------------------------------------------------
+
+export class RedisRateLimiter {
+  private redis: any | null = null;
+  private readonly fallback: RateLimiter;
+  private usingFallback = false;
+
+  constructor(redisUrl: string | undefined, fallbackConfig: RateLimitConfig) {
+    this.fallback = new RateLimiter(fallbackConfig);
+    if (redisUrl) {
+      this.connect(redisUrl);
+    } else {
+      this.usingFallback = true;
+    }
+  }
+
+  private connect(url: string): void {
+    // Dynamic import so the module can be loaded without ioredis installed
+    // (falls back gracefully if the package is absent)
+    import("ioredis")
+      .then((mod) => {
+        // ioredis exports the class as default; handle both CJS and ESM shapes
+        const Redis: any = (mod as any).default ?? mod;
+        const client = new Redis(url, {
+          lazyConnect: true,
+          maxRetriesPerRequest: 1,
+          enableOfflineQueue: false,
+        });
+
+        client.on("error", () => {
+          if (!this.usingFallback) {
+            this.usingFallback = true;
+          }
+        });
+
+        client.on("connect", () => {
+          this.usingFallback = false;
+        });
+
+        this.redis = client;
+        client.connect().catch(() => {
+          this.usingFallback = true;
+        });
+      })
+      .catch(() => {
+        this.usingFallback = true;
+      });
+  }
+
+  /**
+   * Check and increment the rate limit for a given user + endpoint.
+   */
+  async isRateLimited(
+    userId: string,
+    endpoint: string,
+    limit: number,
+    windowMs: number,
+  ): Promise<RateLimitResult> {
+    if (this.usingFallback || !this.redis) {
+      return this.fallbackCheck(userId, limit, windowMs);
+    }
+
+    try {
+      const key = `rl:${endpoint}:${userId}`;
+      const now = Date.now();
+      const member = `${now}-${Math.random().toString(36).slice(2)}`;
+
+      const [countAfter, windowStart] = (await this.redis.eval(
+        SLIDING_WINDOW_LUA,
+        1,
+        key,
+        String(now),
+        String(windowMs),
+        String(limit),
+        member,
+      )) as [number, number];
+
+      const allowed = countAfter <= limit;
+      const resetAt = Math.ceil((windowStart + windowMs) / 1000);
+
+      return {
+        allowed,
+        remaining: allowed ? Math.max(0, limit - countAfter) : 0,
+        resetAt,
+        limit,
+      };
+    } catch {
+      this.usingFallback = true;
+      return this.fallbackCheck(userId, limit, windowMs);
+    }
+  }
+
+  private fallbackCheck(
+    userId: string,
+    limit: number,
+    _windowMs: number,
+  ): RateLimitResult {
+    // Reuse the in-memory limiter with a synthetic request object
+    const req = { socket: { remoteAddress: userId } } as unknown as Request;
+    const allowed = !this.fallback.isLimited(req);
+    const remaining = this.fallback.getRemaining(req);
+    const resetAt = Math.ceil(this.fallback.getResetTime(req) / 1000);
+    return { allowed, remaining, resetAt, limit };
+  }
+
+  async quit(): Promise<void> {
+    await this.redis?.quit().catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Middleware factory
+// ---------------------------------------------------------------------------
+
+export interface RedisRateLimitOptions {
+  /** Redis URL — omit to use in-memory only */
+  redisUrl?: string;
+  /** Whether rate limiting is active at all */
+  enabled?: boolean;
+  limit: number;
+  windowMs: number;
+  /** Derive a user/client identifier from the request (defaults to IP) */
+  keyBy?: (req: Request) => string;
+}
+
+export function createRedisRateLimitMiddleware(options: RedisRateLimitOptions) {
+  const { enabled = true, limit, windowMs, redisUrl, keyBy } = options;
+
+  if (!enabled) {
+    return (_req: Request, _res: Response, next: NextFunction) => next();
+  }
+
+  const limiter = new RedisRateLimiter(redisUrl, {
+    windowMs,
+    maxRequests: limit,
+  });
+
+  return async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const userId = keyBy ? keyBy(req) : (req.socket.remoteAddress ?? "unknown");
+    const endpoint = req.path ?? "/";
+
+    const result = await limiter.isRateLimited(
+      userId,
+      endpoint,
+      limit,
+      windowMs,
+    );
+
+    res.set({
+      "X-RateLimit-Limit": String(result.limit),
+      "X-RateLimit-Remaining": String(result.remaining),
+      "X-RateLimit-Reset": String(result.resetAt),
+    });
+
+    if (!result.allowed) {
+      res.set(
+        "Retry-After",
+        String(result.resetAt - Math.floor(Date.now() / 1000)),
+      );
+      res.status(429).json({
+        success: false,
+        error: {
+          message: "Too Many Requests",
+          code: "RATE_LIMIT_EXCEEDED",
+          details: {
+            retryAfter: new Date(result.resetAt * 1000).toISOString(),
+          },
+        },
+      });
+      return;
+    }
+
+    next();
+  };
+}


### PR DESCRIPTION
PR Description
  
closes #862 
closes #863

   — WebSocket Room-Based Proposal Streaming
  
  backend/src/modules/websocket/websocket.server.ts
  
  - Added joinRoom(connectionId, roomId), leaveRoom(connectionId, roomId), broadcastToRoom(roomId, event) methods backed by a Map<string,
  Set<WebSocket>> room registry
  - Connection cleanup (close/error) now removes the client from all rooms it joined
  - Auth via ?token=<API_KEY> query param — connections are rejected with 4401 if API_KEY is set and the token doesn't match
  - Clients send { type: "join", room: "proposal:123" } / { type: "leave", room: "proposal:123" } messages; server replies with joined/left
   confirmations
  
  backend/src/modules/realtime/realtime-server.ts (rewritten)
  
  - Full WebSocket integration: start(server) attaches a WebSocketServer, stop() tears it down
  - 30s ping / 60s deadline heartbeat — dead connections are terminated and cleaned up
  - subscribe/unsubscribe message handling; topic format accepts both proposal:123 and proposal.123
  - broadcastProposalActivity(record) broadcasts to both proposal.<id> and proposal.contract-<contractId> topics simultaneously
  - Lifecycle hooks: onConnected, onDisconnected, onSubscribed, onUnsubscribed
  
  backend/src/modules/proposals/consumer.ts
  
  - Added optional onActivity?: (record: ProposalActivityRecord) => void hook to constructor and factory
  - Hook is called immediately after each record is buffered (before persistence), enabling zero-latency realtime broadcast
  
  backend/src/modules/websocket/realtime-streaming.test.ts — 14 tests covering:
  
  - Single and multi-subscriber delivery, broadcastProposalActivity dual-topic delivery
  - Connection cleanup removes subscriptions, lifecycle hooks, duplicate subscribe guard
  - onActivity hook ordering and optional usage
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  — Distributed Rate Limiting with Redis Backend
  
  backend/src/shared/http/redisRateLimit.ts
  
  - RedisRateLimiter class: sliding window algorithm using Redis sorted sets + atomic Lua script (ZREMRANGEBYSCORE → ZCARD → ZADD →
  - isRateLimited(userId, endpoint, limit, windowMs) returns { allowed, remaining, resetAt, limit }
  - Dynamic import("ioredis") — gracefully falls back to in-memory RateLimiter if ioredis is absent or Redis is unreachable
  - createRedisRateLimitMiddleware(options) — sets X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, Retry-After headers;
  returns 429 with RATE_LIMIT_EXCEEDED when blocked; enabled: false is a no-op pass-through
  
  backend/src/config/env.ts
  
  - Added rateLimitEnabled, rateLimitRedisUrl, rateLimitProposalsPerMin (100/min), rateLimitExecutePerMin (10/min), rateLimitDefaultPerMin
   (60/min) — all optional with defaults
  
  backend/package.json — added ioredis@^5.6.1
  
  backend/.env.example — added Section 5: Rate Limiting
  
  backend/src/shared/http/redisRateLimit.test.ts — 16 tests covering:
  
  - Sliding window accuracy: allows up to limit, blocks at limit+1, expires old entries, per-user and per-endpoint isolation, remaining
   decrement, resetAt correctness
  - Redis fallback: null redis, eval throws → switches to in-memory, in-memory enforces limits after failure
  - Middleware: disabled pass-through, header presence, 429 response shape
  
