### PR TITLE
With this PR closes #979 closes #980: Event normalizers and LRU cache

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,6 +18,7 @@ import { createWebhookRouter } from "./modules/notifications/webhook.routes.js";
 import { createCacheRouter } from "./shared/cache/cache.routes.js";
 import { createVaultRouter } from "./modules/vault/vault.routes.js";
 import { createCursorsRouter } from "./modules/events/cursor/cursors.routes.js";
+import { createEventsRouter } from "./modules/events/events.routes.js";
 import { error } from "./shared/http/response.js";
 import { createRateLimitMiddleware } from "./shared/http/rateLimit.js";
 import { createAuthMiddleware, requireApiKey } from "./shared/http/auth.js";
@@ -150,6 +151,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   v1Router.use("/status", createStatusRouter(env, runtime));
   v1Router.use("/metrics", createMetricsRouter(runtime, adminAuthMiddleware));
   v1Router.use("/health", createDetailedHealthRouter(env, runtime));
+  v1Router.use("/events", authMiddleware, createEventsRouter());
 
   // Contracts listing
   const registry = new (
@@ -220,7 +222,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     v1Router.use(
       "/cache",
       authMiddleware,
-      createCacheRouter(runtime.cacheManager),
+      createCacheRouter(runtime.cacheManager, adminAuthMiddleware),
     );
   }
 

--- a/backend/src/modules/events/events.routes.ts
+++ b/backend/src/modules/events/events.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { EventNormalizer } from "./normalizers/index.js";
+import { success } from "../../shared/http/response.js";
+
+export function createEventsRouter() {
+  const router = Router();
+
+  router.get("/types", (_req, res) => {
+    success(res, EventNormalizer.registeredTypes());
+  });
+
+  return router;
+}

--- a/backend/src/modules/events/index.ts
+++ b/backend/src/modules/events/index.ts
@@ -1,5 +1,6 @@
 export * from "./events.types.js";
 export * from "./events.service.js";
+export * from "./events.routes.js";
 export * from "./types.js";
 export * from "./normalizers/index.js";
 export * from "./cursor/index.js";

--- a/backend/src/modules/events/normalizers/generic.normalizer.ts
+++ b/backend/src/modules/events/normalizers/generic.normalizer.ts
@@ -1,0 +1,26 @@
+import type { ContractEvent } from "../events.types.js";
+import type { GenericEventData, NormalizedEvent } from "../types.js";
+import type { EventType } from "../types.js";
+
+function meta(event: ContractEvent) {
+  return {
+    id: event.id,
+    contractId: event.contractId,
+    ledger: event.ledger,
+    ledgerClosedAt: event.ledgerClosedAt,
+  };
+}
+
+export class GenericEventNormalizer {
+  static normalize(event: ContractEvent, type: EventType): NormalizedEvent<GenericEventData> {
+    return {
+      type,
+      data: {
+        topic: String(event.topic[0] ?? ""),
+        topicArgs: event.topic.slice(1).map(String),
+        value: event.value,
+      },
+      metadata: meta(event),
+    };
+  }
+}

--- a/backend/src/modules/events/normalizers/index.ts
+++ b/backend/src/modules/events/normalizers/index.ts
@@ -9,6 +9,8 @@ import { InsuranceNormalizer } from "./insurance.normalizer.js";
 import { RecoveryNormalizer } from "./recovery.normalizer.js";
 import { SubscriptionNormalizer } from "./subscription.normalizer.js";
 import { MiscNormalizer } from "./misc.normalizer.js";
+import { GenericEventNormalizer } from "./generic.normalizer.js";
+import { UnknownEventNormalizer } from "./unknown.normalizer.js";
 import { SnapshotNormalizer } from "../../snapshots/normalizer.js";
 
 export class EventNormalizer {
@@ -121,6 +123,8 @@ export class EventNormalizer {
       // ── Recurring / streaming ───────────────────────────────────────────
       case EventType.STREAM_CREATED:
         return RecurringNormalizer.normalizeStreamCreated(event);
+      case EventType.STREAM_RATE_ADJUSTED:
+        return SubscriptionNormalizer.normalizeStreamRateAdjusted(event);
       case EventType.STREAM_STATUS:
         return SubscriptionNormalizer.normalizeStreamStatus(event);
       case EventType.STREAM_CLAIMED:
@@ -179,21 +183,17 @@ export class EventNormalizer {
         return EventNormalizer.unknown(event, "Unmapped topic");
 
       default:
-        return EventNormalizer.unknown(event, "Unhandled event type");
+        return GenericEventNormalizer.normalize(event, type);
     }
   }
 
   private static unknown(event: ContractEvent, reason: string): NormalizedEvent {
-    console.warn(`[event-normalizer] unknown event topic "${event.topic[0]}" — ${reason}`);
-    return {
-      type: EventType.UNKNOWN,
-      data: { rawTopic: event.topic, rawValue: event.value, reason },
-      metadata: {
-        id: event.id,
-        contractId: event.contractId,
-        ledger: event.ledger,
-        ledgerClosedAt: event.ledgerClosedAt,
-      },
-    };
+    return UnknownEventNormalizer.normalize(event, reason);
+  }
+
+  public static registeredTypes(): Array<{ topic: string; type: EventType }> {
+    return Object.entries(CONTRACT_EVENT_MAP)
+      .map(([topic, type]) => ({ topic, type }))
+      .sort((a, b) => a.topic.localeCompare(b.topic));
   }
 }

--- a/backend/src/modules/events/normalizers/misc.normalizer.ts
+++ b/backend/src/modules/events/normalizers/misc.normalizer.ts
@@ -226,39 +226,35 @@ export class MiscNormalizer {
   }
 
   static normalizeFundingRoundApproved(event: ContractEvent): NormalizedEvent<FundingRoundApprovedData> {
-    const d = event.value;
     return {
       type: EventType.FUNDING_ROUND_APPROVED,
       data: {
         roundId: id1(event),
-        proposalId: String(d[0] ?? ""),
-        approver: String(d[1] ?? ""),
+        proposalId: "",
+        approver: String(event.value ?? ""),
       },
       metadata: meta(event),
     };
   }
 
   static normalizeFundingRoundCancelled(event: ContractEvent): NormalizedEvent<FundingRoundCancelledData> {
-    const d = event.value;
     return {
       type: EventType.FUNDING_ROUND_CANCELLED,
       data: {
         roundId: id1(event),
-        cancelledBy: String(d[0] ?? ""),
-        reason: String(d[1] ?? ""),
+        cancelledBy: String(event.value ?? ""),
+        reason: "",
       },
       metadata: meta(event),
     };
   }
 
   static normalizeFundingRoundCompleted(event: ContractEvent): NormalizedEvent<FundingRoundCompletedData> {
-    const d = event.value;
     return {
       type: EventType.FUNDING_ROUND_COMPLETED,
       data: {
         roundId: id1(event),
-        recipient: String(d[0] ?? ""),
-        totalReleased: String(d[1] ?? "0"),
+        totalReleased: String(event.value ?? "0"),
       },
       metadata: meta(event),
     };

--- a/backend/src/modules/events/normalizers/normalizer.test.ts
+++ b/backend/src/modules/events/normalizers/normalizer.test.ts
@@ -168,55 +168,55 @@ describe("EventNormalizer", () => {
     test("should normalize recovery_proposed event", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
-        topic: ["recovery_proposed"],
-        value: ["new-owner-addr", "proposer-addr", "rec-prop-1"],
+        topic: ["recovery_proposed", "rec-prop-1"],
+        value: 3,
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
 
       assert.strictEqual(normalized.type, EventType.RECOVERY_PROPOSED);
-      assert.strictEqual(normalized.data.newOwner, "new-owner-addr");
-      assert.strictEqual(normalized.data.proposer, "proposer-addr");
       assert.strictEqual(normalized.data.proposalId, "rec-prop-1");
+      assert.strictEqual(normalized.data.newThreshold, 3);
     });
 
     test("should normalize recovery_approved event", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
-        topic: ["recovery_approved"],
-        value: ["new-owner-addr", "approver-addr", 2],
+        topic: ["recovery_approved", "rec-prop-2"],
+        value: "guardian-addr",
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
 
       assert.strictEqual(normalized.type, EventType.RECOVERY_APPROVED);
-      assert.strictEqual(normalized.data.approvalCount, 2);
+      assert.strictEqual(normalized.data.proposalId, "rec-prop-2");
+      assert.strictEqual(normalized.data.guardian, "guardian-addr");
     });
 
     test("should normalize recovery_executed event", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
-        topic: ["recovery_executed"],
-        value: ["old-owner-addr", "new-owner-addr", "executor-addr"],
+        topic: ["recovery_executed", "rec-prop-3"],
+        value: [],
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
 
       assert.strictEqual(normalized.type, EventType.RECOVERY_EXECUTED);
-      assert.strictEqual(normalized.data.oldOwner, "old-owner-addr");
-      assert.strictEqual(normalized.data.newOwner, "new-owner-addr");
+      assert.strictEqual(normalized.data.proposalId, "rec-prop-3");
     });
 
     test("should normalize recovery_cancelled event", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
-        topic: ["recovery_cancelled"],
-        value: ["new-owner-addr", "canceller-addr"],
+        topic: ["recovery_cancelled", "rec-prop-4"],
+        value: "canceller-addr",
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
 
       assert.strictEqual(normalized.type, EventType.RECOVERY_CANCELLED);
+      assert.strictEqual(normalized.data.proposalId, "rec-prop-4");
       assert.strictEqual(normalized.data.cancelledBy, "canceller-addr");
     });
   });
@@ -254,7 +254,7 @@ describe("EventNormalizer", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
         topic: ["subscription_created", "sub-1"],
-        value: ["subscriber-addr", "service-addr", "100", "USDC", 720],
+        value: ["subscriber-addr", 2, "100"],
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
@@ -262,7 +262,22 @@ describe("EventNormalizer", () => {
       assert.strictEqual(normalized.type, EventType.SUBSCRIPTION_CREATED);
       assert.strictEqual(normalized.data.subscriptionId, "sub-1");
       assert.strictEqual(normalized.data.subscriber, "subscriber-addr");
-      assert.strictEqual(normalized.data.intervalLedgers, 720);
+      assert.strictEqual(normalized.data.tier, 2);
+      assert.strictEqual(normalized.data.amount, "100");
+    });
+
+    test("should normalize subscription_renewed event", () => {
+      const rawEvent: ContractEvent = {
+        ...mockMetadata,
+        topic: ["subscription_renewed", "sub-1"],
+        value: [3, "100"],
+      };
+
+      const normalized = EventNormalizer.normalize(rawEvent);
+
+      assert.strictEqual(normalized.type, EventType.SUBSCRIPTION_RENEWED);
+      assert.strictEqual(normalized.data.paymentNumber, 3);
+      assert.strictEqual(normalized.data.amount, "100");
     });
 
     test("should normalize subscription_cancelled event", () => {
@@ -281,14 +296,14 @@ describe("EventNormalizer", () => {
     test("should normalize subscription_expired event", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
-        topic: ["subscription_expired", "sub-3"],
-        value: ["subscriber-addr"],
+        topic: ["subscription_expired"],
+        value: "sub-3",
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
 
       assert.strictEqual(normalized.type, EventType.SUBSCRIPTION_EXPIRED);
-      assert.strictEqual(normalized.data.subscriber, "subscriber-addr");
+      assert.strictEqual(normalized.data.subscriptionId, "sub-3");
     });
   });
 
@@ -376,28 +391,40 @@ describe("EventNormalizer", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
         topic: ["funding_round_approved", "round-1"],
-        value: ["prop-1", "approver-addr"],
+        value: "approver-addr",
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
 
       assert.strictEqual(normalized.type, EventType.FUNDING_ROUND_APPROVED);
       assert.strictEqual(normalized.data.roundId, "round-1");
-      assert.strictEqual(normalized.data.proposalId, "prop-1");
+      assert.strictEqual(normalized.data.approver, "approver-addr");
     });
 
     test("should normalize funding_round_completed event", () => {
       const rawEvent: ContractEvent = {
         ...mockMetadata,
         topic: ["funding_round_completed", "round-2"],
-        value: ["recipient-addr", "10000"],
+        value: "10000",
       };
 
       const normalized = EventNormalizer.normalize(rawEvent);
 
       assert.strictEqual(normalized.type, EventType.FUNDING_ROUND_COMPLETED);
-      assert.strictEqual(normalized.data.recipient, "recipient-addr");
       assert.strictEqual(normalized.data.totalReleased, "10000");
+    });
+
+    test("should normalize funding_round_cancelled event", () => {
+      const rawEvent: ContractEvent = {
+        ...mockMetadata,
+        topic: ["funding_round_cancelled", "round-3"],
+        value: "canceller-addr",
+      };
+
+      const normalized = EventNormalizer.normalize(rawEvent);
+
+      assert.strictEqual(normalized.type, EventType.FUNDING_ROUND_CANCELLED);
+      assert.strictEqual(normalized.data.cancelledBy, "canceller-addr");
     });
   });
 });

--- a/backend/src/modules/events/normalizers/recovery.normalizer.ts
+++ b/backend/src/modules/events/normalizers/recovery.normalizer.ts
@@ -8,6 +8,10 @@ import type {
 } from "../types.js";
 import { EventType } from "../types.js";
 
+function id1(event: ContractEvent): string {
+  return String(event.topic[1] ?? "0");
+}
+
 function meta(event: ContractEvent) {
   return {
     id: event.id,
@@ -19,13 +23,11 @@ function meta(event: ContractEvent) {
 
 export class RecoveryNormalizer {
   static normalizeRecoveryProposed(event: ContractEvent): NormalizedEvent<RecoveryProposedData> {
-    const d = event.value;
     return {
       type: EventType.RECOVERY_PROPOSED,
       data: {
-        newOwner: String(d[0] ?? ""),
-        proposer: String(d[1] ?? ""),
-        proposalId: String(d[2] ?? ""),
+        proposalId: id1(event),
+        newThreshold: Number(event.value ?? 0),
       },
       metadata: meta(event),
     };
@@ -36,22 +38,18 @@ export class RecoveryNormalizer {
     return {
       type: EventType.RECOVERY_APPROVED,
       data: {
-        newOwner: String(d[0] ?? ""),
-        approver: String(d[1] ?? ""),
-        approvalCount: Number(d[2] ?? 0),
+        proposalId: id1(event),
+        guardian: String(d ?? ""),
       },
       metadata: meta(event),
     };
   }
 
   static normalizeRecoveryExecuted(event: ContractEvent): NormalizedEvent<RecoveryExecutedData> {
-    const d = event.value;
     return {
       type: EventType.RECOVERY_EXECUTED,
       data: {
-        oldOwner: String(d[0] ?? ""),
-        newOwner: String(d[1] ?? ""),
-        executedBy: String(d[2] ?? ""),
+        proposalId: id1(event),
       },
       metadata: meta(event),
     };
@@ -62,8 +60,8 @@ export class RecoveryNormalizer {
     return {
       type: EventType.RECOVERY_CANCELLED,
       data: {
-        newOwner: String(d[0] ?? ""),
-        cancelledBy: String(d[1] ?? ""),
+        proposalId: id1(event),
+        cancelledBy: String(d ?? ""),
       },
       metadata: meta(event),
     };

--- a/backend/src/modules/events/normalizers/subscription.normalizer.ts
+++ b/backend/src/modules/events/normalizers/subscription.normalizer.ts
@@ -3,6 +3,7 @@ import type {
   NormalizedEvent,
   StreamStatusData,
   StreamClaimedData,
+  StreamRateAdjustedData,
   SubscriptionCreatedData,
   SubscriptionRenewedData,
   SubscriptionCancelledData,
@@ -25,6 +26,20 @@ function meta(event: ContractEvent) {
 }
 
 export class SubscriptionNormalizer {
+  static normalizeStreamRateAdjusted(event: ContractEvent): NormalizedEvent<StreamRateAdjustedData> {
+    const d = event.value;
+    return {
+      type: EventType.STREAM_RATE_ADJUSTED,
+      data: {
+        streamId: id1(event),
+        oldRate: String(d[0] ?? "0"),
+        newRate: String(d[1] ?? "0"),
+        adjustedBy: String(d[2] ?? ""),
+      },
+      metadata: meta(event),
+    };
+  }
+
   static normalizeStreamStatus(event: ContractEvent): NormalizedEvent<StreamStatusData> {
     const d = event.value;
     return {
@@ -58,10 +73,8 @@ export class SubscriptionNormalizer {
       data: {
         subscriptionId: id1(event),
         subscriber: String(d[0] ?? ""),
-        service: String(d[1] ?? ""),
+        tier: Number(d[1] ?? 0),
         amount: String(d[2] ?? "0"),
-        token: String(d[3] ?? ""),
-        intervalLedgers: Number(d[4] ?? 0),
       },
       metadata: meta(event),
     };
@@ -73,8 +86,8 @@ export class SubscriptionNormalizer {
       type: EventType.SUBSCRIPTION_RENEWED,
       data: {
         subscriptionId: id1(event),
-        subscriber: String(d[0] ?? ""),
-        renewedUntil: Number(d[1] ?? 0),
+        paymentNumber: Number(d[0] ?? 0),
+        amount: String(d[1] ?? "0"),
       },
       metadata: meta(event),
     };
@@ -111,8 +124,7 @@ export class SubscriptionNormalizer {
     return {
       type: EventType.SUBSCRIPTION_EXPIRED,
       data: {
-        subscriptionId: id1(event),
-        subscriber: String(d[0] ?? ""),
+        subscriptionId: String(event.topic[1] ?? d ?? "0"),
       },
       metadata: meta(event),
     };

--- a/backend/src/modules/events/normalizers/unknown.normalizer.ts
+++ b/backend/src/modules/events/normalizers/unknown.normalizer.ts
@@ -1,0 +1,23 @@
+import type { ContractEvent } from "../events.types.js";
+import type { NormalizedEvent } from "../types.js";
+import { EventType } from "../types.js";
+
+function meta(event: ContractEvent) {
+  return {
+    id: event.id,
+    contractId: event.contractId,
+    ledger: event.ledger,
+    ledgerClosedAt: event.ledgerClosedAt,
+  };
+}
+
+export class UnknownEventNormalizer {
+  static normalize(event: ContractEvent, reason: string): NormalizedEvent {
+    console.warn(`[event-normalizer] unknown event topic "${event.topic[0]}" - ${reason}`);
+    return {
+      type: EventType.UNKNOWN,
+      data: { rawTopic: event.topic, rawValue: event.value, reason },
+      metadata: meta(event),
+    };
+  }
+}

--- a/backend/src/modules/events/types.ts
+++ b/backend/src/modules/events/types.ts
@@ -22,7 +22,9 @@ export enum EventType {
   PROPOSAL_FROM_TEMPLATE = "PROPOSAL_FROM_TEMPLATE",
   SCHEDULED_PROPOSAL_CANCELLED = "SCHEDULED_PROPOSAL_CANCELLED",
   DELEGATED_VOTE = "DELEGATED_VOTE",
+  VOTE_CHANGED = "VOTE_CHANGED",
   VOTING_DEADLINE_EXTENDED = "VOTING_DEADLINE_EXTENDED",
+  THRESHOLD_REDUCED = "THRESHOLD_REDUCED",
   QUORUM_REACHED = "QUORUM_REACHED",
 
   // ── Role / admin ──────────────────────────────────────────────────────────
@@ -32,6 +34,14 @@ export enum EventType {
   SIGNER_REMOVED = "SIGNER_REMOVED",
   QUORUM_UPDATED = "QUORUM_UPDATED",
   ORACLE_CONFIG_UPDATED = "ORACLE_CONFIG_UPDATED",
+  ORACLE_PRICE_STALE = "ORACLE_PRICE_STALE",
+  RECOVERY_CONFIG_UPDATED = "RECOVERY_CONFIG_UPDATED",
+  INSURANCE_CONFIG_UPDATED = "INSURANCE_CONFIG_UPDATED",
+  GAS_CONFIG_UPDATED = "GAS_CONFIG_UPDATED",
+  DEX_CONFIG_UPDATED = "DEX_CONFIG_UPDATED",
+  CROSS_VAULT_CONFIG_SET = "CROSS_VAULT_CONFIG_SET",
+  BRIDGE_CONFIG_UPDATED = "BRIDGE_CONFIG_UPDATED",
+  REPUTATION_CONFIG_UPDATED = "REPUTATION_CONFIG_UPDATED",
 
   // ── Insurance / staking ───────────────────────────────────────────────────
   INSURANCE_LOCKED = "INSURANCE_LOCKED",
@@ -58,6 +68,7 @@ export enum EventType {
 
   // ── Recurring / streaming ─────────────────────────────────────────────────
   STREAM_CREATED = "STREAM_CREATED",
+  STREAM_RATE_ADJUSTED = "STREAM_RATE_ADJUSTED",
   STREAM_STATUS = "STREAM_STATUS",
   STREAM_CLAIMED = "STREAM_CLAIMED",
   SUBSCRIPTION_CREATED = "SUBSCRIPTION_CREATED",
@@ -75,6 +86,7 @@ export enum EventType {
   // ── Misc ──────────────────────────────────────────────────────────────────
   REPUTATION_UPDATED = "REPUTATION_UPDATED",
   BATCH_EXECUTED = "BATCH_EXECUTED",
+  BATCH_ROLLED_BACK = "BATCH_ROLLED_BACK",
   RETRY_SCHEDULED = "RETRY_SCHEDULED",
   RETRY_ATTEMPTED = "RETRY_ATTEMPTED",
   RETRIES_EXHAUSTED = "RETRIES_EXHAUSTED",
@@ -85,6 +97,36 @@ export enum EventType {
   GAS_LIMIT_EXCEEDED = "GAS_LIMIT_EXCEEDED",
   CROSS_VAULT_PROPOSED = "CROSS_VAULT_PROPOSED",
   CROSS_VAULT_EXECUTED = "CROSS_VAULT_EXECUTED",
+  NOTIFICATION_PREFS_UPDATED = "NOTIFICATION_PREFS_UPDATED",
+  COMMENT_ADDED = "COMMENT_ADDED",
+  COMMENT_EDITED = "COMMENT_EDITED",
+  COMMENT_DELETED = "COMMENT_DELETED",
+  HOOK_REGISTERED = "HOOK_REGISTERED",
+  HOOK_REMOVED = "HOOK_REMOVED",
+  HOOK_EXECUTED = "HOOK_EXECUTED",
+  LIQUIDITY_REMOVED = "LIQUIDITY_REMOVED",
+  LIQUIDITY_ADDED = "LIQUIDITY_ADDED",
+  LP_STAKED = "LP_STAKED",
+  LP_UNSTAKED = "LP_UNSTAKED",
+  REWARDS_CLAIMED = "REWARDS_CLAIMED",
+  EXECUTION_FEE_ESTIMATED = "EXECUTION_FEE_ESTIMATED",
+  EXECUTION_FEE_USED = "EXECUTION_FEE_USED",
+  METRICS_UPDATED = "METRICS_UPDATED",
+  METRICS_BUCKET_UPDATED = "METRICS_BUCKET_UPDATED",
+  TEMPLATE_CREATED = "TEMPLATE_CREATED",
+  TEMPLATE_UPDATED = "TEMPLATE_UPDATED",
+  TEMPLATE_VERSION_PRUNED = "TEMPLATE_VERSION_PRUNED",
+  TEMPLATE_STATUS_CHANGED = "TEMPLATE_STATUS_CHANGED",
+  FEE_STRUCTURE_UPDATED = "FEE_STRUCTURE_UPDATED",
+  FEE_COLLECTED = "FEE_COLLECTED",
+  SWAP_EXECUTED = "SWAP_EXECUTED",
+  PERMISSION_GRANTED = "PERMISSION_GRANTED",
+  PERMISSION_REVOKED = "PERMISSION_REVOKED",
+  PERMISSION_DELEGATED = "PERMISSION_DELEGATED",
+  DISPUTE_RAISED = "DISPUTE_RAISED",
+  DISPUTE_RESOLVED = "DISPUTE_RESOLVED",
+  BRIDGE_PROPOSED = "BRIDGE_PROPOSED",
+  BRIDGE_EXECUTED = "BRIDGE_EXECUTED",
 
   UNKNOWN = "UNKNOWN",
 }
@@ -335,7 +377,6 @@ export interface FundingRoundCancelledData {
 
 export interface FundingRoundCompletedData {
   readonly roundId: string;
-  readonly recipient: string;
   readonly totalReleased: string;
 }
 
@@ -362,21 +403,26 @@ export interface StreamClaimedData {
   readonly amount: string;
 }
 
+export interface StreamRateAdjustedData {
+  readonly streamId: string;
+  readonly oldRate: string;
+  readonly newRate: string;
+  readonly adjustedBy: string;
+}
+
 // ── Subscription data interfaces ──────────────────────────────────────────────
 
 export interface SubscriptionCreatedData {
   readonly subscriptionId: string;
   readonly subscriber: string;
-  readonly service: string;
+  readonly tier: number;
   readonly amount: string;
-  readonly token: string;
-  readonly intervalLedgers: number;
 }
 
 export interface SubscriptionRenewedData {
   readonly subscriptionId: string;
-  readonly subscriber: string;
-  readonly renewedUntil: number;
+  readonly paymentNumber: number;
+  readonly amount: string;
 }
 
 export interface SubscriptionCancelledData {
@@ -393,32 +439,33 @@ export interface SubscriptionUpgradedData {
 
 export interface SubscriptionExpiredData {
   readonly subscriptionId: string;
-  readonly subscriber: string;
 }
 
 // ── Recovery data interfaces ──────────────────────────────────────────────────
 
 export interface RecoveryProposedData {
-  readonly newOwner: string;
-  readonly proposer: string;
   readonly proposalId: string;
+  readonly newThreshold: number;
 }
 
 export interface RecoveryApprovedData {
-  readonly newOwner: string;
-  readonly approver: string;
-  readonly approvalCount: number;
+  readonly proposalId: string;
+  readonly guardian: string;
 }
 
 export interface RecoveryExecutedData {
-  readonly oldOwner: string;
-  readonly newOwner: string;
-  readonly executedBy: string;
+  readonly proposalId: string;
 }
 
 export interface RecoveryCancelledData {
-  readonly newOwner: string;
+  readonly proposalId: string;
   readonly cancelledBy: string;
+}
+
+export interface GenericEventData {
+  readonly topic: string;
+  readonly topicArgs: readonly string[];
+  readonly value: unknown;
 }
 
 // ── Misc data interfaces ──────────────────────────────────────────────────────
@@ -537,7 +584,9 @@ export const CONTRACT_EVENT_MAP: Record<string, EventType> = {
   proposal_from_template: EventType.PROPOSAL_FROM_TEMPLATE,
   scheduled_proposal_cancelled: EventType.SCHEDULED_PROPOSAL_CANCELLED,
   delegated_vote: EventType.DELEGATED_VOTE,
+  vote_changed: EventType.VOTE_CHANGED,
   voting_deadline_ext: EventType.VOTING_DEADLINE_EXTENDED,
+  threshold_reduced: EventType.THRESHOLD_REDUCED,
   quorum_reached: EventType.QUORUM_REACHED,
 
   // Role / admin
@@ -547,6 +596,14 @@ export const CONTRACT_EVENT_MAP: Record<string, EventType> = {
   signer_removed: EventType.SIGNER_REMOVED,
   quorum_updated: EventType.QUORUM_UPDATED,
   oracle_cfg_updated: EventType.ORACLE_CONFIG_UPDATED,
+  oracle_price_stale: EventType.ORACLE_PRICE_STALE,
+  recovery_config: EventType.RECOVERY_CONFIG_UPDATED,
+  insurance_cfg_updated: EventType.INSURANCE_CONFIG_UPDATED,
+  gas_cfg_updated: EventType.GAS_CONFIG_UPDATED,
+  dex_cfg_updated: EventType.DEX_CONFIG_UPDATED,
+  cv_config_set: EventType.CROSS_VAULT_CONFIG_SET,
+  bridge_cfg_updated: EventType.BRIDGE_CONFIG_UPDATED,
+  rep_config_updated: EventType.REPUTATION_CONFIG_UPDATED,
 
   // Insurance / staking
   insurance_locked: EventType.INSURANCE_LOCKED,
@@ -573,6 +630,7 @@ export const CONTRACT_EVENT_MAP: Record<string, EventType> = {
 
   // Recurring / streaming
   stream_created: EventType.STREAM_CREATED,
+  stream_rate_adj: EventType.STREAM_RATE_ADJUSTED,
   stream_status: EventType.STREAM_STATUS,
   stream_claimed: EventType.STREAM_CLAIMED,
   subscription_created: EventType.SUBSCRIPTION_CREATED,
@@ -590,6 +648,7 @@ export const CONTRACT_EVENT_MAP: Record<string, EventType> = {
   // Misc
   reputation_updated: EventType.REPUTATION_UPDATED,
   batch_executed: EventType.BATCH_EXECUTED,
+  batch_rolled_back: EventType.BATCH_ROLLED_BACK,
   retry_scheduled: EventType.RETRY_SCHEDULED,
   retry_attempted: EventType.RETRY_ATTEMPTED,
   retries_exhausted: EventType.RETRIES_EXHAUSTED,
@@ -600,4 +659,34 @@ export const CONTRACT_EVENT_MAP: Record<string, EventType> = {
   gas_limit_exceeded: EventType.GAS_LIMIT_EXCEEDED,
   cv_proposed: EventType.CROSS_VAULT_PROPOSED,
   cv_executed: EventType.CROSS_VAULT_EXECUTED,
+  notif_prefs_updated: EventType.NOTIFICATION_PREFS_UPDATED,
+  comment_added: EventType.COMMENT_ADDED,
+  comment_edited: EventType.COMMENT_EDITED,
+  comment_deleted: EventType.COMMENT_DELETED,
+  hook_registered: EventType.HOOK_REGISTERED,
+  hook_removed: EventType.HOOK_REMOVED,
+  hook_executed: EventType.HOOK_EXECUTED,
+  liquidity_removed: EventType.LIQUIDITY_REMOVED,
+  liquidity_added: EventType.LIQUIDITY_ADDED,
+  lp_staked: EventType.LP_STAKED,
+  lp_unstaked: EventType.LP_UNSTAKED,
+  rewards_claimed: EventType.REWARDS_CLAIMED,
+  exec_fee_estimated: EventType.EXECUTION_FEE_ESTIMATED,
+  exec_fee_used: EventType.EXECUTION_FEE_USED,
+  metrics_updated: EventType.METRICS_UPDATED,
+  metrics_bucket_upd: EventType.METRICS_BUCKET_UPDATED,
+  template_created: EventType.TEMPLATE_CREATED,
+  template_updated: EventType.TEMPLATE_UPDATED,
+  template_ver_pruned: EventType.TEMPLATE_VERSION_PRUNED,
+  template_status: EventType.TEMPLATE_STATUS_CHANGED,
+  fee_structure_updated: EventType.FEE_STRUCTURE_UPDATED,
+  fee_collected: EventType.FEE_COLLECTED,
+  swap_executed: EventType.SWAP_EXECUTED,
+  permission_granted: EventType.PERMISSION_GRANTED,
+  permission_revoked: EventType.PERMISSION_REVOKED,
+  permission_delegated: EventType.PERMISSION_DELEGATED,
+  dispute_raised: EventType.DISPUTE_RAISED,
+  dispute_resolved: EventType.DISPUTE_RESOLVED,
+  bridge_proposed: EventType.BRIDGE_PROPOSED,
+  bridge_executed: EventType.BRIDGE_EXECUTED,
 };

--- a/backend/src/modules/health/metrics.controller.ts
+++ b/backend/src/modules/health/metrics.controller.ts
@@ -17,6 +17,13 @@ export function getMetricsController(runtime: BackendRuntime): RequestHandler {
       (Date.now() - new Date(runtime.startedAt).getTime()) / 1000,
     );
     runtime.metricsRegistry.setGauge("vaultdao_uptime_seconds", uptimeSeconds);
+    if (runtime.cacheManager) {
+      const cacheStats = runtime.cacheManager.stats();
+      runtime.metricsRegistry.setGauge("vaultdao_cache_hits_total", cacheStats.hits);
+      runtime.metricsRegistry.setGauge("vaultdao_cache_misses_total", cacheStats.misses);
+      runtime.metricsRegistry.setGauge("vaultdao_cache_hit_rate", (cacheStats as any).hitRate ?? cacheStats.hitRatio);
+      runtime.metricsRegistry.setGauge("vaultdao_cache_miss_rate", (cacheStats as any).missRate ?? 0);
+    }
 
     const acceptsPlain = (_request.get("Accept") ?? "").includes("text/plain");
 
@@ -36,7 +43,7 @@ export function getMetricsController(runtime: BackendRuntime): RequestHandler {
         success: true,
         timestamp: new Date().toISOString(),
         uptimeSeconds,
-        // We could expose the raw registry values here if desired
+        cache: runtime.cacheManager?.stats(),
       });
   };
 }

--- a/backend/src/modules/recurring/recurring.controller.ts
+++ b/backend/src/modules/recurring/recurring.controller.ts
@@ -136,6 +136,7 @@ export function getDueWithLookaheadController(
   };
 }
 
+export function getDueRecurringController(
   service: RecurringIndexerService,
 ): RequestHandler {
   return async (request, response) => {

--- a/backend/src/modules/recurring/recurring.routes.ts
+++ b/backend/src/modules/recurring/recurring.routes.ts
@@ -4,7 +4,6 @@ import type { RecurringIndexerService } from "./recurring.service.js";
 import {
   getAllRecurringController,
   getRecurringByIdController,
-  getDueRecurringController,
   getDueWithLookaheadController,
   triggerSyncController,
 } from "./recurring.controller.js";

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -93,6 +93,26 @@ export async function startServer(
     "Total background job executions",
     "counter",
   );
+  metricsRegistry.register(
+    "vaultdao_cache_hits_total",
+    "Total cache hits",
+    "gauge",
+  );
+  metricsRegistry.register(
+    "vaultdao_cache_misses_total",
+    "Total cache misses",
+    "gauge",
+  );
+  metricsRegistry.register(
+    "vaultdao_cache_hit_rate",
+    "Cache hit rate as a ratio from 0 to 1",
+    "gauge",
+  );
+  metricsRegistry.register(
+    "vaultdao_cache_miss_rate",
+    "Cache miss rate as a ratio from 0 to 1",
+    "gauge",
+  );
 
   const jobManager = new JobManager(metricsRegistry);
 

--- a/backend/src/shared/cache/cache-manager.ts
+++ b/backend/src/shared/cache/cache-manager.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "../logging/logger.js";
 import type { CacheStats, TaggedCacheAdapter } from "./cache.adapter.js";
 import { InMemoryCacheAdapter } from "./cache.adapter.js";
+import { LRUCacheManager, type LRUCacheOptions } from "./lru-cache.manager.js";
 
 const logger = createLogger("cache-manager");
 
@@ -25,9 +26,21 @@ export class CacheManager {
   private readonly primary: TaggedCacheAdapter;
   private readonly fallback: InMemoryCacheAdapter<unknown>;
 
-  constructor(primary?: TaggedCacheAdapter) {
+  constructor(primary?: TaggedCacheAdapter, lruOptions?: LRUCacheOptions) {
     this.fallback = new InMemoryCacheAdapter();
-    this.primary = primary ?? (this.fallback as unknown as TaggedCacheAdapter);
+    this.primary = primary ?? new LRUCacheManager(lruOptions);
+  }
+
+  get<T>(key: string): T | null {
+    return this.primary.get(key) as T | null;
+  }
+
+  set<T>(key: string, value: T, ttlMs?: number): void {
+    (this.primary as TaggedCacheAdapter<T>).set(key, value, ttlMs);
+  }
+
+  invalidate(pattern: string): number {
+    return this.invalidatePattern(pattern);
   }
 
   // ── Cache-aside ─────────────────────────────────────────────────────────────
@@ -61,13 +74,15 @@ export class CacheManager {
     this.fallback.deleteByPrefix(tag);
   }
 
-  invalidatePattern(pattern: string): void {
+  invalidatePattern(pattern: string): number {
+    let deleted = 0;
     try {
-      this.primary.invalidatePattern(pattern);
+      deleted = this.primary.invalidatePattern(pattern);
     } catch (err) {
       logger.warn("pattern invalidation error", { pattern, error: String(err) });
     }
     this.fallback.deleteByPrefix(pattern.replace(/\*/g, ""));
+    return deleted;
   }
 
   // ── Event-driven invalidation hooks ─────────────────────────────────────────
@@ -92,7 +107,15 @@ export class CacheManager {
     };
   }
 
+  resetMetrics(): void {
+    this.primary.resetStats?.();
+    this.fallback.resetStats();
+  }
+
   destroy(): void {
+    if ("destroy" in this.primary && typeof this.primary.destroy === "function") {
+      this.primary.destroy();
+    }
     this.fallback.destroy();
   }
 }

--- a/backend/src/shared/cache/cache.routes.ts
+++ b/backend/src/shared/cache/cache.routes.ts
@@ -1,14 +1,33 @@
 import { Router } from "express";
+import type { RequestHandler } from "express";
 import type { CacheManager } from "./cache-manager.js";
 import { success } from "../http/response.js";
 
-export function createCacheRouter(cacheManager: CacheManager) {
+export function createCacheRouter(
+  cacheManager: CacheManager,
+  adminAuthMiddleware?: RequestHandler,
+) {
   const router = Router();
+
+  /** GET /api/v1/cache */
+  router.get("/", (_req, res) => {
+    success(res, cacheManager.stats());
+  });
 
   /** GET /api/v1/cache/stats */
   router.get("/stats", (_req, res) => {
     success(res, cacheManager.stats());
   });
+
+  /** POST /api/v1/cache/reset */
+  router.post(
+    "/reset",
+    ...(adminAuthMiddleware ? [adminAuthMiddleware] : []),
+    (_req, res) => {
+      cacheManager.resetMetrics();
+      success(res, cacheManager.stats());
+    },
+  );
 
   return router;
 }

--- a/backend/src/shared/cache/cache.test.ts
+++ b/backend/src/shared/cache/cache.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { LRUCacheManager } from "./lru-cache.manager.js";
+
+test("LRUCacheManager set/get", () => {
+  const cache = new LRUCacheManager<string>({ maxSize: 2, defaultTtlMs: 30_000 });
+
+  cache.set("a", "value-a");
+
+  assert.equal(cache.get("a"), "value-a");
+  assert.equal(cache.stats().hits, 1);
+  assert.equal(cache.stats().misses, 0);
+});
+
+test("LRUCacheManager TTL expiry", async () => {
+  const cache = new LRUCacheManager<string>({ maxSize: 2, defaultTtlMs: 30_000 });
+
+  cache.set("a", "value-a", 1);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.equal(cache.get("a"), null);
+  assert.equal(cache.stats().misses, 1);
+});
+
+test("LRUCacheManager evicts least recently used entry at maxSize", () => {
+  const cache = new LRUCacheManager<string>({ maxSize: 2, defaultTtlMs: 30_000 });
+
+  cache.set("a", "value-a");
+  cache.set("b", "value-b");
+  assert.equal(cache.get("a"), "value-a");
+  cache.set("c", "value-c");
+
+  assert.equal(cache.get("b"), null);
+  assert.equal(cache.get("a"), "value-a");
+  assert.equal(cache.get("c"), "value-c");
+});
+
+test("LRUCacheManager invalidates glob patterns", () => {
+  const cache = new LRUCacheManager<string>({ maxSize: 10, defaultTtlMs: 30_000 });
+
+  cache.set("proposals:1", "a");
+  cache.set("proposals:2", "b");
+  cache.set("vault:1", "c");
+
+  const deleted = cache.invalidatePattern("proposals:*");
+
+  assert.equal(deleted, 2);
+  assert.equal(cache.get("proposals:1"), null);
+  assert.equal(cache.get("proposals:2"), null);
+  assert.equal(cache.get("vault:1"), "c");
+});
+
+test("LRUCacheManager rejects values larger than 1MB", () => {
+  const cache = new LRUCacheManager<string>({ maxSize: 2 });
+  const tooLarge = "x".repeat(1024 * 1024 + 1);
+
+  assert.throws(() => cache.set("large", tooLarge), /1MB/);
+});

--- a/backend/src/shared/cache/index.ts
+++ b/backend/src/shared/cache/index.ts
@@ -1,4 +1,5 @@
 export * from "./cache.adapter.js";
+export * from "./lru-cache.manager.js";
 export * from "./redis-adapter.js";
 export * from "./cache-manager.js";
 export * from "./cache.routes.js";

--- a/backend/src/shared/cache/lru-cache.manager.ts
+++ b/backend/src/shared/cache/lru-cache.manager.ts
@@ -1,0 +1,226 @@
+import type { CacheStats, TaggedCacheAdapter } from "./cache.adapter.js";
+
+const DEFAULT_MAX_SIZE = 1_000;
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+const MAX_VALUE_BYTES = 1024 * 1024;
+
+interface LRUCacheEntry<T> {
+  readonly value: T;
+  readonly expiresAt: number | null;
+  readonly createdAt: number;
+  readonly tags: readonly string[];
+}
+
+export interface LRUCacheStats extends CacheStats {
+  readonly maxSize: number;
+  readonly hitRate: number;
+  readonly missRate: number;
+  readonly oldestEntry: string | null;
+}
+
+export interface LRUCacheOptions {
+  readonly maxSize?: number;
+  readonly defaultTtlMs?: number;
+}
+
+export class LRUCacheManager<T = unknown> implements TaggedCacheAdapter<T> {
+  private readonly maxSize: number;
+  private readonly defaultTtlMs: number;
+  private readonly entries = new Map<string, LRUCacheEntry<T>>();
+  private readonly tagIndex = new Map<string, Set<string>>();
+  private hits = 0;
+  private misses = 0;
+
+  constructor(options: LRUCacheOptions = {}) {
+    this.maxSize = Math.max(1, options.maxSize ?? DEFAULT_MAX_SIZE);
+    this.defaultTtlMs = Math.max(0, options.defaultTtlMs ?? DEFAULT_TTL_MS);
+  }
+
+  get(key: string): T | null {
+    const entry = this.entries.get(key);
+
+    if (!entry) {
+      this.misses++;
+      return null;
+    }
+
+    if (this.isExpired(entry)) {
+      this.delete(key);
+      this.misses++;
+      return null;
+    }
+
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    this.hits++;
+    return entry.value;
+  }
+
+  set(key: string, value: T, ttlMs?: number, tags: readonly string[] = []): void {
+    this.assertValueSize(value);
+
+    if (this.entries.has(key)) {
+      this.delete(key);
+    }
+
+    while (this.entries.size >= this.maxSize) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (oldestKey === undefined) break;
+      this.delete(oldestKey);
+    }
+
+    const effectiveTtlMs = ttlMs ?? this.defaultTtlMs;
+    const entry: LRUCacheEntry<T> = {
+      value,
+      expiresAt: effectiveTtlMs > 0 ? Date.now() + effectiveTtlMs : null,
+      createdAt: Date.now(),
+      tags,
+    };
+
+    this.entries.set(key, entry);
+    for (const tag of tags) {
+      let keys = this.tagIndex.get(tag);
+      if (!keys) {
+        keys = new Set();
+        this.tagIndex.set(tag, keys);
+      }
+      keys.add(key);
+    }
+  }
+
+  delete(key: string): void {
+    const entry = this.entries.get(key);
+    if (!entry) return;
+
+    this.entries.delete(key);
+    for (const tag of entry.tags) {
+      const keys = this.tagIndex.get(tag);
+      keys?.delete(key);
+      if (keys?.size === 0) {
+        this.tagIndex.delete(tag);
+      }
+    }
+  }
+
+  has(key: string): boolean {
+    return this.get(key) !== null;
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.tagIndex.clear();
+    this.resetStats();
+  }
+
+  countByPrefix(prefix: string): number {
+    this.pruneExpired();
+    let count = 0;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) count++;
+    }
+    return count;
+  }
+
+  deleteByPrefix(prefix: string): number {
+    let deleted = 0;
+    for (const key of [...this.entries.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.delete(key);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  async getOrSet(
+    key: string,
+    ttlMs: number,
+    fetchFn: () => Promise<T>,
+    tags: readonly string[] = [],
+  ): Promise<T> {
+    const cached = this.get(key);
+    if (cached !== null) return cached;
+
+    const value = await fetchFn();
+    this.set(key, value, ttlMs, tags);
+    return value;
+  }
+
+  invalidateByTag(tag: string): number {
+    const keys = this.tagIndex.get(tag);
+    if (!keys) return 0;
+
+    let deleted = 0;
+    for (const key of [...keys]) {
+      this.delete(key);
+      deleted++;
+    }
+    return deleted;
+  }
+
+  invalidatePattern(pattern: string): number {
+    const matcher = globToRegExp(pattern);
+    let deleted = 0;
+    for (const key of [...this.entries.keys()]) {
+      if (matcher.test(key)) {
+        this.delete(key);
+        deleted++;
+      }
+    }
+    return deleted;
+  }
+
+  stats(): LRUCacheStats {
+    this.pruneExpired();
+    const total = this.hits + this.misses;
+    const hitRate = total === 0 ? 0 : this.hits / total;
+    return {
+      size: this.entries.size,
+      maxSize: this.maxSize,
+      hits: this.hits,
+      misses: this.misses,
+      hitRatio: hitRate,
+      hitRate,
+      missRate: total === 0 ? 0 : this.misses / total,
+      oldestEntry: this.oldestEntry(),
+    };
+  }
+
+  resetStats(): void {
+    this.hits = 0;
+    this.misses = 0;
+  }
+
+  destroy(): void {
+    this.clear();
+  }
+
+  private oldestEntry(): string | null {
+    const first = this.entries.keys().next().value as string | undefined;
+    return first ?? null;
+  }
+
+  private pruneExpired(): void {
+    for (const [key, entry] of [...this.entries.entries()]) {
+      if (this.isExpired(entry)) {
+        this.delete(key);
+      }
+    }
+  }
+
+  private isExpired(entry: LRUCacheEntry<T>): boolean {
+    return entry.expiresAt !== null && Date.now() > entry.expiresAt;
+  }
+
+  private assertValueSize(value: T): void {
+    const bytes = Buffer.byteLength(JSON.stringify(value) ?? "null", "utf8");
+    if (bytes > MAX_VALUE_BYTES) {
+      throw new Error(`Cache value exceeds 1MB limit (${bytes} bytes)`);
+    }
+  }
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}


### PR DESCRIPTION
With this PR, closes #979.
Closes #980.

Summary:
- Registers all contract event topics from contracts/vault/src/events.rs and adds normalizers/routes for event type discovery.
- Adds UnknownEventNormalizer plus generic normalization for recognized low-level topics.
- Implements bounded LRU cache with TTL, glob invalidation, hit/miss stats, metrics exposure, and admin reset.

Tests:
- npm test -- src/shared/cache/cache.test.ts src/modules/events/normalizers/normalizer.test.ts
- npm test -- src/modules/events/normalizers/normalizer.property.test.ts

Note: npm run typecheck is still blocked by pre-existing unrelated TypeScript errors in audit, health, notifications, tracing, and several tests.