### PR TITLE
feat: PWA offline queue, stale-while-revalidate caching, and AuditLog chain verification

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,137 +1,133 @@
-const CACHE_NAME = 'vaultdao-v1';
-const RUNTIME_CACHE = 'vaultdao-runtime-v1';
-const OFFLINE_PAGE = '/offline.html';
+/**
+ * VaultDAO Service Worker (legacy registration path)
+ * Delegates to sw.js for full functionality.
+ * This file is kept for backwards compatibility with any existing registrations.
+ */
 
-const ASSETS_TO_CACHE = [
+// Re-export the same logic as sw.js by importing it.
+// Since this is a separate file, we implement the same strategies inline.
+
+const CACHE_VERSION = 'v2';
+const STATIC_CACHE = `vaultdao-static-${CACHE_VERSION}`;
+const API_CACHE = `vaultdao-api-${CACHE_VERSION}`;
+const ALL_CACHES = [STATIC_CACHE, API_CACHE];
+
+const PRECACHE_ASSETS = [
   '/',
   '/index.html',
-  '/vite.svg',
   '/manifest.json',
+  '/icons/icon-192x192.png',
+  '/icons/icon-512x512.png',
 ];
 
-// Install event - cache assets
+const CACHEABLE_API_PATTERNS = [
+  /\/api\/v1\/audit/,
+  /\/api\/v1\/proposals/,
+  /\/api\/v1\/transactions/,
+  /\/api\/v1\/vault/,
+  /\/api\/v1\/recurring/,
+];
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    Promise.all([
-      caches.open(CACHE_NAME).then((cache) => {
-        return cache.addAll(ASSETS_TO_CACHE).catch((error) => {
-          console.warn('Failed to cache assets:', error);
-        });
-      }),
-      // Pre-cache offline page
-      caches.open(RUNTIME_CACHE).then((cache) => {
-        return fetch(OFFLINE_PAGE)
-          .then((response) => cache.put(OFFLINE_PAGE, response))
-          .catch(() => console.warn('Offline page not available'));
-      }),
-    ])
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) => cache.addAll(PRECACHE_ASSETS).catch(() => {}))
+      .then(() => self.skipWaiting()),
   );
-  self.skipWaiting();
 });
 
-// Activate event - clean up old caches
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames.map((cacheName) => {
-          if (cacheName !== CACHE_NAME && cacheName !== RUNTIME_CACHE) {
-            return caches.delete(cacheName);
-          }
-        })
-      );
-    })
+    caches
+      .keys()
+      .then((names) =>
+        Promise.all(names.filter((n) => !ALL_CACHES.includes(n)).map((n) => caches.delete(n))),
+      )
+      .then(() => self.clients.claim()),
   );
-  self.clients.claim();
 });
 
-// Fetch event - network-first for API, cache-first for assets
 self.addEventListener('fetch', (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
-  // Skip non-GET requests
-  if (request.method !== 'GET') {
+  if (request.method !== 'GET') return;
+  if (!url.protocol.startsWith('http')) return;
+
+  const isApiRoute = CACHEABLE_API_PATTERNS.some((p) => p.test(url.pathname));
+  if (isApiRoute) {
+    event.respondWith(staleWhileRevalidate(request, API_CACHE));
     return;
   }
 
-  // Network-first strategy for API calls
-  if (url.pathname.includes('/api/')) {
+  if (request.mode === 'navigate') {
     event.respondWith(
-      fetch(request)
-        .then((response) => {
-          // Cache successful API responses
-          if (response && response.status === 200) {
-            const responseToCache = response.clone();
-            caches.open(RUNTIME_CACHE).then((cache) => {
-              cache.put(request, responseToCache);
-            });
-          }
-          return response;
-        })
-        .catch(() => {
-          // Return cached API response if network fails
-          return caches.match(request).then((response) => {
-            return response || new Response(
-              JSON.stringify({ error: 'Offline' }),
-              { status: 503, headers: { 'Content-Type': 'application/json' } }
-            );
-          });
-        })
+      caches
+        .match('/index.html')
+        .then((cached) => cached ?? fetch(request).catch(() => new Response('Offline', { status: 503 }))),
     );
     return;
   }
 
-  // Cache-first strategy for static assets
-  event.respondWith(
-    caches.match(request).then((response) => {
-      if (response) {
-        return response;
-      }
+  if (isStaticAsset(url.pathname)) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
+    return;
+  }
 
-      return fetch(request)
-        .then((response) => {
-          // Don't cache non-successful responses
-          if (!response || response.status !== 200 || response.type === 'error') {
-            return response;
-          }
-
-          // Clone the response
-          const responseToCache = response.clone();
-
-          // Cache successful responses for static assets
-          const isStaticAsset =
-            url.pathname.includes('.js') ||
-            url.pathname.includes('.css') ||
-            url.pathname.includes('.woff') ||
-            url.pathname.includes('.png') ||
-            url.pathname.includes('.svg') ||
-            url.pathname.includes('.jpg') ||
-            url.pathname.includes('.jpeg');
-
-          if (isStaticAsset) {
-            caches.open(CACHE_NAME).then((cache) => {
-              cache.put(request, responseToCache);
-            });
-          }
-
-          return response;
-        })
-        .catch(() => {
-          // Return offline page for navigation requests
-          if (request.mode === 'navigate') {
-            return caches.match(OFFLINE_PAGE);
-          }
-          // Return cached response if available
-          return caches.match(request);
-        });
-    })
-  );
+  event.respondWith(networkFirst(request, STATIC_CACHE));
 });
 
-// Handle messages from clients
-self.addEventListener('message', (event) => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
+async function staleWhileRevalidate(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  const networkPromise = fetch(request)
+    .then((response) => {
+      if (response && response.status === 200) cache.put(request, response.clone());
+      return response;
+    })
+    .catch(() => null);
+  return cached ?? (await networkPromise) ?? offlineApiResponse();
+}
+
+async function cacheFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  try {
+    const response = await fetch(request);
+    if (response && response.status === 200 && response.type !== 'error') {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return new Response('', { status: 503 });
   }
+}
+
+async function networkFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  try {
+    const response = await fetch(request);
+    if (response && response.status === 200) cache.put(request, response.clone());
+    return response;
+  } catch {
+    const cached = await cache.match(request);
+    return cached ?? new Response('', { status: 503 });
+  }
+}
+
+function offlineApiResponse() {
+  return new Response(JSON.stringify({ error: 'Offline', offline: true }), {
+    status: 503,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function isStaticAsset(pathname) {
+  return /\.(js|css|woff2?|ttf|eot|png|jpg|jpeg|svg|ico|webp|gif|avif)(\?.*)?$/.test(pathname);
+}
+
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'SKIP_WAITING') self.skipWaiting();
 });

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,8 +1,12 @@
-// Service Worker for VaultDAO PWA
-const CACHE_NAME = 'vaultdao-v1';
-const RUNTIME_CACHE = 'vaultdao-runtime-v1';
+// VaultDAO Service Worker — stale-while-revalidate + Background Sync
+// Version: 2.0.0
 
-// Assets to cache on install
+const CACHE_VERSION = 'v2';
+const STATIC_CACHE = `vaultdao-static-${CACHE_VERSION}`;
+const API_CACHE = `vaultdao-api-${CACHE_VERSION}`;
+const ALL_CACHES = [STATIC_CACHE, API_CACHE];
+
+// Assets to precache on install
 const PRECACHE_ASSETS = [
   '/',
   '/index.html',
@@ -11,140 +15,246 @@ const PRECACHE_ASSETS = [
   '/icons/icon-512x512.png',
 ];
 
-// Install event - cache essential assets
+// API routes to cache (stale-while-revalidate)
+const CACHEABLE_API_PATTERNS = [
+  /\/api\/v1\/audit/,
+  /\/api\/v1\/proposals/,
+  /\/api\/v1\/transactions/,
+  /\/api\/v1\/vault/,
+  /\/api\/v1\/recurring/,
+];
+
+// ─── Install ────────────────────────────────────────────────────────────────
 self.addEventListener('install', (event) => {
-  console.log('[SW] Installing service worker...');
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      console.log('[SW] Precaching assets');
-      return cache.addAll(PRECACHE_ASSETS);
-    })
+    caches
+      .open(STATIC_CACHE)
+      .then((cache) =>
+        cache.addAll(PRECACHE_ASSETS).catch((err) => {
+          console.warn('[SW] Precache partial failure:', err);
+        }),
+      )
+      .then(() => self.skipWaiting()),
   );
-  self.skipWaiting();
 });
 
-// Activate event - clean up old caches
+// ─── Activate ───────────────────────────────────────────────────────────────
 self.addEventListener('activate', (event) => {
-  console.log('[SW] Activating service worker...');
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
-        cacheNames
-          .filter((name) => name !== CACHE_NAME && name !== RUNTIME_CACHE)
-          .map((name) => {
-            console.log('[SW] Deleting old cache:', name);
-            return caches.delete(name);
-          })
-      );
-    })
+    caches
+      .keys()
+      .then((names) =>
+        Promise.all(
+          names
+            .filter((n) => !ALL_CACHES.includes(n))
+            .map((n) => caches.delete(n)),
+        ),
+      )
+      .then(() => self.clients.claim()),
   );
-  self.clients.claim();
 });
 
-// Fetch event - network first, fallback to cache
+// ─── Fetch ──────────────────────────────────────────────────────────────────
 self.addEventListener('fetch', (event) => {
   const { request } = event;
   const url = new URL(request.url);
 
-  // Skip cross-origin requests
-  if (url.origin !== location.origin) {
+  // Only handle same-origin GET requests (non-GET are handled by Background Sync)
+  if (request.method !== 'GET') return;
+
+  // Skip chrome-extension and non-http(s) schemes
+  if (!url.protocol.startsWith('http')) return;
+
+  // ── API routes: stale-while-revalidate ──────────────────────────────────
+  const isApiRoute = CACHEABLE_API_PATTERNS.some((p) => p.test(url.pathname));
+  if (isApiRoute) {
+    event.respondWith(staleWhileRevalidate(request, API_CACHE));
     return;
   }
 
-  // Skip API calls and blockchain requests
-  if (
-    url.pathname.startsWith('/api/') ||
-    url.hostname.includes('stellar.org') ||
-    url.hostname.includes('soroban')
-  ) {
+  // ── Navigation requests: serve app shell ────────────────────────────────
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      caches.match('/index.html').then(
+        (cached) => cached ?? fetch(request).catch(() => new Response('Offline', { status: 503 })),
+      ),
+    );
     return;
   }
 
-  event.respondWith(
-    caches.match(request).then((cachedResponse) => {
-      // Return cached response if available
-      if (cachedResponse) {
-        // Update cache in background
-        fetch(request)
-          .then((response) => {
-            if (response && response.status === 200) {
-              caches.open(RUNTIME_CACHE).then((cache) => {
-                cache.put(request, response.clone());
-              });
-            }
-          })
-          .catch(() => {
-            // Network error, use cached version
-          });
-        return cachedResponse;
+  // ── Static assets: cache-first, then network ────────────────────────────
+  if (isStaticAsset(url.pathname)) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
+    return;
+  }
+
+  // ── Everything else: network-first ──────────────────────────────────────
+  event.respondWith(networkFirst(request, STATIC_CACHE));
+});
+
+// ─── Strategies ─────────────────────────────────────────────────────────────
+
+/** Stale-while-revalidate: return cache immediately, update in background */
+async function staleWhileRevalidate(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+
+  const networkPromise = fetch(request)
+    .then((response) => {
+      if (response && response.status === 200) {
+        cache.put(request, response.clone());
       }
-
-      // Fetch from network
-      return fetch(request)
-        .then((response) => {
-          // Don't cache non-successful responses
-          if (!response || response.status !== 200 || response.type === 'error') {
-            return response;
-          }
-
-          // Cache successful responses
-          const responseToCache = response.clone();
-          caches.open(RUNTIME_CACHE).then((cache) => {
-            cache.put(request, responseToCache);
-          });
-
-          return response;
-        })
-        .catch(() => {
-          // Network error and no cache - return offline page
-          if (request.destination === 'document') {
-            return caches.match('/index.html');
-          }
-        });
+      return response;
     })
-  );
-});
+    .catch(() => null);
 
-// Background sync for offline actions
-self.addEventListener('sync', (event) => {
-  console.log('[SW] Background sync:', event.tag);
-  
-  if (event.tag === 'sync-proposals') {
-    event.waitUntil(syncProposals());
-  }
-});
+  return cached ?? (await networkPromise) ?? offlineApiResponse();
+}
 
-async function syncProposals() {
+/** Cache-first: return from cache, fall back to network and cache result */
+async function cacheFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
   try {
-    // Get pending proposals from IndexedDB
-    const db = await openDB();
-    const pendingProposals = await db.getAll('pending-proposals');
-    
-    // Sync each proposal
-    for (const proposal of pendingProposals) {
-      try {
-        const response = await fetch('/api/proposals', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(proposal),
-        });
-        
-        if (response.ok) {
-          await db.delete('pending-proposals', proposal.id);
-        }
-      } catch (error) {
-        console.error('[SW] Failed to sync proposal:', error);
-      }
+    const response = await fetch(request);
+    if (response && response.status === 200 && response.type !== 'error') {
+      cache.put(request, response.clone());
     }
-  } catch (error) {
-    console.error('[SW] Background sync failed:', error);
+    return response;
+  } catch {
+    return new Response('', { status: 503 });
   }
 }
 
-// Push notifications
+/** Network-first: try network, fall back to cache */
+async function networkFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  try {
+    const response = await fetch(request);
+    if (response && response.status === 200) {
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await cache.match(request);
+    return cached ?? new Response('', { status: 503 });
+  }
+}
+
+function offlineApiResponse() {
+  return new Response(JSON.stringify({ error: 'Offline', offline: true }), {
+    status: 503,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function isStaticAsset(pathname) {
+  return /\.(js|css|woff2?|ttf|eot|png|jpg|jpeg|svg|ico|webp|gif|avif)(\?.*)?$/.test(pathname);
+}
+
+// ─── Background Sync ─────────────────────────────────────────────────────────
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'vaultdao-offline-actions') {
+    event.waitUntil(replayOfflineActions());
+  }
+});
+
+async function replayOfflineActions() {
+  let db;
+  try {
+    db = await openDB();
+  } catch (err) {
+    console.error('[SW] Failed to open IndexedDB for sync:', err);
+    return;
+  }
+
+  const actions = await getAllActions(db);
+  if (actions.length === 0) return;
+
+  const results = [];
+  for (const action of actions) {
+    try {
+      const response = await fetch(action.url, {
+        method: action.method,
+        headers: action.headers,
+        body: action.body,
+      });
+
+      if (response.ok) {
+        await deleteAction(db, action.id);
+        results.push({ id: action.id, success: true, action });
+      } else {
+        const errText = await response.text().catch(() => `HTTP ${response.status}`);
+        results.push({ id: action.id, success: false, error: errText, action });
+      }
+    } catch (err) {
+      results.push({ id: action.id, success: false, error: String(err), action });
+    }
+  }
+
+  // Notify all open clients about replay results
+  const clients = await self.clients.matchAll({ type: 'window' });
+  for (const client of clients) {
+    client.postMessage({ type: 'SYNC_RESULTS', results });
+  }
+}
+
+// ─── Messages from clients ───────────────────────────────────────────────────
+self.addEventListener('message', (event) => {
+  if (!event.data) return;
+
+  switch (event.data.type) {
+    case 'SKIP_WAITING':
+      self.skipWaiting();
+      break;
+
+    case 'QUEUE_ACTION':
+      openDB()
+        .then((db) => putAction(db, event.data.action))
+        .then(() => {
+          // Attempt immediate Background Sync registration
+          if (self.registration.sync) {
+            return self.registration.sync.register('vaultdao-offline-actions');
+          }
+        })
+        .catch((err) => console.error('[SW] Failed to queue action:', err));
+      break;
+
+    case 'GET_QUEUE_COUNT':
+      openDB()
+        .then((db) => countActions(db))
+        .then((count) => {
+          event.source?.postMessage({ type: 'QUEUE_COUNT', count });
+        })
+        .catch(() => {
+          event.source?.postMessage({ type: 'QUEUE_COUNT', count: 0 });
+        });
+      break;
+
+    case 'CLEAR_CACHE':
+      Promise.all(ALL_CACHES.map((name) => caches.delete(name)))
+        .then(() => {
+          event.source?.postMessage({ type: 'CACHE_CLEARED' });
+        })
+        .catch((err) => console.error('[SW] Failed to clear cache:', err));
+      break;
+
+    case 'GET_CACHE_SIZE':
+      getCacheSize()
+        .then((size) => {
+          event.source?.postMessage({ type: 'CACHE_SIZE', size });
+        })
+        .catch(() => {
+          event.source?.postMessage({ type: 'CACHE_SIZE', size: 0 });
+        });
+      break;
+  }
+});
+
+// ─── Push Notifications ──────────────────────────────────────────────────────
 self.addEventListener('push', (event) => {
-  console.log('[SW] Push notification received');
-  
   const data = event.data ? event.data.json() : {};
   const title = data.title || 'VaultDAO';
   const options = {
@@ -158,48 +268,84 @@ self.addEventListener('push', (event) => {
       { action: 'dismiss', title: 'Dismiss' },
     ],
   };
-
   event.waitUntil(self.registration.showNotification(title, options));
 });
 
-// Notification click handler
 self.addEventListener('notificationclick', (event) => {
-  console.log('[SW] Notification clicked:', event.action);
-  
   event.notification.close();
-
   if (event.action === 'view') {
-    const urlToOpen = event.notification.data.url || '/dashboard';
+    const urlToOpen = event.notification.data?.url || '/dashboard';
     event.waitUntil(
       clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
-        // Check if there's already a window open
         for (const client of clientList) {
-          if (client.url === urlToOpen && 'focus' in client) {
-            return client.focus();
-          }
+          if (client.url === urlToOpen && 'focus' in client) return client.focus();
         }
-        // Open new window
-        if (clients.openWindow) {
-          return clients.openWindow(urlToOpen);
-        }
-      })
+        if (clients.openWindow) return clients.openWindow(urlToOpen);
+      }),
     );
   }
 });
 
-// Helper function to open IndexedDB
+// ─── IndexedDB helpers ───────────────────────────────────────────────────────
+const DB_NAME = 'vaultdao-offline-db';
+const DB_VERSION = 2;
+const STORE_ACTIONS = 'offline-actions';
+
 function openDB() {
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open('vaultdao-db', 1);
-    
-    request.onerror = () => reject(request.error);
-    request.onsuccess = () => resolve(request.result);
-    
-    request.onupgradeneeded = (event) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result);
+    req.onupgradeneeded = (event) => {
       const db = event.target.result;
-      if (!db.objectStoreNames.contains('pending-proposals')) {
-        db.createObjectStore('pending-proposals', { keyPath: 'id' });
+      if (!db.objectStoreNames.contains(STORE_ACTIONS)) {
+        const store = db.createObjectStore(STORE_ACTIONS, { keyPath: 'id' });
+        store.createIndex('timestamp', 'timestamp', { unique: false });
       }
     };
   });
+}
+
+function putAction(db, action) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_ACTIONS, 'readwrite');
+    const req = tx.objectStore(STORE_ACTIONS).put(action);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+function getAllActions(db) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_ACTIONS, 'readonly');
+    const req = tx.objectStore(STORE_ACTIONS).index('timestamp').getAll();
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+function deleteAction(db, id) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_ACTIONS, 'readwrite');
+    const req = tx.objectStore(STORE_ACTIONS).delete(id);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve();
+  });
+}
+
+function countActions(db) {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_ACTIONS, 'readonly');
+    const req = tx.objectStore(STORE_ACTIONS).count();
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+async function getCacheSize() {
+  if ('storage' in self && 'estimate' in self.storage) {
+    const estimate = await self.storage.estimate();
+    return estimate.usage || 0;
+  }
+  return 0;
 }

--- a/frontend/src/__tests__/auditLog.test.tsx
+++ b/frontend/src/__tests__/auditLog.test.tsx
@@ -1,0 +1,373 @@
+/**
+ * AuditLog component tests
+ *
+ * Tests:
+ * - Verify chain shows success banner
+ * - Broken chain highlights entry and shows error banner
+ * - CSV export triggers download
+ */
+
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockShowToast = vi.fn();
+const mockNotify = vi.fn();
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ showToast: mockShowToast, notify: mockNotify }),
+}));
+
+// Mock react-infinite-scroll-component to render children directly
+vi.mock('react-infinite-scroll-component', () => ({
+  default: ({ children, loader, endMessage }: {
+    children: React.ReactNode;
+    loader: React.ReactNode;
+    endMessage: React.ReactNode;
+    dataLength: number;
+    next: () => void;
+    hasMore: boolean;
+  }) => (
+    <div data-testid="infinite-scroll">
+      {children}
+      {endMessage}
+    </div>
+  ),
+}));
+
+// Mock pdfExport
+vi.mock('../utils/pdfExport', () => ({
+  exportAuditToPDF: vi.fn().mockResolvedValue(new Blob(['pdf'], { type: 'application/pdf' })),
+}));
+
+// Mock exportHistory
+vi.mock('../utils/exportHistory', () => ({
+  saveExportHistoryItem: vi.fn(),
+}));
+
+// ─── Sample data ─────────────────────────────────────────────────────────────
+
+const sampleEntries = [
+  {
+    id: 'entry-1',
+    action: 'proposal_created',
+    actor: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
+    target: 'GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
+    txHash: 'abc123',
+    timestamp: new Date(Date.now() - 60_000).toISOString(),
+    hash: 'hash1',
+    prev_hash: '0',
+  },
+  {
+    id: 'entry-2',
+    action: 'proposal_approved',
+    actor: 'GDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
+    txHash: 'def456',
+    timestamp: new Date(Date.now() - 30_000).toISOString(),
+    hash: 'hash2',
+    prev_hash: 'hash1',
+  },
+  {
+    id: 'entry-3',
+    action: 'proposal_executed',
+    actor: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
+    txHash: 'ghi789',
+    timestamp: new Date().toISOString(),
+    hash: 'hash3',
+    prev_hash: 'hash2',
+  },
+];
+
+// ─── Fetch mock helpers ───────────────────────────────────────────────────────
+
+function mockFetchAudit(entries = sampleEntries) {
+  return vi.fn().mockImplementation((url: string) => {
+    const urlStr = String(url);
+
+    if (urlStr.includes('/audit/verify')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ verified: true, brokenAtEntry: null }),
+      });
+    }
+
+    if (urlStr.includes('/audit/export')) {
+      return Promise.resolve({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['id,action\n1,proposal_created'], { type: 'text/csv' })),
+      });
+    }
+
+    if (urlStr.includes('/audit')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ entries }),
+      });
+    }
+
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+function mockFetchBrokenChain() {
+  return vi.fn().mockImplementation((url: string) => {
+    const urlStr = String(url);
+
+    if (urlStr.includes('/audit/verify')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ verified: false, brokenAtEntry: 1 }),
+      });
+    }
+
+    if (urlStr.includes('/audit')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ entries: sampleEntries }),
+      });
+    }
+
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+// ─── Import component (after mocks) ──────────────────────────────────────────
+
+import AuditLog from '../components/AuditLog';
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('AuditLog — chain verification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock URL.createObjectURL
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    global.URL.revokeObjectURL = vi.fn();
+    // Mock document.createElement for download link
+    const originalCreate = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') {
+        const el = originalCreate('a');
+        el.click = vi.fn();
+        return el;
+      }
+      return originalCreate(tag);
+    });
+  });
+
+  it('renders audit entries from API', async () => {
+    vi.stubGlobal('fetch', mockFetchAudit());
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('proposal_approved')).toBeInTheDocument();
+    expect(screen.getByText('proposal_executed')).toBeInTheDocument();
+  });
+
+  it('shows "Chain Verified ✓" banner when verification succeeds', async () => {
+    vi.stubGlobal('fetch', mockFetchAudit());
+
+    render(<AuditLog />);
+
+    // Wait for entries to load
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    // Click Verify Chain
+    const verifyBtn = screen.getByTestId('verify-chain-button');
+    await act(async () => {
+      await userEvent.click(verifyBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('verification-banner')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/chain verified/i)).toBeInTheDocument();
+    expect(screen.getByTestId('verification-banner')).toHaveTextContent('Chain Verified ✓');
+  });
+
+  it('shows "Chain Broken" banner and highlights broken entry', async () => {
+    vi.stubGlobal('fetch', mockFetchBrokenChain());
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    const verifyBtn = screen.getByTestId('verify-chain-button');
+    await act(async () => {
+      await userEvent.click(verifyBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('verification-banner')).toBeInTheDocument();
+    });
+
+    // Banner should show broken chain message
+    expect(screen.getByTestId('verification-banner')).toHaveTextContent('Chain Broken');
+    expect(screen.getByTestId('verification-banner')).toHaveTextContent('#1');
+
+    // The broken entry should be highlighted
+    await waitFor(() => {
+      const brokenEntries = screen.getAllByTestId('broken-entry');
+      expect(brokenEntries.length).toBeGreaterThan(0);
+    });
+
+    // Chain break tooltip should appear at the break point
+    expect(screen.getByTestId('chain-break-tooltip')).toBeInTheDocument();
+  });
+
+  it('shows spinner during verification', async () => {
+    let resolveVerify: (value: unknown) => void;
+    const verifyPromise = new Promise((resolve) => {
+      resolveVerify = resolve;
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (String(url).includes('/audit/verify')) {
+          return verifyPromise.then(() => ({
+            ok: true,
+            json: () => Promise.resolve({ verified: true, brokenAtEntry: null }),
+          }));
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ entries: sampleEntries }),
+        });
+      }),
+    );
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    const verifyBtn = screen.getByTestId('verify-chain-button');
+    await act(async () => {
+      await userEvent.click(verifyBtn);
+    });
+
+    // Should show "Verifying…" text while in progress
+    expect(screen.getByText(/verifying/i)).toBeInTheDocument();
+
+    // Resolve the verification
+    await act(async () => {
+      resolveVerify!({});
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/verifying/i)).toBeNull();
+    });
+  });
+});
+
+describe('AuditLog — CSV export', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('triggers CSV download when Export button is clicked', async () => {
+    vi.stubGlobal('fetch', mockFetchAudit());
+
+    const clickSpy = vi.fn();
+    const originalCreate = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') {
+        const el = originalCreate('a');
+        el.click = clickSpy;
+        return el;
+      }
+      return originalCreate(tag);
+    });
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    // The export button shows entry count
+    const exportBtn = screen.getByTestId('export-button');
+    expect(exportBtn).toHaveTextContent('Export 3');
+
+    await act(async () => {
+      await userEvent.click(exportBtn);
+    });
+
+    await waitFor(() => {
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    expect(global.URL.createObjectURL).toHaveBeenCalled();
+    expect(global.URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('shows success toast after export', async () => {
+    vi.stubGlobal('fetch', mockFetchAudit());
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    const exportBtn = screen.getByTestId('export-button');
+    await act(async () => {
+      await userEvent.click(exportBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockNotify).toHaveBeenCalledWith(
+        'export_success',
+        expect.stringContaining('Exported'),
+        'success',
+      );
+    });
+  });
+
+  it('shows actor address with copy button', async () => {
+    vi.stubGlobal('fetch', mockFetchAudit());
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    // Actor should be truncated
+    expect(screen.getByText('GABC12…90AB')).toBeInTheDocument();
+
+    // Copy button should be present
+    const copyButtons = screen.getAllByTitle(/copy full address/i);
+    expect(copyButtons.length).toBeGreaterThan(0);
+  });
+
+  it('shows relative timestamp with absolute on hover', async () => {
+    vi.stubGlobal('fetch', mockFetchAudit());
+
+    render(<AuditLog />);
+
+    await waitFor(() => {
+      expect(screen.getByText('proposal_created')).toBeInTheDocument();
+    });
+
+    // Relative time should be shown (e.g. "1m ago")
+    const timeElements = screen.getAllByTitle(/\d{1,2}\/\d{1,2}\/\d{4}/);
+    expect(timeElements.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/__tests__/pwa.test.tsx
+++ b/frontend/src/__tests__/pwa.test.tsx
@@ -1,0 +1,408 @@
+/**
+ * PWA offline support tests
+ *
+ * Tests:
+ * - Offline banner appears when navigator.onLine === false
+ * - Action is queued when offline
+ * - Queued actions are replayed on reconnect
+ */
+
+import React from 'react';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// ─── Mock IndexedDB ──────────────────────────────────────────────────────────
+
+const mockStore: Record<string, unknown> = {};
+
+const mockIDB = {
+  open: vi.fn(),
+};
+
+// Minimal IDBDatabase mock
+function createMockDB() {
+  const store = new Map<string, unknown>();
+
+  const makeRequest = <T>(result: T) => {
+    const req = {
+      result,
+      error: null,
+      onsuccess: null as ((e: Event) => void) | null,
+      onerror: null as ((e: Event) => void) | null,
+    };
+    setTimeout(() => req.onsuccess?.({ target: req } as unknown as Event), 0);
+    return req;
+  };
+
+  const objectStore = {
+    put: (record: unknown) => {
+      const r = record as { id: string };
+      store.set(r.id, record);
+      return makeRequest(r.id);
+    },
+    delete: (id: string) => {
+      store.delete(id);
+      return makeRequest(undefined);
+    },
+    count: () => makeRequest(store.size),
+    clear: () => {
+      store.clear();
+      return makeRequest(undefined);
+    },
+    index: (_name: string) => ({
+      getAll: () => makeRequest(Array.from(store.values())),
+    }),
+  };
+
+  const transaction = {
+    objectStore: () => objectStore,
+  };
+
+  return {
+    transaction: () => transaction,
+    objectStoreNames: { contains: () => true },
+    createObjectStore: () => objectStore,
+    _store: store,
+  };
+}
+
+const mockDB = createMockDB();
+
+// Patch global indexedDB
+const openRequest = {
+  result: mockDB,
+  error: null,
+  onsuccess: null as ((e: Event) => void) | null,
+  onerror: null as ((e: Event) => void) | null,
+  onupgradeneeded: null as ((e: Event) => void) | null,
+};
+
+vi.stubGlobal('indexedDB', {
+  open: vi.fn(() => {
+    setTimeout(() => openRequest.onsuccess?.({ target: openRequest } as unknown as Event), 0);
+    return openRequest;
+  }),
+});
+
+// ─── Mock navigator.onLine ───────────────────────────────────────────────────
+
+let onlineStatus = true;
+
+Object.defineProperty(navigator, 'onLine', {
+  get: () => onlineStatus,
+  configurable: true,
+});
+
+// ─── Mock pwa utils ──────────────────────────────────────────────────────────
+
+vi.mock('../utils/pwa', () => ({
+  isOnline: () => onlineStatus,
+  setupNetworkListeners: (onOnline: () => void, onOffline: () => void) => {
+    window.addEventListener('online', onOnline);
+    window.addEventListener('offline', onOffline);
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('offline', onOffline);
+    };
+  },
+  isInstalled: () => false,
+  canInstall: () => false,
+  showInstallPrompt: vi.fn(),
+  requestNotificationPermission: vi.fn(),
+  clearCache: vi.fn(),
+  getCacheSize: vi.fn().mockResolvedValue(1024 * 512),
+}));
+
+// ─── Mock offlineQueue ───────────────────────────────────────────────────────
+
+const queueStore: import('../utils/offlineQueue').OfflineAction[] = [];
+
+vi.mock('../utils/offlineQueue', () => ({
+  enqueueOfflineAction: vi.fn(async (walletAddress, actionType, parameters) => {
+    const id = `${actionType}-${Date.now()}`;
+    queueStore.push({
+      id,
+      walletAddress,
+      actionType,
+      parameters,
+      timestamp: new Date().toISOString(),
+      attempts: 0,
+    });
+    return id;
+  }),
+  getQueuedActions: vi.fn(async () => [...queueStore]),
+  getQueuedActionCount: vi.fn(async () => queueStore.length),
+  removeQueuedAction: vi.fn(async (id: string) => {
+    const idx = queueStore.findIndex((a) => a.id === id);
+    if (idx !== -1) queueStore.splice(idx, 1);
+  }),
+  updateActionAttempt: vi.fn(async (id: string, lastError?: string) => {
+    const action = queueStore.find((a) => a.id === id);
+    if (action) {
+      action.attempts += 1;
+      action.lastError = lastError;
+    }
+  }),
+  clearOfflineQueue: vi.fn(async () => queueStore.splice(0)),
+}));
+
+// ─── Mock ToastContext ───────────────────────────────────────────────────────
+
+const mockShowToast = vi.fn();
+const mockNotify = vi.fn();
+
+vi.mock('../hooks/useToast', () => ({
+  useToast: () => ({ showToast: mockShowToast, notify: mockNotify }),
+}));
+
+// ─── Imports (after mocks) ───────────────────────────────────────────────────
+
+import { OfflineIndicator } from '../components/OfflineIndicator';
+import { enqueueOfflineAction, getQueuedActionCount } from '../utils/offlineQueue';
+import { useOfflineSync } from '../hooks/useOfflineSync';
+
+// ─── Helper: render with ToastProvider stub ──────────────────────────────────
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(ui);
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('OfflineIndicator', () => {
+  beforeEach(() => {
+    onlineStatus = true;
+    queueStore.splice(0);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    onlineStatus = true;
+  });
+
+  it('renders nothing when online with no queued actions', () => {
+    renderWithProviders(<OfflineIndicator />);
+    expect(screen.queryByTestId('offline-indicator')).toBeNull();
+  });
+
+  it('shows offline banner when navigator.onLine is false', async () => {
+    onlineStatus = false;
+
+    renderWithProviders(<OfflineIndicator />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
+  });
+
+  it('shows queued count badge when offline with queued actions', async () => {
+    onlineStatus = false;
+
+    // Pre-populate queue
+    await enqueueOfflineAction('GTEST', 'approve_proposal', { proposalId: 1 });
+    await enqueueOfflineAction('GTEST', 'execute_proposal', { proposalId: 2 });
+
+    renderWithProviders(<OfflineIndicator />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('queued-count-badge')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('queued-count-badge')).toHaveTextContent('2 queued');
+  });
+
+  it('shows "Back online" banner after reconnect', async () => {
+    onlineStatus = false;
+    renderWithProviders(<OfflineIndicator />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('offline-indicator')).toBeInTheDocument();
+    });
+
+    // Simulate coming back online
+    onlineStatus = true;
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/back online/i)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('enqueueOfflineAction', () => {
+  beforeEach(() => {
+    queueStore.splice(0);
+    vi.clearAllMocks();
+  });
+
+  it('queues an action with wallet address, action type, parameters, and timestamp', async () => {
+    const walletAddress = 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB';
+    const actionType = 'approve_proposal' as const;
+    const parameters = { proposalId: 42 };
+
+    const id = await enqueueOfflineAction(walletAddress, actionType, parameters);
+
+    expect(id).toBeTruthy();
+    expect(id).toContain('approve_proposal');
+
+    const count = await getQueuedActionCount();
+    expect(count).toBe(1);
+
+    const actions = queueStore;
+    expect(actions[0]).toMatchObject({
+      walletAddress,
+      actionType,
+      parameters,
+    });
+    expect(actions[0].timestamp).toBeTruthy();
+    expect(new Date(actions[0].timestamp).getTime()).toBeGreaterThan(0);
+  });
+
+  it('queues multiple actions in order', async () => {
+    await enqueueOfflineAction('GTEST', 'approve_proposal', { proposalId: 1 });
+    await enqueueOfflineAction('GTEST', 'execute_proposal', { proposalId: 2 });
+    await enqueueOfflineAction('GTEST', 'reject_proposal', { proposalId: 3 });
+
+    const count = await getQueuedActionCount();
+    expect(count).toBe(3);
+  });
+});
+
+describe('useOfflineSync — replay on reconnect', () => {
+  beforeEach(() => {
+    queueStore.splice(0);
+    onlineStatus = true;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    onlineStatus = true;
+  });
+
+  it('calls executeAction for each queued action on reconnect', async () => {
+    // Pre-populate queue
+    queueStore.push({
+      id: 'approve_proposal-1',
+      walletAddress: 'GTEST',
+      actionType: 'approve_proposal',
+      parameters: { proposalId: 1 },
+      timestamp: new Date().toISOString(),
+      attempts: 0,
+    });
+    queueStore.push({
+      id: 'execute_proposal-2',
+      walletAddress: 'GTEST',
+      actionType: 'execute_proposal',
+      parameters: { proposalId: 2 },
+      timestamp: new Date().toISOString(),
+      attempts: 0,
+    });
+
+    const executeAction = vi.fn().mockResolvedValue('tx-hash');
+
+    function TestComponent() {
+      const { queuedCount, isReplaying } = useOfflineSync(executeAction);
+      return (
+        <div>
+          <span data-testid="count">{queuedCount}</span>
+          <span data-testid="replaying">{isReplaying ? 'yes' : 'no'}</span>
+        </div>
+      );
+    }
+
+    renderWithProviders(<TestComponent />);
+
+    // Simulate going offline then online
+    onlineStatus = false;
+    await act(async () => {
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    onlineStatus = true;
+    await act(async () => {
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await waitFor(() => {
+      expect(executeAction).toHaveBeenCalledTimes(2);
+    });
+
+    expect(executeAction).toHaveBeenCalledWith('approve_proposal', { proposalId: 1 });
+    expect(executeAction).toHaveBeenCalledWith('execute_proposal', { proposalId: 2 });
+  });
+
+  it('shows success toast for each replayed action', async () => {
+    queueStore.push({
+      id: 'approve_proposal-1',
+      walletAddress: 'GTEST',
+      actionType: 'approve_proposal',
+      parameters: { proposalId: 5 },
+      timestamp: new Date().toISOString(),
+      attempts: 0,
+    });
+
+    const executeAction = vi.fn().mockResolvedValue('tx-hash');
+
+    function TestComponent() {
+      useOfflineSync(executeAction);
+      return null;
+    }
+
+    renderWithProviders(<TestComponent />);
+
+    onlineStatus = false;
+    await act(async () => window.dispatchEvent(new Event('offline')));
+
+    onlineStatus = true;
+    await act(async () => window.dispatchEvent(new Event('online')));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.stringContaining('Replayed'),
+        'success',
+      );
+    });
+  });
+
+  it('shows error toast and keeps action in queue when replay fails', async () => {
+    queueStore.push({
+      id: 'execute_proposal-99',
+      walletAddress: 'GTEST',
+      actionType: 'execute_proposal',
+      parameters: { proposalId: 99 },
+      timestamp: new Date().toISOString(),
+      attempts: 0,
+    });
+
+    const executeAction = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    function TestComponent() {
+      useOfflineSync(executeAction);
+      return null;
+    }
+
+    renderWithProviders(<TestComponent />);
+
+    onlineStatus = false;
+    await act(async () => window.dispatchEvent(new Event('offline')));
+
+    onlineStatus = true;
+    await act(async () => window.dispatchEvent(new Event('online')));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to replay'),
+        'error',
+      );
+    });
+
+    // Action should remain in queue
+    expect(queueStore).toHaveLength(1);
+    expect(queueStore[0].lastError).toBe('Network error');
+  });
+});

--- a/frontend/src/components/AuditExporter.tsx
+++ b/frontend/src/components/AuditExporter.tsx
@@ -6,12 +6,17 @@ import { exportAuditToPDF } from '../utils/pdfExport';
 import { env } from '../config/env';
 import type { BackendAuditEntry } from './AuditLog';
 
+const API_BASE =
+  (import.meta.env as Record<string, string | undefined>).VITE_API_BASE_URL ??
+  'http://localhost:3000';
+
 interface AuditExporterProps {
   entries: BackendAuditEntry[];
 }
 
 type ExportFormat = 'CSV' | 'PDF';
 
+/** Build a CSV blob client-side from the provided entries (fallback). */
 function buildCSV(entries: BackendAuditEntry[]): Blob {
   const headers = ['Timestamp', 'Action', 'Actor', 'Target', 'TxHash', 'Details'];
   const rows = entries.map((e) => [
@@ -22,7 +27,9 @@ function buildCSV(entries: BackendAuditEntry[]): Blob {
     e.txHash ?? '',
     JSON.stringify(e.details ?? {}),
   ]);
-  const csv = [headers, ...rows].map((r) => r.map((c) => `"${c}"`).join(',')).join('\n');
+  const csv = [headers, ...rows]
+    .map((r) => r.map((c) => `"${String(c).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
   return new Blob([csv], { type: 'text/csv' });
 }
 
@@ -38,16 +45,34 @@ const AuditExporter: React.FC<AuditExporterProps> = ({ entries }) => {
     }
     setBusy(true);
     try {
-      let blob: Blob;
       const timestamp = new Date().toISOString().split('T')[0];
       const filename = `audit_export_${timestamp}.${format.toLowerCase()}`;
+      let blob: Blob;
 
       if (format === 'CSV') {
-        blob = buildCSV(entries);
+        // Prefer the backend CSV endpoint (includes hash verification column)
+        try {
+          const params = new URLSearchParams({
+            contractId: env.contractId,
+            offset: '0',
+            limit: String(Math.max(entries.length, 50)),
+          });
+          const res = await fetch(`${API_BASE}/api/v1/audit/export?${params.toString()}`);
+          if (res.ok) {
+            blob = await res.blob();
+          } else {
+            // Fallback to client-side CSV
+            blob = buildCSV(entries);
+          }
+        } catch {
+          // Network unavailable — build CSV client-side
+          blob = buildCSV(entries);
+        }
       } else {
         blob = await exportAuditToPDF(entries, env.contractId);
       }
 
+      // Trigger download using Blob + URL.createObjectURL
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
@@ -74,7 +99,7 @@ const AuditExporter: React.FC<AuditExporterProps> = ({ entries }) => {
   };
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex items-center gap-3" data-testid="audit-exporter">
       {/* Format toggle */}
       <div className="flex rounded-lg overflow-hidden border border-gray-700">
         {(['CSV', 'PDF'] as ExportFormat[]).map((f) => (
@@ -82,10 +107,18 @@ const AuditExporter: React.FC<AuditExporterProps> = ({ entries }) => {
             key={f}
             onClick={() => setFormat(f)}
             className={`flex items-center gap-1.5 px-3 py-2 text-sm transition-colors ${
-              format === f ? 'bg-purple-600 text-white' : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+              format === f
+                ? 'bg-purple-600 text-white'
+                : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
             }`}
+            aria-pressed={format === f}
+            aria-label={`Export as ${f}`}
           >
-            {f === 'CSV' ? <Database size={14} /> : <FileText size={14} />}
+            {f === 'CSV' ? (
+              <Database size={14} aria-hidden="true" />
+            ) : (
+              <FileText size={14} aria-hidden="true" />
+            )}
             {f}
           </button>
         ))}
@@ -95,8 +128,10 @@ const AuditExporter: React.FC<AuditExporterProps> = ({ entries }) => {
         onClick={() => void handleExport()}
         disabled={busy || entries.length === 0}
         className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-700 disabled:text-gray-500 rounded-lg text-sm transition-colors"
+        aria-label={busy ? 'Exporting…' : `Export ${entries.length} audit entries as ${format}`}
+        data-testid="export-button"
       >
-        <Download size={14} />
+        <Download size={14} aria-hidden="true" />
         {busy ? 'Exporting…' : `Export ${entries.length}`}
       </button>
     </div>

--- a/frontend/src/components/AuditLog.tsx
+++ b/frontend/src/components/AuditLog.tsx
@@ -1,15 +1,43 @@
-import React, { useState, useCallback, useEffect } from 'react';
-import { Copy, ExternalLink, ChevronDown } from 'lucide-react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import {
+  Copy,
+  ExternalLink,
+  ShieldCheck,
+  ShieldAlert,
+  Loader2,
+  UserPlus,
+  UserMinus,
+  CheckCircle2,
+  XCircle,
+  PlayCircle,
+  PlusCircle,
+  Settings,
+  Key,
+  Zap,
+  AlertTriangle,
+} from 'lucide-react';
 import { useToast } from '../hooks/useToast';
 import { env } from '../config/env';
+import AuditExporter from './AuditExporter';
 
-const API_BASE = ((import.meta.env as Record<string, string | undefined>).VITE_API_BASE_URL) ?? 'http://localhost:3000';
-const PAGE_SIZE = 20;
+const API_BASE =
+  (import.meta.env as Record<string, string | undefined>).VITE_API_BASE_URL ??
+  'http://localhost:3000';
+const PAGE_SIZE = 50;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
 
 export type AuditAction =
-  | 'proposal_created' | 'proposal_approved' | 'proposal_executed'
-  | 'proposal_rejected' | 'signer_added' | 'signer_removed'
-  | 'config_updated' | 'role_assigned' | 'initialized';
+  | 'proposal_created'
+  | 'proposal_approved'
+  | 'proposal_executed'
+  | 'proposal_rejected'
+  | 'signer_added'
+  | 'signer_removed'
+  | 'config_updated'
+  | 'role_assigned'
+  | 'initialized';
 
 export interface BackendAuditEntry {
   id: string;
@@ -19,57 +47,131 @@ export interface BackendAuditEntry {
   txHash?: string;
   timestamp: string;
   details?: Record<string, unknown>;
+  hash?: string;
+  prev_hash?: string;
 }
+
+interface VerificationResult {
+  verified: boolean;
+  brokenAtEntry: number | null;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function truncate(addr: string): string {
   if (addr.length <= 14) return addr;
   return `${addr.slice(0, 6)}…${addr.slice(-6)}`;
 }
 
+function relativeTime(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  if (diff < 60_000) return 'just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  if (diff < 2_592_000_000) return `${Math.floor(diff / 86_400_000)}d ago`;
+  return new Date(isoString).toLocaleDateString();
+}
+
+function ActionIcon({ action }: { action: string }) {
+  const cls = 'w-4 h-4 flex-shrink-0';
+  switch (action) {
+    case 'proposal_created':
+      return <PlusCircle className={`${cls} text-blue-400`} aria-hidden="true" />;
+    case 'proposal_approved':
+      return <CheckCircle2 className={`${cls} text-green-400`} aria-hidden="true" />;
+    case 'proposal_executed':
+      return <PlayCircle className={`${cls} text-purple-400`} aria-hidden="true" />;
+    case 'proposal_rejected':
+      return <XCircle className={`${cls} text-red-400`} aria-hidden="true" />;
+    case 'signer_added':
+      return <UserPlus className={`${cls} text-teal-400`} aria-hidden="true" />;
+    case 'signer_removed':
+      return <UserMinus className={`${cls} text-orange-400`} aria-hidden="true" />;
+    case 'config_updated':
+      return <Settings className={`${cls} text-gray-400`} aria-hidden="true" />;
+    case 'role_assigned':
+      return <Key className={`${cls} text-yellow-400`} aria-hidden="true" />;
+    case 'initialized':
+      return <Zap className={`${cls} text-indigo-400`} aria-hidden="true" />;
+    default:
+      return <AlertTriangle className={`${cls} text-gray-500`} aria-hidden="true" />;
+  }
+}
+
 const ALL_ACTIONS: (AuditAction | string)[] = [
-  'proposal_created', 'proposal_approved', 'proposal_executed',
-  'proposal_rejected', 'signer_added', 'signer_removed',
-  'config_updated', 'role_assigned', 'initialized',
+  'proposal_created',
+  'proposal_approved',
+  'proposal_executed',
+  'proposal_rejected',
+  'signer_added',
+  'signer_removed',
+  'config_updated',
+  'role_assigned',
+  'initialized',
 ];
+
+// ─── Component ───────────────────────────────────────────────────────────────
 
 const AuditLog: React.FC = () => {
   const { notify, showToast } = useToast();
+
   const [entries, setEntries] = useState<BackendAuditEntry[]>([]);
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(false);
   const [actionFilter, setActionFilter] = useState<string>('');
 
-  const fetchPage = useCallback(async (nextOffset: number, filter: string, replace: boolean) => {
-    setLoading(true);
-    try {
-      const params = new URLSearchParams({
-        contractId: env.contractId,
-        offset: String(nextOffset),
-        limit: String(PAGE_SIZE),
-      });
-      if (filter) params.set('action', filter);
+  // Verification state
+  const [verifying, setVerifying] = useState(false);
+  const [verificationResult, setVerificationResult] = useState<VerificationResult | null>(null);
+  const [verificationError, setVerificationError] = useState<string | null>(null);
 
-      const res = await fetch(`${API_BASE}/api/v1/audit?${params.toString()}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = await res.json() as { entries: BackendAuditEntry[]; total?: number };
-      const fetched = data.entries ?? [];
+  // Track broken entry index for highlighting
+  const brokenEntryRef = useRef<number | null>(null);
 
-      setEntries((prev) => replace ? fetched : [...prev, ...fetched]);
-      setOffset(nextOffset + fetched.length);
-      setHasMore(fetched.length === PAGE_SIZE);
-    } catch (e) {
-      notify('audit_error', e instanceof Error ? e.message : 'Failed to load audit log', 'error');
-    } finally {
-      setLoading(false);
-    }
-  }, [notify]);
+  const fetchPage = useCallback(
+    async (nextOffset: number, filter: string, replace: boolean) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({
+          contractId: env.contractId,
+          offset: String(nextOffset),
+          limit: String(PAGE_SIZE),
+        });
+        if (filter) params.set('action', filter);
+
+        const res = await fetch(`${API_BASE}/api/v1/audit?${params.toString()}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { entries?: BackendAuditEntry[]; data?: BackendAuditEntry[]; total?: number };
+        const fetched = data.entries ?? data.data ?? [];
+
+        setEntries((prev) => (replace ? fetched : [...prev, ...fetched]));
+        setOffset(nextOffset + fetched.length);
+        setHasMore(fetched.length === PAGE_SIZE);
+      } catch (e) {
+        notify('audit_error', e instanceof Error ? e.message : 'Failed to load audit log', 'error');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [notify],
+  );
 
   // Initial load
   useEffect(() => {
     void fetchPage(0, actionFilter, true);
+    // Reset verification when filter changes
+    setVerificationResult(null);
+    setVerificationError(null);
+    brokenEntryRef.current = null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [actionFilter]);
+
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore) {
+      void fetchPage(offset, actionFilter, false);
+    }
+  }, [loading, hasMore, offset, actionFilter, fetchPage]);
 
   const handleFilterChange = (action: string) => {
     setActionFilter(action);
@@ -82,112 +184,305 @@ const AuditLog: React.FC = () => {
     showToast('Address copied', 'success');
   };
 
+  // ── Chain Verification ────────────────────────────────────────────────────
+
+  const handleVerifyChain = useCallback(async () => {
+    setVerifying(true);
+    setVerificationResult(null);
+    setVerificationError(null);
+    brokenEntryRef.current = null;
+
+    try {
+      const params = new URLSearchParams({
+        contractId: env.contractId,
+        offset: '0',
+        limit: String(Math.max(entries.length, PAGE_SIZE)),
+      });
+
+      const res = await fetch(`${API_BASE}/api/v1/audit/verify?${params.toString()}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = (await res.json()) as { data?: VerificationResult } | VerificationResult;
+
+      // Handle both wrapped and unwrapped response shapes
+      const result: VerificationResult =
+        'data' in data && data.data ? data.data : (data as VerificationResult);
+
+      setVerificationResult(result);
+      brokenEntryRef.current = result.brokenAtEntry;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Verification failed';
+      setVerificationError(msg);
+      notify('audit_verify_error', msg, 'error');
+    } finally {
+      setVerifying(false);
+    }
+  }, [entries.length, notify]);
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  const isBrokenEntry = (index: number) =>
+    verificationResult !== null &&
+    !verificationResult.verified &&
+    verificationResult.brokenAtEntry !== null &&
+    index >= verificationResult.brokenAtEntry;
+
   return (
     <div className="space-y-4">
-      {/* Action filter */}
-      <div className="flex flex-wrap gap-2">
-        <button
-          onClick={() => handleFilterChange('')}
-          className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
-            actionFilter === '' ? 'bg-purple-600 text-white' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-          }`}
-        >
-          All
-        </button>
-        {ALL_ACTIONS.map((a) => (
+      {/* Toolbar: filter + verify + export */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {/* Action filter */}
+        <div className="flex flex-wrap gap-2">
           <button
-            key={a}
-            onClick={() => handleFilterChange(a)}
+            onClick={() => handleFilterChange('')}
             className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
-              actionFilter === a ? 'bg-purple-600 text-white' : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              actionFilter === ''
+                ? 'bg-purple-600 text-white'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
             }`}
           >
-            {a}
+            All
           </button>
-        ))}
-      </div>
-
-      {/* Table */}
-      <div className="bg-gray-800/50 rounded-xl border border-gray-700 overflow-hidden">
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-800 border-b border-gray-700">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">ID</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Action</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Actor</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Target</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Timestamp</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">Tx</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-700">
-              {entries.length === 0 && !loading ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-gray-400">No audit entries found.</td>
-                </tr>
-              ) : (
-                entries.map((entry) => (
-                  <tr key={entry.id} className="hover:bg-gray-700/30 transition-colors">
-                    <td className="px-4 py-3 text-gray-500 text-xs">{entry.id.slice(0, 12)}…</td>
-                    <td className="px-4 py-3">
-                      <span className="px-2 py-1 bg-purple-500/20 text-purple-300 rounded text-xs font-medium">
-                        {entry.action}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-1">
-                        <code className="text-xs text-gray-300">{truncate(entry.actor)}</code>
-                        <button
-                          onClick={() => copyActor(entry.actor)}
-                          className="text-gray-500 hover:text-gray-300 transition-colors"
-                          title="Copy address"
-                        >
-                          <Copy size={12} />
-                        </button>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-xs text-gray-400">
-                      {entry.target ? truncate(entry.target) : '—'}
-                    </td>
-                    <td className="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">
-                      {new Date(entry.timestamp).toLocaleString()}
-                    </td>
-                    <td className="px-4 py-3">
-                      {entry.txHash ? (
-                        <a
-                          href={`${env.explorerUrl}/tx/${entry.txHash}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-purple-400 hover:text-purple-300 transition-colors"
-                          title="View on Stellar Expert"
-                        >
-                          <ExternalLink size={14} />
-                        </a>
-                      ) : '—'}
-                    </td>
-                  </tr>
-                ))
-              )}
-              {loading && (
-                <tr>
-                  <td colSpan={6} className="px-4 py-4 text-center text-gray-400 text-xs">Loading…</td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+          {ALL_ACTIONS.map((a) => (
+            <button
+              key={a}
+              onClick={() => handleFilterChange(a)}
+              className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
+                actionFilter === a
+                  ? 'bg-purple-600 text-white'
+                  : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              }`}
+            >
+              {a}
+            </button>
+          ))}
         </div>
 
-        {hasMore && !loading && (
-          <div className="px-4 py-3 border-t border-gray-700 flex justify-center">
-            <button
-              onClick={() => void fetchPage(offset, actionFilter, false)}
-              className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-sm transition-colors"
-            >
-              <ChevronDown size={16} /> Load More
-            </button>
+        {/* Actions */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <button
+            onClick={() => void handleVerifyChain()}
+            disabled={verifying || entries.length === 0}
+            className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 rounded-lg text-sm transition-colors"
+            aria-label="Verify audit chain integrity"
+            data-testid="verify-chain-button"
+          >
+            {verifying ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                Verifying…
+              </>
+            ) : (
+              <>
+                <ShieldCheck className="w-4 h-4" aria-hidden="true" />
+                Verify Chain
+              </>
+            )}
+          </button>
+
+          <AuditExporter entries={entries} />
+        </div>
+      </div>
+
+      {/* Verification banner */}
+      {verificationResult !== null && (
+        <div
+          className={`flex items-start gap-3 rounded-xl px-4 py-3 text-sm border ${
+            verificationResult.verified
+              ? 'bg-green-500/10 border-green-500/30 text-green-300'
+              : 'bg-red-500/10 border-red-500/30 text-red-300'
+          }`}
+          role="status"
+          aria-live="polite"
+          data-testid="verification-banner"
+        >
+          {verificationResult.verified ? (
+            <>
+              <ShieldCheck className="w-5 h-5 flex-shrink-0 mt-0.5" aria-hidden="true" />
+              <div>
+                <p className="font-semibold">Chain Verified ✓</p>
+                <p className="text-xs opacity-80 mt-0.5">
+                  All {entries.length} entries form a valid hash chain.
+                </p>
+              </div>
+            </>
+          ) : (
+            <>
+              <ShieldAlert className="w-5 h-5 flex-shrink-0 mt-0.5" aria-hidden="true" />
+              <div>
+                <p className="font-semibold">
+                  Chain Broken at entry #{verificationResult.brokenAtEntry ?? '?'} ✗
+                </p>
+                <p className="text-xs opacity-80 mt-0.5">
+                  The hash chain is invalid from entry #{verificationResult.brokenAtEntry ?? '?'}{' '}
+                  onwards. This may indicate tampered or missing records.
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      {verificationError && (
+        <div
+          className="flex items-center gap-2 rounded-xl px-4 py-3 text-sm bg-red-500/10 border border-red-500/30 text-red-300"
+          role="alert"
+        >
+          <AlertTriangle className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+          {verificationError}
+        </div>
+      )}
+
+      {/* Infinite scroll table */}
+      <div
+        id="audit-scroll-container"
+        className="bg-gray-800/50 rounded-xl border border-gray-700 overflow-hidden"
+      >
+        <InfiniteScroll
+          dataLength={entries.length}
+          next={loadMore}
+          hasMore={hasMore}
+          loader={
+            <div className="px-4 py-4 text-center text-gray-400 text-xs">
+              <Loader2 className="w-4 h-4 animate-spin inline mr-2" aria-hidden="true" />
+              Loading more entries…
+            </div>
+          }
+          endMessage={
+            entries.length > 0 ? (
+              <div className="px-4 py-3 text-center text-gray-500 text-xs border-t border-gray-700">
+                All {entries.length} entries loaded
+              </div>
+            ) : null
+          }
+          scrollableTarget="audit-scroll-container"
+          style={{ overflow: 'visible' }}
+        >
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" aria-label="Audit log entries">
+              <thead className="bg-gray-800 border-b border-gray-700">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">
+                    Action
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">
+                    Actor
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">
+                    Target
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">
+                    Time
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-medium text-gray-400 uppercase">
+                    Tx
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-700">
+                {entries.length === 0 && !loading ? (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-8 text-center text-gray-400">
+                      No audit entries found.
+                    </td>
+                  </tr>
+                ) : (
+                  entries.map((entry, index) => {
+                    const broken = isBrokenEntry(index);
+                    const isBreakPoint =
+                      verificationResult !== null &&
+                      !verificationResult.verified &&
+                      index === verificationResult.brokenAtEntry;
+
+                    return (
+                      <tr
+                        key={entry.id}
+                        className={`transition-colors ${
+                          broken
+                            ? 'bg-red-500/10 hover:bg-red-500/15'
+                            : 'hover:bg-gray-700/30'
+                        }`}
+                        data-testid={broken ? 'broken-entry' : 'audit-entry'}
+                      >
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-2">
+                            <ActionIcon action={entry.action} />
+                            <span
+                              className={`px-2 py-1 rounded text-xs font-medium ${
+                                broken
+                                  ? 'bg-red-500/20 text-red-300'
+                                  : 'bg-purple-500/20 text-purple-300'
+                              }`}
+                            >
+                              {entry.action}
+                            </span>
+                            {isBreakPoint && (
+                              <span
+                                className="ml-1 px-1.5 py-0.5 bg-red-600/30 border border-red-500/50 rounded text-xs text-red-300"
+                                title="Hash chain breaks at this entry — subsequent entries may be tampered"
+                                role="tooltip"
+                                data-testid="chain-break-tooltip"
+                              >
+                                ⚠ chain break
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-1">
+                            <code className="text-xs text-gray-300">{truncate(entry.actor)}</code>
+                            <button
+                              onClick={() => copyActor(entry.actor)}
+                              className="text-gray-500 hover:text-gray-300 transition-colors p-0.5 rounded"
+                              title={`Copy full address: ${entry.actor}`}
+                              aria-label={`Copy actor address ${entry.actor}`}
+                            >
+                              <Copy size={12} aria-hidden="true" />
+                            </button>
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-xs text-gray-400">
+                          {entry.target ? truncate(entry.target) : '—'}
+                        </td>
+                        <td className="px-4 py-3 text-xs text-gray-400 whitespace-nowrap">
+                          <span
+                            title={new Date(entry.timestamp).toLocaleString()}
+                            className="cursor-help"
+                          >
+                            {relativeTime(entry.timestamp)}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3">
+                          {entry.txHash ? (
+                            <a
+                              href={`${env.explorerUrl}/tx/${entry.txHash}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-purple-400 hover:text-purple-300 transition-colors"
+                              title="View on Stellar Expert"
+                              aria-label={`View transaction ${entry.txHash} on Stellar Expert`}
+                            >
+                              <ExternalLink size={14} aria-hidden="true" />
+                            </a>
+                          ) : (
+                            '—'
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+                {loading && entries.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-8 text-center text-gray-400 text-xs">
+                      <Loader2 className="w-4 h-4 animate-spin inline mr-2" aria-hidden="true" />
+                      Loading…
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
-        )}
+        </InfiniteScroll>
       </div>
     </div>
   );

--- a/frontend/src/components/InstallPrompt.tsx
+++ b/frontend/src/components/InstallPrompt.tsx
@@ -2,24 +2,25 @@ import React, { useState, useEffect } from 'react';
 import { Download, X } from 'lucide-react';
 import { setupInstallPrompt, showInstallPrompt, isInstalled } from '../utils/pwa';
 
+const INSTALL_DELAY_MS = 30_000; // 30 seconds of use before showing prompt
+const DISMISSED_KEY = 'pwa-install-dismissed';
+
 export function InstallPrompt() {
   const [canInstall, setCanInstall] = useState(false);
   const [dismissed, setDismissed] = useState(false);
+  const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    // Don't show if already installed
-    if (isInstalled()) {
-      return;
-    }
+    // Don't show if already installed as PWA
+    if (isInstalled()) return;
 
-    // Check if user previously dismissed
-    const wasDismissed = localStorage.getItem('pwa-install-dismissed');
-    if (wasDismissed) {
+    // Don't show if user previously dismissed
+    if (localStorage.getItem(DISMISSED_KEY)) {
       setDismissed(true);
       return;
     }
 
-    // Setup install prompt listener
+    // Listen for the browser's beforeinstallprompt event
     const cleanup = setupInstallPrompt((installable) => {
       setCanInstall(installable);
     });
@@ -27,11 +28,19 @@ export function InstallPrompt() {
     return cleanup;
   }, []);
 
+  // Show the banner only after 30 seconds of use
+  useEffect(() => {
+    if (!canInstall || dismissed) return;
+
+    const timer = setTimeout(() => setVisible(true), INSTALL_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [canInstall, dismissed]);
+
   const handleInstall = async () => {
     const outcome = await showInstallPrompt();
-    
     if (outcome === 'accepted') {
       setCanInstall(false);
+      setVisible(false);
     } else if (outcome === 'dismissed') {
       handleDismiss();
     }
@@ -39,34 +48,36 @@ export function InstallPrompt() {
 
   const handleDismiss = () => {
     setDismissed(true);
-    localStorage.setItem('pwa-install-dismissed', 'true');
+    setVisible(false);
+    localStorage.setItem(DISMISSED_KEY, 'true');
   };
 
-  if (!canInstall || dismissed) {
+  if (!visible || !canInstall || dismissed) {
     return null;
   }
 
   return (
-    <div className="fixed bottom-4 left-4 right-4 z-50 md:left-auto md:right-4 md:w-96">
+    <div
+      className="fixed bottom-4 left-4 right-4 z-50 md:left-auto md:right-4 md:w-96"
+      data-testid="install-prompt"
+    >
       <div className="rounded-xl border border-purple-500/30 bg-gray-900/95 backdrop-blur-md p-4 shadow-2xl">
         <div className="flex items-start gap-3">
           <div className="flex-shrink-0 rounded-lg bg-purple-500/20 p-2">
             <Download className="h-5 w-5 text-purple-400" aria-hidden="true" />
           </div>
-          
+
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-semibold text-white mb-1">
-              Install VaultDAO
-            </h3>
+            <h3 className="text-sm font-semibold text-white mb-1">Install VaultDAO</h3>
             <p className="text-xs text-gray-400 mb-3">
               Install our app for faster access and offline support
             </p>
-            
+
             <div className="flex gap-2">
               <button
-                onClick={handleInstall}
+                onClick={() => void handleInstall()}
                 className="flex-1 rounded-lg bg-purple-600 px-3 py-2 text-xs font-medium text-white hover:bg-purple-700 transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 focus:ring-offset-gray-900"
-                aria-label="Install app"
+                aria-label="Install VaultDAO app"
               >
                 Install
               </button>
@@ -79,7 +90,7 @@ export function InstallPrompt() {
               </button>
             </div>
           </div>
-          
+
           <button
             onClick={handleDismiss}
             className="flex-shrink-0 rounded-lg p-1 text-gray-400 hover:bg-gray-800 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500"

--- a/frontend/src/components/OfflineIndicator.tsx
+++ b/frontend/src/components/OfflineIndicator.tsx
@@ -1,29 +1,63 @@
 import React, { useState, useEffect } from 'react';
-import { WifiOff, Wifi } from 'lucide-react';
+import { WifiOff, Wifi, Clock } from 'lucide-react';
 import { isOnline, setupNetworkListeners } from '../utils/pwa';
+import { getQueuedActionCount } from '../utils/offlineQueue';
 
-export function OfflineIndicator() {
+interface OfflineIndicatorProps {
+  /** Optionally override the queued count (e.g. from a parent context) */
+  queuedCount?: number;
+}
+
+export function OfflineIndicator({ queuedCount: externalCount }: OfflineIndicatorProps) {
   const [online, setOnline] = useState(isOnline());
   const [showReconnected, setShowReconnected] = useState(false);
+  const [queuedCount, setQueuedCount] = useState(externalCount ?? 0);
+
+  // Refresh queue count from IndexedDB
+  const refreshCount = async () => {
+    try {
+      const c = await getQueuedActionCount();
+      setQueuedCount(c);
+    } catch {
+      // IndexedDB unavailable
+    }
+  };
 
   useEffect(() => {
+    // Use external count if provided
+    if (externalCount !== undefined) {
+      setQueuedCount(externalCount);
+    }
+  }, [externalCount]);
+
+  useEffect(() => {
+    // Load initial count
+    void refreshCount();
+
     const cleanup = setupNetworkListeners(
       () => {
         setOnline(true);
         setShowReconnected(true);
-        
-        // Hide reconnected message after 3 seconds
-        setTimeout(() => {
-          setShowReconnected(false);
-        }, 3000);
+        // Refresh count after reconnect (actions may have been replayed)
+        setTimeout(() => void refreshCount(), 2000);
+        setTimeout(() => setShowReconnected(false), 4000);
       },
       () => {
         setOnline(false);
         setShowReconnected(false);
-      }
+        void refreshCount();
+      },
     );
 
-    return cleanup;
+    // Poll queue count while offline
+    const interval = setInterval(() => {
+      if (!navigator.onLine) void refreshCount();
+    }, 5000);
+
+    return () => {
+      cleanup();
+      clearInterval(interval);
+    };
   }, []);
 
   if (online && !showReconnected) {
@@ -39,19 +73,31 @@ export function OfflineIndicator() {
       }`}
       role="status"
       aria-live="polite"
+      data-testid="offline-indicator"
     >
       <div className="flex items-center gap-2">
         {online ? (
           <>
             <Wifi className="h-4 w-4" aria-hidden="true" />
             <span className="text-sm font-medium">Back online</span>
+            {queuedCount > 0 && (
+              <span className="text-xs opacity-80">— replaying {queuedCount} action{queuedCount !== 1 ? 's' : ''}…</span>
+            )}
           </>
         ) : (
           <>
             <WifiOff className="h-4 w-4 text-yellow-400" aria-hidden="true" />
-            <span className="text-sm font-medium">
-              You're offline - Some features may be limited
-            </span>
+            <span className="text-sm font-medium">You're offline</span>
+            {queuedCount > 0 && (
+              <span
+                className="flex items-center gap-1 ml-1 px-2 py-0.5 bg-yellow-500/20 border border-yellow-500/40 rounded-full text-xs text-yellow-300"
+                aria-label={`${queuedCount} action${queuedCount !== 1 ? 's' : ''} queued`}
+                data-testid="queued-count-badge"
+              >
+                <Clock className="h-3 w-3" aria-hidden="true" />
+                {queuedCount} queued
+              </span>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/components/PWASettings.tsx
+++ b/frontend/src/components/PWASettings.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Download, Bell, Trash2, Smartphone, Wifi } from 'lucide-react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { Download, Bell, Trash2, Smartphone, Wifi, Clock, RefreshCw, AlertCircle } from 'lucide-react';
 import {
   isInstalled,
   canInstall,
@@ -9,33 +9,106 @@ import {
   getCacheSize,
   isOnline,
 } from '../utils/pwa';
+import {
+  getQueuedActions,
+  getQueuedActionCount,
+  clearOfflineQueue,
+  type OfflineAction,
+} from '../utils/offlineQueue';
+
+const LAST_SYNC_KEY = 'vaultdao_last_sync_time';
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${Math.round((bytes / Math.pow(k, i)) * 100) / 100} ${sizes[i]}`;
+}
+
+function formatRelativeTime(isoString: string | null): string {
+  if (!isoString) return 'Never';
+  const diff = Date.now() - new Date(isoString).getTime();
+  if (diff < 60_000) return 'Just now';
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return new Date(isoString).toLocaleDateString();
+}
+
+function formatActionLabel(action: OfflineAction): string {
+  switch (action.actionType) {
+    case 'approve_proposal':
+      return `Approve proposal #${action.parameters.proposalId ?? '?'}`;
+    case 'execute_proposal':
+      return `Execute proposal #${action.parameters.proposalId ?? '?'}`;
+    case 'reject_proposal':
+      return `Reject proposal #${action.parameters.proposalId ?? '?'}`;
+    case 'propose_transfer':
+      return `Propose transfer to ${String(action.parameters.recipient ?? '?').slice(0, 8)}…`;
+    default:
+      return action.actionType;
+  }
+}
 
 export function PWASettings() {
   const [installed, setInstalled] = useState(isInstalled());
   const [installable, setInstallable] = useState(canInstall());
   const [notificationPermission, setNotificationPermission] = useState<NotificationPermission>(
-    'Notification' in window ? Notification.permission : 'denied'
+    'Notification' in window ? Notification.permission : 'denied',
   );
   const [cacheSize, setCacheSize] = useState<number>(0);
   const [clearing, setClearing] = useState(false);
   const [online, setOnline] = useState(isOnline());
+  const [queuedCount, setQueuedCount] = useState(0);
+  const [queuedActions, setQueuedActions] = useState<OfflineAction[]>([]);
+  const [lastSyncTime, setLastSyncTime] = useState<string | null>(
+    localStorage.getItem(LAST_SYNC_KEY),
+  );
+  const [showQueueDetails, setShowQueueDetails] = useState(false);
+  const [clearingQueue, setClearingQueue] = useState(false);
+
+  const refreshStats = useCallback(async () => {
+    try {
+      const [size, count, actions] = await Promise.all([
+        getCacheSize(),
+        getQueuedActionCount(),
+        getQueuedActions(),
+      ]);
+      setCacheSize(size);
+      setQueuedCount(count);
+      setQueuedActions(actions);
+    } catch {
+      // Ignore — storage APIs may be unavailable
+    }
+  }, []);
 
   useEffect(() => {
-    // Update cache size
-    getCacheSize().then(setCacheSize);
+    void refreshStats();
 
-    // Listen for online/offline events
-    const handleOnline = () => setOnline(true);
-    const handleOffline = () => setOnline(false);
-    
+    const handleOnline = () => {
+      setOnline(true);
+      const now = new Date().toISOString();
+      setLastSyncTime(now);
+      localStorage.setItem(LAST_SYNC_KEY, now);
+      void refreshStats();
+    };
+    const handleOffline = () => {
+      setOnline(false);
+      void refreshStats();
+    };
+
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
+
+    // Refresh stats every 30s
+    const interval = setInterval(() => void refreshStats(), 30_000);
 
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);
+      clearInterval(interval);
     };
-  }, []);
+  }, [refreshStats]);
 
   const handleInstall = async () => {
     const outcome = await showInstallPrompt();
@@ -63,12 +136,17 @@ export function PWASettings() {
     }
   };
 
-  const formatBytes = (bytes: number): string => {
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
+  const handleClearQueue = async () => {
+    setClearingQueue(true);
+    try {
+      await clearOfflineQueue();
+      setQueuedCount(0);
+      setQueuedActions([]);
+    } catch (error) {
+      console.error('Failed to clear queue:', error);
+    } finally {
+      setClearingQueue(false);
+    }
   };
 
   return (
@@ -84,14 +162,27 @@ export function PWASettings() {
       <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
         <div className="flex items-start gap-4">
           <div className={`p-3 rounded-lg ${online ? 'bg-green-500/20' : 'bg-yellow-500/20'}`}>
-            <Wifi className={`w-6 h-6 ${online ? 'text-green-400' : 'text-yellow-400'}`} aria-hidden="true" />
+            <Wifi
+              className={`w-6 h-6 ${online ? 'text-green-400' : 'text-yellow-400'}`}
+              aria-hidden="true"
+            />
           </div>
-          <div>
+          <div className="flex-1">
             <h3 className="text-lg font-semibold text-white mb-1">Connection Status</h3>
             <p className="text-sm text-gray-400">
-              {online ? 'You are online' : 'You are offline - Some features may be limited'}
+              {online ? 'You are online' : 'You are offline — actions will be queued'}
+            </p>
+            <p className="text-xs text-gray-500 mt-1">
+              Last sync: {formatRelativeTime(lastSyncTime)}
             </p>
           </div>
+          <button
+            onClick={() => void refreshStats()}
+            className="p-2 text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-gray-700"
+            aria-label="Refresh stats"
+          >
+            <RefreshCw className="w-4 h-4" aria-hidden="true" />
+          </button>
         </div>
       </div>
 
@@ -115,7 +206,7 @@ export function PWASettings() {
           </div>
           {!installed && installable && (
             <button
-              onClick={handleInstall}
+              onClick={() => void handleInstall()}
               className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 min-h-[44px]"
               aria-label="Install app"
             >
@@ -139,13 +230,18 @@ export function PWASettings() {
                 Get notified about proposal updates and important events
               </p>
               <p className="text-xs text-gray-500">
-                Status: {notificationPermission === 'granted' ? 'Enabled' : notificationPermission === 'denied' ? 'Blocked' : 'Not enabled'}
+                Status:{' '}
+                {notificationPermission === 'granted'
+                  ? 'Enabled'
+                  : notificationPermission === 'denied'
+                  ? 'Blocked'
+                  : 'Not enabled'}
               </p>
             </div>
           </div>
           {notificationPermission !== 'granted' && notificationPermission !== 'denied' && (
             <button
-              onClick={handleNotificationRequest}
+              onClick={() => void handleNotificationRequest()}
               className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[44px]"
               aria-label="Enable notifications"
             >
@@ -162,6 +258,77 @@ export function PWASettings() {
         )}
       </div>
 
+      {/* Offline Action Queue */}
+      <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
+        <div className="flex items-start gap-4 mb-4">
+          <div className={`p-3 rounded-lg ${queuedCount > 0 ? 'bg-yellow-500/20' : 'bg-gray-500/20'}`}>
+            <Clock
+              className={`w-6 h-6 ${queuedCount > 0 ? 'text-yellow-400' : 'text-gray-400'}`}
+              aria-hidden="true"
+            />
+          </div>
+          <div className="flex-1">
+            <h3 className="text-lg font-semibold text-white mb-1">Offline Action Queue</h3>
+            <p className="text-sm text-gray-400 mb-1">
+              Actions queued while offline are replayed automatically on reconnect
+            </p>
+            <p className="text-xs text-gray-500" data-testid="queued-action-count">
+              {queuedCount === 0
+                ? 'No pending actions'
+                : `${queuedCount} action${queuedCount !== 1 ? 's' : ''} pending`}
+            </p>
+          </div>
+          {queuedCount > 0 && (
+            <button
+              onClick={() => setShowQueueDetails((v) => !v)}
+              className="text-xs text-purple-400 hover:text-purple-300 transition-colors"
+            >
+              {showQueueDetails ? 'Hide' : 'Show'} details
+            </button>
+          )}
+        </div>
+
+        {/* Queue details */}
+        {showQueueDetails && queuedActions.length > 0 && (
+          <div className="mb-4 space-y-2">
+            {queuedActions.map((action) => (
+              <div
+                key={action.id}
+                className="flex items-start gap-3 p-3 bg-gray-700/50 rounded-lg text-sm"
+              >
+                <div className="flex-1 min-w-0">
+                  <p className="text-gray-200 font-medium truncate">
+                    {formatActionLabel(action)}
+                  </p>
+                  <p className="text-gray-500 text-xs mt-0.5">
+                    Queued {new Date(action.timestamp).toLocaleString()} · {action.attempts} attempt
+                    {action.attempts !== 1 ? 's' : ''}
+                  </p>
+                  {action.lastError && (
+                    <p className="text-red-400 text-xs mt-1 flex items-center gap-1">
+                      <AlertCircle className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
+                      {action.lastError}
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {queuedCount > 0 && (
+          <button
+            onClick={() => void handleClearQueue()}
+            disabled={clearingQueue}
+            className="flex items-center gap-2 px-4 py-2 bg-yellow-600/20 hover:bg-yellow-600/30 border border-yellow-600/40 text-yellow-300 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-yellow-500 min-h-[44px]"
+            aria-label="Clear offline action queue"
+          >
+            <Trash2 className="w-4 h-4" aria-hidden="true" />
+            {clearingQueue ? 'Clearing…' : 'Clear Queue'}
+          </button>
+        )}
+      </div>
+
       {/* Cache Management */}
       <div className="bg-gray-800/50 border border-gray-700 rounded-xl p-6">
         <div className="flex items-start gap-4 mb-4">
@@ -170,32 +337,31 @@ export function PWASettings() {
           </div>
           <div>
             <h3 className="text-lg font-semibold text-white mb-1">Storage & Cache</h3>
-            <p className="text-sm text-gray-400 mb-2">
-              Manage offline data and cached content
-            </p>
-            <p className="text-xs text-gray-500">
+            <p className="text-sm text-gray-400 mb-2">Manage offline data and cached content</p>
+            <p className="text-xs text-gray-500" data-testid="cache-size">
               Cache size: {formatBytes(cacheSize)}
             </p>
           </div>
         </div>
-        
+
         <button
-          onClick={handleClearCache}
+          onClick={() => void handleClearCache()}
           disabled={clearing || cacheSize === 0}
           className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-gray-500 min-h-[44px]"
           aria-label={clearing ? 'Clearing cache' : 'Clear cache'}
+          data-testid="clear-cache-button"
         >
           <Trash2 className="w-4 h-4" aria-hidden="true" />
-          {clearing ? 'Clearing...' : 'Clear Cache'}
+          {clearing ? 'Clearing…' : 'Clear Cache'}
         </button>
       </div>
 
       {/* Info Box */}
       <div className="bg-blue-500/10 border border-blue-500/30 rounded-xl p-4">
         <p className="text-sm text-blue-300">
-          <strong>Note:</strong> PWA features enhance your experience with offline support, 
-          faster loading, and native app-like functionality. Some features may not be available 
-          on all devices or browsers.
+          <strong>Note:</strong> PWA features enhance your experience with offline support, faster
+          loading, and native app-like functionality. Queued actions (approvals, votes) are
+          replayed automatically when you reconnect.
         </p>
       </div>
     </div>

--- a/frontend/src/hooks/useOfflineSync.ts
+++ b/frontend/src/hooks/useOfflineSync.ts
@@ -1,0 +1,147 @@
+/**
+ * useOfflineSync
+ *
+ * Manages the offline action queue lifecycle:
+ * - Tracks queue count and exposes it to UI
+ * - On reconnect, replays queued actions in order
+ * - Shows a toast for each replayed action (success or failure)
+ * - Failed actions remain in the queue for manual retry
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  getQueuedActions,
+  getQueuedActionCount,
+  removeQueuedAction,
+  updateActionAttempt,
+  type OfflineAction,
+  type OfflineActionType,
+} from '../utils/offlineQueue';
+import { useToast } from './useToast';
+
+export interface UseOfflineSyncReturn {
+  queuedCount: number;
+  isReplaying: boolean;
+  replayQueue: () => Promise<void>;
+  refreshCount: () => Promise<void>;
+}
+
+type ActionExecutor = (
+  actionType: OfflineActionType,
+  parameters: Record<string, unknown>,
+) => Promise<string | void>;
+
+/**
+ * @param executeAction - Callback that actually executes a contract action.
+ *   Receives the action type and parameters; should throw on failure.
+ */
+export function useOfflineSync(executeAction?: ActionExecutor): UseOfflineSyncReturn {
+  const { showToast } = useToast();
+  const [queuedCount, setQueuedCount] = useState(0);
+  const [isReplaying, setIsReplaying] = useState(false);
+  const wasOfflineRef = useRef(!navigator.onLine);
+  const executeRef = useRef(executeAction);
+  executeRef.current = executeAction;
+
+  const refreshCount = useCallback(async () => {
+    try {
+      const c = await getQueuedActionCount();
+      setQueuedCount(c);
+    } catch {
+      // IndexedDB may not be available in all environments
+    }
+  }, []);
+
+  // Initial count
+  useEffect(() => {
+    void refreshCount();
+  }, [refreshCount]);
+
+  const replayQueue = useCallback(async () => {
+    if (!executeRef.current) return;
+    if (isReplaying) return;
+
+    let actions: OfflineAction[];
+    try {
+      actions = await getQueuedActions();
+    } catch {
+      return;
+    }
+
+    if (actions.length === 0) return;
+
+    setIsReplaying(true);
+
+    for (const action of actions) {
+      const label = formatActionLabel(action.actionType, action.parameters);
+      try {
+        await executeRef.current(action.actionType, action.parameters);
+        await removeQueuedAction(action.id);
+        showToast(`✓ Replayed: ${label}`, 'success');
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        await updateActionAttempt(action.id, errMsg);
+        showToast(`✗ Failed to replay: ${label} — ${errMsg}`, 'error');
+      }
+    }
+
+    setIsReplaying(false);
+    await refreshCount();
+  }, [isReplaying, showToast, refreshCount]);
+
+  // Listen for online event to trigger replay
+  useEffect(() => {
+    const handleOnline = () => {
+      if (wasOfflineRef.current) {
+        wasOfflineRef.current = false;
+        void replayQueue();
+      }
+    };
+
+    const handleOffline = () => {
+      wasOfflineRef.current = true;
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, [replayQueue]);
+
+  // Listen for SW sync results
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.data?.type === 'SYNC_RESULTS') {
+        void refreshCount();
+      }
+    };
+
+    navigator.serviceWorker.addEventListener('message', handleMessage);
+    return () => navigator.serviceWorker.removeEventListener('message', handleMessage);
+  }, [refreshCount]);
+
+  return { queuedCount, isReplaying, replayQueue, refreshCount };
+}
+
+function formatActionLabel(
+  actionType: OfflineActionType,
+  parameters: Record<string, unknown>,
+): string {
+  switch (actionType) {
+    case 'approve_proposal':
+      return `Approve proposal #${parameters.proposalId ?? '?'}`;
+    case 'execute_proposal':
+      return `Execute proposal #${parameters.proposalId ?? '?'}`;
+    case 'reject_proposal':
+      return `Reject proposal #${parameters.proposalId ?? '?'}`;
+    case 'propose_transfer':
+      return `Propose transfer to ${String(parameters.recipient ?? '?').slice(0, 8)}…`;
+    default:
+      return actionType;
+  }
+}

--- a/frontend/src/utils/offlineQueue.ts
+++ b/frontend/src/utils/offlineQueue.ts
@@ -1,0 +1,173 @@
+/**
+ * Offline action queue backed by IndexedDB.
+ *
+ * When the user performs a contract action (approve, execute, vote) while
+ * offline, the action is serialised and stored here. On reconnect the queue
+ * is replayed in insertion order via the Background Sync API (or a manual
+ * flush if Background Sync is unavailable).
+ */
+
+export type OfflineActionType =
+  | 'approve_proposal'
+  | 'execute_proposal'
+  | 'reject_proposal'
+  | 'propose_transfer';
+
+export interface OfflineAction {
+  /** Unique id for this queued item */
+  id: string;
+  /** Wallet address that initiated the action */
+  walletAddress: string;
+  /** Action type */
+  actionType: OfflineActionType;
+  /** Action-specific parameters */
+  parameters: Record<string, unknown>;
+  /** ISO timestamp when the action was queued */
+  timestamp: string;
+  /** Number of replay attempts */
+  attempts: number;
+  /** Last error message if replay failed */
+  lastError?: string;
+}
+
+const DB_NAME = 'vaultdao-offline-db';
+const DB_VERSION = 2;
+const STORE = 'offline-actions';
+
+// ─── DB lifecycle ────────────────────────────────────────────────────────────
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result as IDBDatabase);
+    req.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { keyPath: 'id' });
+        store.createIndex('timestamp', 'timestamp', { unique: false });
+      }
+    };
+  });
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/** Add an action to the offline queue. Returns the generated id. */
+export async function enqueueOfflineAction(
+  walletAddress: string,
+  actionType: OfflineActionType,
+  parameters: Record<string, unknown>,
+): Promise<string> {
+  const action: OfflineAction = {
+    id: `${actionType}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    walletAddress,
+    actionType,
+    parameters,
+    timestamp: new Date().toISOString(),
+    attempts: 0,
+  };
+
+  const db = await openDB();
+  await put(db, action);
+
+  // Ask the service worker to register a Background Sync tag
+  if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({
+      type: 'QUEUE_ACTION',
+      action: {
+        id: action.id,
+        url: '/api/v1/offline-sync', // placeholder — actual replay is done in-app
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(action),
+        timestamp: action.timestamp,
+      },
+    });
+  }
+
+  return action.id;
+}
+
+/** Return all queued actions in chronological order. */
+export async function getQueuedActions(): Promise<OfflineAction[]> {
+  const db = await openDB();
+  return getAll(db);
+}
+
+/** Return the number of queued actions. */
+export async function getQueuedActionCount(): Promise<number> {
+  const db = await openDB();
+  return count(db);
+}
+
+/** Remove a specific action from the queue (after successful replay). */
+export async function removeQueuedAction(id: string): Promise<void> {
+  const db = await openDB();
+  await remove(db, id);
+}
+
+/** Update an action's attempt count and last error. */
+export async function updateActionAttempt(
+  id: string,
+  lastError?: string,
+): Promise<void> {
+  const db = await openDB();
+  const all = await getAll(db);
+  const action = all.find((a) => a.id === id);
+  if (!action) return;
+  await put(db, { ...action, attempts: action.attempts + 1, lastError });
+}
+
+/** Clear the entire queue. */
+export async function clearOfflineQueue(): Promise<void> {
+  const db = await openDB();
+  await clear(db);
+}
+
+// ─── IDB helpers ─────────────────────────────────────────────────────────────
+
+function put(db: IDBDatabase, record: OfflineAction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const req = tx.objectStore(STORE).put(record);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve();
+  });
+}
+
+function getAll(db: IDBDatabase): Promise<OfflineAction[]> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).index('timestamp').getAll();
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result as OfflineAction[]);
+  });
+}
+
+function remove(db: IDBDatabase, id: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const req = tx.objectStore(STORE).delete(id);
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve();
+  });
+}
+
+function count(db: IDBDatabase): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly');
+    const req = tx.objectStore(STORE).count();
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve(req.result as number);
+  });
+}
+
+function clear(db: IDBDatabase): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite');
+    const req = tx.objectStore(STORE).clear();
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => resolve();
+  });
+}


### PR DESCRIPTION


closes #1044 

closes #1036 

Implements complete PWA offline support and AuditLog hash chain verification UI.

### A — PWA Offline Support

- **sw.js**: stale-while-revalidate for all `/api/v1/*` routes; cache-first
  for static assets; app shell fallback for navigation; Background Sync
  replays queued actions on reconnect; IndexedDB schema v2
- **offlineQueue.ts** (new): IndexedDB-backed queue storing `walletAddress`,
  `actionType`, `parameters`, `timestamp`, `attempts`, `lastError`
- **useOfflineSync.ts** (new): replays queue on reconnect, success/error
  toast per action, failed actions stay in queue for manual retry
- **OfflineIndicator**: offline banner with queued count badge;
  "Back online — replaying N actions…" on reconnect
- **InstallPrompt**: banner deferred until 30s of use
- **PWASettings**: cache size, last sync time, queued count, expandable
  queue detail list, Clear Cache + Clear Queue buttons

### B — AuditLog Chain Verification

- **AuditLog**: Verify Chain button → `GET /api/v1/audit/verify` → green/red
  banner; broken entries highlighted red with chain-break tooltip; action
  icons (lucide-react); truncated actor + copy button; relative timestamps
  with absolute on hover; infinite scroll (50/page)
- **AuditExporter**: CSV via `GET /api/v1/audit/export` with client-side
  fallback; `Blob + URL.createObjectURL` download

### Tests

- `pwa.test.tsx`: offline banner, queued count badge, back-online banner,
  action queuing (walletAddress/actionType/parameters/timestamp), replay
  on reconnect — success toast, error toast + queue retention
- `auditLog.test.tsx`: chain verified banner, broken chain + entry
  highlight + tooltip, spinner during verification, CSV download trigger
