### PR TITLE
fix: pass all 9 args to propose_transfer contract call

### DIFF
--- a/frontend/src/hooks/useVaultContract.ts
+++ b/frontend/src/hooks/useVaultContract.ts
@@ -21,6 +21,7 @@ import { withRetry } from '../utils/retryUtils';
 import type { VaultActivity, GetVaultEventsResult, VaultEventType } from '../types/activity';
 import type { SimulationResult } from '../utils/simulation';
 import type { Comment, ListMode } from '../types';
+import { Priority, ConditionLogic } from '../types';
 import type { TokenBalance } from '../types';
 import type { TokenInfo } from '../constants/tokens';
 import {
@@ -573,7 +574,16 @@ return { totalBalance: balance, totalProposals, pendingApprovals, readyToExecute
         };
     }, [address, getUserRole, readContractValue]);
 
-    const proposeTransfer = async (recipient: string, token: string, amount: string, memo: string) => {
+    const proposeTransfer = async (
+        recipient: string,
+        token: string,
+        amount: string,
+        memo: string,
+        priority: Priority = Priority.Normal,
+        conditions: xdr.ScVal[] = [],
+        conditionLogic: ConditionLogic = ConditionLogic.And,
+        insuranceAmount: bigint = 0n,
+    ) => {
         const _addr = assertReady();
         setLoading(true);
         try {
@@ -592,6 +602,10 @@ return { totalBalance: balance, totalProposals, pendingApprovals, readyToExecute
                                 new Address(token).toScVal(),
                                 nativeToScVal(BigInt(amount)),
                                 xdr.ScVal.scvSymbol(memo),
+                                nativeToScVal(priority, { type: "u32" }),
+                                xdr.ScVal.scvVec(conditions),
+                                nativeToScVal(conditionLogic, { type: "u32" }),
+                                nativeToScVal(insuranceAmount),
                             ],
                         })
                     ),
@@ -987,11 +1001,24 @@ interface GetEventsParams {
         }
     };
 
-    const simulateProposeTransfer = async (recipient: string, token: string, amount: string, memo: string): Promise<SimulationResult> => {
+    const simulateProposeTransfer = async (
+        recipient: string,
+        token: string,
+        amount: string,
+        memo: string,
+        priority: Priority = Priority.Normal,
+        conditions: xdr.ScVal[] = [],
+        conditionLogic: ConditionLogic = ConditionLogic.And,
+        insuranceAmount: bigint = 0n,
+    ): Promise<SimulationResult> => {
         if (!address) throw new Error("Wallet not connected");
         return simulateTransaction('propose_transfer', [
             new Address(address).toScVal(), new Address(recipient).toScVal(),
             new Address(token).toScVal(), nativeToScVal(BigInt(amount)), xdr.ScVal.scvSymbol(memo),
+            nativeToScVal(priority, { type: "u32" }),
+            xdr.ScVal.scvVec(conditions),
+            nativeToScVal(conditionLogic, { type: "u32" }),
+            nativeToScVal(insuranceAmount),
         ], { recipient, amount, memo });
     };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -31,6 +31,20 @@ export interface Comment {
 // List mode types
 export type ListMode = 'Disabled' | 'Whitelist' | 'Blacklist';
 
+// Proposal priority level — mirrors the contract's Priority enum (u32)
+export enum Priority {
+  Low = 0,
+  Normal = 1,
+  High = 2,
+  Critical = 3,
+}
+
+// Logic for combining multiple conditions — mirrors the contract's ConditionLogic enum (u32)
+export enum ConditionLogic {
+  And = 0,
+  Or = 1,
+}
+
 // Re-export activity types
 export type { VaultActivity, VaultEventType, VaultEventsFilters, GetVaultEventsResult } from './activity';
 export type { DashboardLayout, DashboardTemplate, WidgetConfig, WidgetType } from './dashboard';


### PR DESCRIPTION
closes #807
- Add Priority and ConditionLogic enums to frontend/src/types/index.ts matching the contract's u32 repr values
- Update proposeTransfer in useVaultContract.ts to accept optional priority, conditions, conditionLogic, insuranceAmount params with safe defaults (Normal, [], And, 0n)
- Encode new args as ScVal: priority/conditionLogic as u32, conditions as vec, insuranceAmount as i128
- Apply same fix to simulateProposeTransfer
- Existing callers (Templates.tsx, NewProposalModal) unchanged — they rely on the new optional defaults
