### PR TITLE
feat: implement proposal side-by-side diff view 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-grid-layout": "^1.3.6",
         "@types/react-window": "^1.8.8",
         "browser-image-compression": "^2.0.2",
+        "diff-match-patch": "^1.0.5",
         "fuse.js": "^7.1.0",
         "html2canvas": "^1.4.1",
         "i18next": "^25.8.13",
@@ -4628,6 +4629,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@types/react-grid-layout": "^1.3.6",
     "@types/react-window": "^1.8.8",
     "browser-image-compression": "^2.0.2",
+    "diff-match-patch": "^1.0.5",
     "fuse.js": "^7.1.0",
     "html2canvas": "^1.4.1",
     "i18next": "^25.8.13",

--- a/frontend/src/app/dashboard/__tests__/RecurringPayments.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/RecurringPayments.test.tsx
@@ -124,7 +124,9 @@ describe('RecurringPayments page', () => {
     await waitFor(() => {
       expect(screen.getByText('Overdue payment')).toBeInTheDocument();
       // The Overdue status badge should be present
-      expect(screen.getByText('Overdue')).toBeInTheDocument();
+      const badge = document.querySelector('span.bg-red-500\\/20');
+      expect(badge).toBeInTheDocument();
+      expect(badge?.textContent).toContain('Overdue');
     });
   });
 
@@ -147,7 +149,9 @@ describe('RecurringPayments page', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Paused subscription')).toBeInTheDocument();
-      expect(screen.getByText('Paused')).toBeInTheDocument();
+      const badge = document.querySelector('span.bg-gray-500\\/20');
+      expect(badge).toBeInTheDocument();
+      expect(badge?.textContent).toContain('Paused');
     });
   });
 

--- a/frontend/src/app/dashboard/__tests__/StreamingPayments.test.tsx
+++ b/frontend/src/app/dashboard/__tests__/StreamingPayments.test.tsx
@@ -5,11 +5,13 @@ import StreamingPayments, { type Stream } from '../StreamingPayments';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
+const mockWallet = {
+  address: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
+  isConnected: true,
+};
+
 vi.mock('../../../hooks/useWallet', () => ({
-  useWallet: () => ({
-    address: 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB',
-    isConnected: true,
-  }),
+  useWallet: () => mockWallet,
 }));
 
 vi.mock('../../../context/ToastContext', () => ({
@@ -44,13 +46,13 @@ const makeStream = (overrides: Partial<Stream> = {}): Stream => ({
 
 describe('StreamingPayments page', () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    mockWallet.address = 'GABC1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890AB';
+    mockWallet.isConnected = true;
     // Mock fetch to return demo streams
     global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -69,6 +71,7 @@ describe('StreamingPayments page', () => {
   });
 
   it('claimable counter increments over time for active streams', async () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval', 'Date'] });
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ streams: [makeStream()] }),
@@ -85,6 +88,7 @@ describe('StreamingPayments page', () => {
       const claimableEl = screen.getByText(/Claimable now/i).closest('div')?.nextElementSibling;
       expect(claimableEl?.textContent).toMatch(/XLM/);
     });
+    vi.useRealTimers();
   });
 
   it('shows paused status for paused streams', async () => {
@@ -116,12 +120,9 @@ describe('StreamingPayments page', () => {
   });
 
   it('shows "Connect your wallet" when not connected', () => {
-    vi.doMock('../../../hooks/useWallet', () => ({
-      useWallet: () => ({ address: null, isConnected: false }),
-    }));
-    // Re-render with disconnected wallet via direct prop override
+    mockWallet.address = null;
+    mockWallet.isConnected = false;
     render(<StreamingPayments />);
-    // The page still renders (wallet mock is module-level), just verify no crash
-    expect(document.body).toBeTruthy();
+    expect(screen.getByText('Connect your wallet')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ComparisonView.tsx
+++ b/frontend/src/components/ComparisonView.tsx
@@ -1,8 +1,25 @@
-import React, { useMemo } from 'react';
-import { ArrowLeft, Download, Copy, FilePen } from 'lucide-react';
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import {
+  ArrowLeft,
+  Download,
+  Copy,
+  FilePen,
+  ArrowLeftRight,
+  ChevronDown,
+  ChevronUp,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+} from 'lucide-react';
 import { getDiffSegments } from '../utils/diffHighlighting';
 import { calculateProposalSimilarity } from '../utils/similarityDetection';
-import type { DiffSegment, ComparisonField } from '../types/comparison';
+import { compareAmounts, formatAmountDiff } from '../utils/amountComparator';
+import { compareAddresses, resolveAddressLabel } from '../utils/addressComparator';
+import type { DiffSegment } from '../types/comparison';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DESCRIPTION_TRUNCATE_LIMIT = 2000;
 
 interface ComparisonViewProps {
   proposals: any[];
@@ -12,68 +29,233 @@ interface ComparisonViewProps {
   onAmendment?: (data: Record<string, string>) => void;
 }
 
-const COMPARISON_FIELDS: ComparisonField[] = [
-  { key: 'id', label: 'ID', type: 'text', getValue: (p) => p.id },
-  { key: 'status', label: 'Status', type: 'status', getValue: (p) => p.status },
-  { key: 'proposer', label: 'Proposer', type: 'address', getValue: (p) => p.proposer },
-  { key: 'recipient', label: 'Recipient', type: 'address', getValue: (p) => p.recipient },
-  { key: 'amount', label: 'Amount', type: 'number', getValue: (p) => p.amount },
-  { key: 'token', label: 'Token', type: 'text', getValue: (p) => p.tokenSymbol || p.token || 'XLM' },
-  { key: 'memo', label: 'Description', type: 'text', getValue: (p) => p.memo || 'N/A' },
-  { key: 'approvals', label: 'Approvals', type: 'number', getValue: (p) => `${p.approvals || 0}/${p.threshold || 0}` },
-  { key: 'createdAt', label: 'Created', type: 'date', getValue: (p) => new Date(p.createdAt).toLocaleDateString() },
-];
+// ─── DiffRenderer ────────────────────────────────────────────────────────────
 
-const DiffText: React.FC<{ segments: DiffSegment[] }> = ({ segments }) => {
+/**
+ * Renders diff segments from the perspective of one side:
+ *   - `side='left'`  → show equal + delete (what was removed from A)
+ *   - `side='right'` → show equal + insert (what was added in B)
+ */
+const DiffRenderer: React.FC<{
+  segments: DiffSegment[];
+  side: 'left' | 'right';
+}> = ({ segments, side }) => (
+  <span className="inline break-words whitespace-pre-wrap">
+    {segments.map((seg, idx) => {
+      if (seg.type === 'equal') {
+        return <span key={idx}>{seg.value}</span>;
+      }
+      if (seg.type === 'insert' && side === 'right') {
+        return (
+          <span
+            key={idx}
+            className="bg-green-500/25 text-green-300 rounded px-0.5 diff-insert"
+            data-testid="diff-insert"
+          >
+            {seg.value}
+          </span>
+        );
+      }
+      if (seg.type === 'delete' && side === 'left') {
+        return (
+          <span
+            key={idx}
+            className="bg-red-500/25 text-red-300 line-through rounded px-0.5 diff-delete"
+            data-testid="diff-delete"
+          >
+            {seg.value}
+          </span>
+        );
+      }
+      // Skip inserts on left side and deletes on right side
+      return null;
+    })}
+  </span>
+);
+
+// ─── ExpandableText ───────────────────────────────────────────────────────────
+
+const ExpandableText: React.FC<{
+  text: string;
+  segments?: DiffSegment[];
+  side?: 'left' | 'right';
+  limit?: number;
+}> = ({ text, segments, side, limit = DESCRIPTION_TRUNCATE_LIMIT }) => {
+  const [expanded, setExpanded] = useState(false);
+  const needsExpansion = text.length > limit;
+
+  if (!needsExpansion) {
+    return segments && side ? (
+      <DiffRenderer segments={segments} side={side} />
+    ) : (
+      <span className="break-words whitespace-pre-wrap">{text}</span>
+    );
+  }
+
+  const preview = text.slice(0, limit);
+
   return (
-    <span className="inline break-words whitespace-pre-wrap">
-      {segments.map((segment, idx) => {
-        if (segment.type === 'equal') {
-          return <span key={idx}>{segment.value}</span>;
-        }
-        if (segment.type === 'insert') {
-          return (
-            <span key={idx} className="bg-green-500/20 text-green-400">
-              {segment.value}
-            </span>
-          );
-        }
-        if (segment.type === 'delete') {
-          return (
-            <span key={idx} className="bg-red-500/20 text-red-400 line-through">
-              {segment.value}
-            </span>
-          );
-        }
-        return null;
-      })}
+    <span className="block">
+      {expanded ? (
+        segments && side ? (
+          <DiffRenderer segments={segments} side={side} />
+        ) : (
+          <span className="break-words whitespace-pre-wrap">{text}</span>
+        )
+      ) : (
+        <span className="break-words whitespace-pre-wrap">{preview}…</span>
+      )}
+      <button
+        onClick={() => setExpanded((e) => !e)}
+        className="ml-2 inline-flex items-center gap-1 text-xs text-purple-400 hover:text-purple-300 transition-colors font-medium"
+        aria-label={expanded ? 'Show less' : 'Show more'}
+      >
+        {expanded ? (
+          <>
+            <ChevronUp size={12} /> Show less
+          </>
+        ) : (
+          <>
+            <ChevronDown size={12} /> Show more
+          </>
+        )}
+      </button>
     </span>
   );
 };
 
-const ComparisonView: React.FC<ComparisonViewProps> = ({ proposals, onClose, onExport, onAmendment }) => {
-  const comparisonData = useMemo(() => {
-    return COMPARISON_FIELDS.map((field) => {
-      const values = proposals.map((p) => String(field.getValue(p)));
-      const hasDifferences = new Set(values).size > 1;
+// ─── AmountRow ────────────────────────────────────────────────────────────────
 
-      // Calculate diffs for text fields
-      const diffs = new Map<number, DiffSegment[]>();
-      if (hasDifferences && field.type === 'text' && proposals.length === 2) {
-        diffs.set(0, getDiffSegments(values[0], values[1]));
-        diffs.set(1, getDiffSegments(values[1], values[0]));
-      }
+const AmountRow: React.FC<{
+  leftValue: string;
+  rightValue: string;
+  token: string;
+  swapped: boolean;
+}> = ({ leftValue, rightValue, token, swapped }) => {
+  const diff = useMemo(
+    () => compareAmounts(swapped ? rightValue : leftValue, swapped ? leftValue : rightValue),
+    [leftValue, rightValue, swapped],
+  );
 
-      return {
-        field,
-        values,
-        diffs,
-        hasDifferences,
-      };
+  const DeltaIcon =
+    diff.direction === 'up'
+      ? TrendingUp
+      : diff.direction === 'down'
+      ? TrendingDown
+      : Minus;
+
+  const deltaColor =
+    diff.direction === 'up'
+      ? 'text-green-400'
+      : diff.direction === 'down'
+      ? 'text-red-400'
+      : 'text-gray-400';
+
+  const formatVal = (raw: string | number) => {
+    const n = typeof raw === 'string' ? parseFloat(raw) : raw;
+    if (isNaN(n)) return String(raw);
+    const v = n >= 1_000_000 ? n / 10_000_000 : n;
+    return `${v.toFixed(7)} ${token}`;
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-gray-200">{formatVal(leftValue)}</span>
+      {diff.direction !== 'equal' && (
+        <span className={`inline-flex items-center gap-1 text-xs font-medium ${deltaColor}`}>
+          <DeltaIcon size={11} />
+          {formatAmountDiff(leftValue, rightValue, token)}
+        </span>
+      )}
+    </div>
+  );
+};
+
+// ─── AddressCell ──────────────────────────────────────────────────────────────
+
+const AddressCell: React.FC<{ address: string; hasDiff: boolean }> = ({
+  address,
+  hasDiff,
+}) => {
+  const [label, setLabel] = useState<string>(
+    address.length > 12
+      ? `${address.slice(0, 6)}...${address.slice(-6)}`
+      : address,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    resolveAddressLabel(address).then((resolved) => {
+      if (!cancelled) setLabel(resolved);
     });
-  }, [proposals]);
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
 
-  // Similarity score for exactly 2 proposals
+  return (
+    <span
+      className={`font-mono text-xs break-all ${hasDiff ? 'text-yellow-300' : 'text-gray-300'}`}
+      title={address}
+    >
+      {label}
+    </span>
+  );
+};
+
+// ─── StatusBadge ─────────────────────────────────────────────────────────────
+
+const statusColors: Record<string, string> = {
+  Pending: 'bg-yellow-500/15 text-yellow-400 border-yellow-500/30',
+  Approved: 'bg-green-500/15 text-green-400 border-green-500/30',
+  Rejected: 'bg-red-500/15 text-red-400 border-red-500/30',
+  Executed: 'bg-blue-500/15 text-blue-400 border-blue-500/30',
+};
+
+const StatusBadge: React.FC<{ status: string }> = ({ status }) => (
+  <span
+    className={`inline-block px-2 py-0.5 rounded text-xs border ${
+      statusColors[status] ?? 'bg-gray-500/15 text-gray-400 border-gray-500/30'
+    }`}
+  >
+    {status}
+  </span>
+);
+
+// ─── ComparisonView (main) ────────────────────────────────────────────────────
+
+const ComparisonView: React.FC<ComparisonViewProps> = ({
+  proposals,
+  onClose,
+  onExport,
+  onAmendment,
+}) => {
+  const [swapped, setSwapped] = useState(false);
+
+  // For 2-proposal mode, left/right depends on swap state
+  const [left, right] = useMemo(() => {
+    if (proposals.length !== 2) return [proposals[0], proposals[1]];
+    return swapped ? [proposals[1], proposals[0]] : [proposals[0], proposals[1]];
+  }, [proposals, swapped]);
+
+  const isSideBySide = proposals.length === 2;
+
+  // Precompute diffs for all text fields
+  const memoField = useCallback(
+    (getter: (p: any) => string) => {
+      if (!isSideBySide) return [];
+      const t1 = String(getter(left) ?? '');
+      const t2 = String(getter(right) ?? '');
+      return getDiffSegments(t1, t2);
+    },
+    [left, right, isSideBySide],
+  );
+
+  const descDiff = useMemo(
+    () => memoField((p) => p.memo ?? p.description ?? ''),
+    [memoField],
+  );
+
   const similarityScore = useMemo(() => {
     if (proposals.length !== 2) return null;
     const result = calculateProposalSimilarity(proposals[0], proposals[1]);
@@ -81,45 +263,240 @@ const ComparisonView: React.FC<ComparisonViewProps> = ({ proposals, onClose, onE
   }, [proposals]);
 
   const handleCopyToClipboard = () => {
-    const lines: string[] = [`Proposal Comparison — ${new Date().toLocaleDateString()}`, ''];
-    lines.push(['Field', ...proposals.map((p) => `Proposal #${p.id}`)].join('\t'));
-    comparisonData.forEach(({ field, values }) => {
-      lines.push([field.label, ...values].join('\t'));
-    });
-    if (similarityScore !== null) lines.push(`\nSimilarity Score: ${similarityScore}%`);
+    const lines: string[] = [
+      `Proposal Comparison — ${new Date().toLocaleDateString()}`,
+      '',
+      `Left: Proposal #${left?.id ?? '?'}   Right: Proposal #${right?.id ?? '?'}`,
+    ];
+    if (similarityScore !== null)
+      lines.push(`Similarity: ${similarityScore}%`);
     void navigator.clipboard.writeText(lines.join('\n'));
   };
 
   const handleProposeAmendment = () => {
-    if (!onAmendment || proposals.length < 2) return;
+    if (!onAmendment || !isSideBySide) return;
     const diffs: Record<string, string> = {};
-    comparisonData.forEach(({ field, values, hasDifferences }) => {
-      if (hasDifferences) diffs[field.key] = values[1]; // use second proposal's value
+    const fields = ['memo', 'amount', 'recipient', 'token'];
+    fields.forEach((k) => {
+      const lv = String(left?.[k] ?? '');
+      const rv = String(right?.[k] ?? '');
+      if (lv !== rv) diffs[k] = rv;
     });
     onAmendment(diffs);
   };
 
-  const formatAddress = (address: string): string => {
-    if (address.length <= 12) return address;
-    return `${address.slice(0, 6)}...${address.slice(-6)}`;
-  };
+  // ── Fallback table for 3+ proposals ──────────────────────────────────────
+  if (!isSideBySide) {
+    return (
+      <div className="fixed inset-0 bg-black/70 backdrop-blur-sm z-50 overflow-hidden">
+        <div className="h-full flex flex-col bg-gray-900">
+          <div className="flex-shrink-0 bg-gray-800/60 border-b border-gray-700 px-4 py-3 flex items-center gap-3">
+            <button
+              onClick={onClose}
+              className="p-2 hover:bg-gray-700 rounded-lg transition-colors"
+              aria-label="Close comparison"
+            >
+              <ArrowLeft size={20} className="text-gray-400" />
+            </button>
+            <h2 className="text-lg font-bold text-white">Proposal Comparison</h2>
+            <span className="text-sm text-gray-400">({proposals.length} proposals)</span>
+            <div className="ml-auto">
+              <button
+                onClick={onExport}
+                className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg text-white text-sm transition-colors"
+              >
+                <Download size={15} />
+                Export PDF
+              </button>
+            </div>
+          </div>
+          <div className="flex-1 overflow-auto p-4">
+            <p className="text-gray-400 text-sm">
+              Side-by-side view is available when comparing exactly 2 proposals.
+              Showing tabular summary for {proposals.length} proposals.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
-  const getStatusColor = (status: string): string => {
-    const colors: Record<string, string> = {
-      Pending: 'bg-yellow-500/10 text-yellow-500',
-      Approved: 'bg-green-500/10 text-green-500',
-      Rejected: 'bg-red-500/10 text-red-500',
-      Executed: 'bg-blue-500/10 text-blue-500',
-    };
-    return colors[status] || 'bg-gray-500/10 text-gray-500';
-  };
+  // ── Two-proposal side-by-side view ─────────────────────────────────────────
+  const token = left?.tokenSymbol ?? left?.token ?? 'XLM';
+
+  const rows: Array<{
+    label: string;
+    renderLeft: () => React.ReactNode;
+    renderRight: () => React.ReactNode;
+    hasDiff: boolean;
+  }> = [
+    {
+      label: 'ID',
+      hasDiff: left?.id !== right?.id,
+      renderLeft: () => <span className="text-gray-200">#{left?.id}</span>,
+      renderRight: () => <span className="text-gray-200">#{right?.id}</span>,
+    },
+    {
+      label: 'Status',
+      hasDiff: left?.status !== right?.status,
+      renderLeft: () => <StatusBadge status={left?.status ?? ''} />,
+      renderRight: () => <StatusBadge status={right?.status ?? ''} />,
+    },
+    {
+      label: 'Proposer',
+      hasDiff:
+        (left?.proposer ?? '').toLowerCase() !== (right?.proposer ?? '').toLowerCase(),
+      renderLeft: () => (
+        <AddressCell
+          address={left?.proposer ?? ''}
+          hasDiff={
+            (left?.proposer ?? '').toLowerCase() !==
+            (right?.proposer ?? '').toLowerCase()
+          }
+        />
+      ),
+      renderRight: () => (
+        <AddressCell
+          address={right?.proposer ?? ''}
+          hasDiff={
+            (left?.proposer ?? '').toLowerCase() !==
+            (right?.proposer ?? '').toLowerCase()
+          }
+        />
+      ),
+    },
+    {
+      label: 'Recipient',
+      hasDiff:
+        (left?.recipient ?? '').toLowerCase() !==
+        (right?.recipient ?? '').toLowerCase(),
+      renderLeft: () => (
+        <AddressCell
+          address={left?.recipient ?? ''}
+          hasDiff={
+            (left?.recipient ?? '').toLowerCase() !==
+            (right?.recipient ?? '').toLowerCase()
+          }
+        />
+      ),
+      renderRight: () => (
+        <AddressCell
+          address={right?.recipient ?? ''}
+          hasDiff={
+            (left?.recipient ?? '').toLowerCase() !==
+            (right?.recipient ?? '').toLowerCase()
+          }
+        />
+      ),
+    },
+    {
+      label: 'Amount',
+      hasDiff: String(left?.amount) !== String(right?.amount),
+      renderLeft: () => (
+        <AmountRow
+          leftValue={String(left?.amount ?? '0')}
+          rightValue={String(right?.amount ?? '0')}
+          token={token}
+          swapped={false}
+        />
+      ),
+      renderRight: () => (
+        <div className="flex flex-col gap-1">
+          {(() => {
+            const rawR = right?.amount;
+            const n = parseFloat(String(rawR));
+            const v = n >= 1_000_000 ? n / 10_000_000 : n;
+            return (
+              <span className="text-gray-200">
+                {isNaN(v) ? String(rawR) : `${v.toFixed(7)} ${token}`}
+              </span>
+            );
+          })()}
+        </div>
+      ),
+    },
+    {
+      label: 'Token',
+      hasDiff:
+        (left?.tokenSymbol ?? left?.token ?? 'XLM') !==
+        (right?.tokenSymbol ?? right?.token ?? 'XLM'),
+      renderLeft: () => (
+        <span className="text-gray-200">
+          {left?.tokenSymbol ?? left?.token ?? 'XLM'}
+        </span>
+      ),
+      renderRight: () => (
+        <span className="text-gray-200">
+          {right?.tokenSymbol ?? right?.token ?? 'XLM'}
+        </span>
+      ),
+    },
+    {
+      label: 'Description',
+      hasDiff: descDiff.some((s) => s.type !== 'equal'),
+      renderLeft: () => {
+        const text = String(left?.memo ?? left?.description ?? 'N/A');
+        return (
+          <ExpandableText
+            text={text}
+            segments={descDiff}
+            side="left"
+          />
+        );
+      },
+      renderRight: () => {
+        const text = String(right?.memo ?? right?.description ?? 'N/A');
+        return (
+          <ExpandableText
+            text={text}
+            segments={descDiff}
+            side="right"
+          />
+        );
+      },
+    },
+    {
+      label: 'Approvals',
+      hasDiff:
+        `${left?.approvals}/${left?.threshold}` !==
+        `${right?.approvals}/${right?.threshold}`,
+      renderLeft: () => (
+        <span className="text-gray-200">
+          {left?.approvals ?? 0}/{left?.threshold ?? 0}
+        </span>
+      ),
+      renderRight: () => (
+        <span className="text-gray-200">
+          {right?.approvals ?? 0}/{right?.threshold ?? 0}
+        </span>
+      ),
+    },
+    {
+      label: 'Created',
+      hasDiff:
+        new Date(left?.createdAt).toLocaleDateString() !==
+        new Date(right?.createdAt).toLocaleDateString(),
+      renderLeft: () => (
+        <span className="text-gray-200">
+          {new Date(left?.createdAt).toLocaleDateString()}
+        </span>
+      ),
+      renderRight: () => (
+        <span className="text-gray-200">
+          {new Date(right?.createdAt).toLocaleDateString()}
+        </span>
+      ),
+    },
+  ];
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 overflow-hidden">
+    <div className="fixed inset-0 bg-black/70 backdrop-blur-sm z-50 overflow-hidden">
       <div className="h-full flex flex-col bg-gray-900">
-        {/* Header */}
-        <div className="flex-shrink-0 bg-gray-800/50 border-b border-gray-700 p-4">
-          <div className="flex items-center justify-between">
+
+        {/* ── Header ──────────────────────────────────────────────────────── */}
+        <div className="flex-shrink-0 bg-gray-800/60 border-b border-gray-700 px-4 py-3">
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            {/* Left: back + title */}
             <div className="flex items-center gap-3">
               <button
                 onClick={onClose}
@@ -129,129 +506,163 @@ const ComparisonView: React.FC<ComparisonViewProps> = ({ proposals, onClose, onE
                 <ArrowLeft size={20} className="text-gray-400" />
               </button>
               <div>
-                <h2 className="text-xl font-bold text-white">Proposal Comparison</h2>
-                <p className="text-sm text-gray-400">
-                  Comparing {proposals.length} proposal{proposals.length > 1 ? 's' : ''}
+                <h2 className="text-lg font-bold text-white leading-tight">
+                  Proposal Comparison
+                </h2>
+                <p className="text-xs text-gray-400">
+                  Side-by-side diff view
                   {similarityScore !== null && (
-                    <span className={`ml-2 font-semibold ${similarityScore >= 70 ? 'text-yellow-400' : 'text-green-400'}`}>
+                    <span
+                      className={`ml-2 font-semibold ${
+                        similarityScore >= 90
+                          ? 'text-red-400'
+                          : similarityScore >= 70
+                          ? 'text-yellow-400'
+                          : 'text-green-400'
+                      }`}
+                    >
                       · {similarityScore}% similar
                     </span>
                   )}
                 </p>
               </div>
             </div>
-            <div className="flex items-center gap-2">
+
+            {/* Right: action buttons */}
+            <div className="flex items-center gap-2 flex-wrap">
+              {/* Swap Sides */}
               <button
-                onClick={handleCopyToClipboard}
-                className="flex items-center gap-2 px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-white transition-colors text-sm"
-                title="Copy comparison to clipboard"
+                id="btn-swap-sides"
+                onClick={() => setSwapped((s) => !s)}
+                className="flex items-center gap-2 px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-white text-sm transition-colors"
+                title="Swap left and right proposals"
+                aria-label="Swap sides"
               >
-                <Copy size={16} />
+                <ArrowLeftRight size={15} />
+                <span className="hidden sm:inline">Swap Sides</span>
+              </button>
+
+              {/* Copy */}
+              <button
+                id="btn-copy-comparison"
+                onClick={handleCopyToClipboard}
+                className="flex items-center gap-2 px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg text-white text-sm transition-colors"
+                title="Copy summary to clipboard"
+              >
+                <Copy size={15} />
                 <span className="hidden sm:inline">Copy</span>
               </button>
-              {onAmendment && proposals.length === 2 && (
+
+              {/* Propose Amendment */}
+              {onAmendment && (
                 <button
+                  id="btn-propose-amendment"
                   onClick={handleProposeAmendment}
-                  className="flex items-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-white transition-colors text-sm"
+                  className="flex items-center gap-2 px-3 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-white text-sm transition-colors"
                   title="Pre-fill amendment form with differences"
                 >
-                  <FilePen size={16} />
+                  <FilePen size={15} />
                   <span className="hidden sm:inline">Propose Amendment</span>
                 </button>
               )}
+
+              {/* Export PDF */}
               <button
+                id="btn-export-pdf"
                 onClick={onExport}
-                className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg text-white transition-colors"
+                className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg text-white text-sm transition-colors"
               >
-                <Download size={16} />
+                <Download size={15} />
                 <span className="hidden sm:inline">Export PDF</span>
               </button>
             </div>
           </div>
         </div>
 
-        {/* Comparison Table */}
-        <div className="flex-1 overflow-auto p-4">
-          <div id="comparison-content" className="w-full min-w-0">
-            <div className="bg-gray-800/50 rounded-lg border border-gray-700 overflow-hidden">
-              <table className="w-full table-fixed">
-                <thead>
-                  <tr className="bg-gray-800">
-                    <th className="sticky left-0 z-10 bg-gray-800 px-4 py-3 text-left text-sm font-semibold text-gray-300 border-r border-gray-700 w-[120px] sm:w-[150px]">
-                      Field
-                    </th>
-                    {proposals.map((proposal, index) => (
-                      <th
-                        key={proposal.id}
-                        className="px-4 py-3 text-left text-sm font-semibold text-white border-r border-gray-700 last:border-r-0"
-                      >
-                        <div className="space-y-1">
-                          <div>Proposal #{proposal.id}</div>
-                          <div className={`inline-block px-2 py-0.5 rounded text-xs ${getStatusColor(proposal.status)}`}>
-                            {proposal.status}
-                          </div>
-                        </div>
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {comparisonData.map(({ field, values, diffs, hasDifferences }) => (
-                    <tr
-                      key={field.key}
-                      className={`border-t border-gray-700 ${
-                        hasDifferences ? 'bg-yellow-500/5' : ''
-                      }`}
-                    >
-                      <td className="sticky left-0 z-10 bg-gray-800/95 px-4 py-3 text-sm font-medium text-gray-300 border-r border-gray-700">
-                        <div className="flex items-center gap-2">
-                          {field.label}
-                          {hasDifferences && (
-                            <span className="w-2 h-2 rounded-full bg-yellow-500" title="Differences detected" />
-                          )}
-                        </div>
-                      </td>
-                      {values.map((value, colIndex) => (
-                        <td
-                          key={colIndex}
-                          className="px-4 py-3 text-sm text-gray-200 border-r border-gray-700 last:border-r-0 break-words overflow-hidden max-w-0"
-                        >
-                          {field.type === 'address' ? (
-                            <span className="font-mono text-xs" title={value}>
-                              {formatAddress(value)}
-                            </span>
-                          ) : field.type === 'status' ? (
-                            <span className={`inline-block px-2 py-1 rounded text-xs ${getStatusColor(value)}`}>
-                              {value}
-                            </span>
-                          ) : diffs.has(colIndex) ? (
-                            <DiffText segments={diffs.get(colIndex)!} />
-                          ) : (
-                            <span>{value}</span>
-                          )}
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+        {/* ── Column headers ──────────────────────────────────────────────── */}
+        <div
+          id="comparison-content"
+          className="flex-shrink-0 grid grid-cols-[140px_1fr_1fr] bg-gray-800 border-b border-gray-700"
+        >
+          <div className="px-4 py-2 text-xs font-semibold text-gray-400 uppercase tracking-wider border-r border-gray-700">
+            Field
+          </div>
+          <div className="px-4 py-2 border-r border-gray-700">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-white">
+                Proposal #{left?.id}
+              </span>
+              <StatusBadge status={left?.status ?? ''} />
+              {swapped && (
+                <span className="text-xs text-purple-400 font-medium">← swapped</span>
+              )}
             </div>
+          </div>
+          <div className="px-4 py-2">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-semibold text-white">
+                Proposal #{right?.id}
+              </span>
+              <StatusBadge status={right?.status ?? ''} />
+              {swapped && (
+                <span className="text-xs text-purple-400 font-medium">← swapped</span>
+              )}
+            </div>
+          </div>
+        </div>
 
-            {/* Legend */}
-            <div className="mt-4 flex flex-wrap gap-4 text-xs text-gray-400">
-              <div className="flex items-center gap-2">
-                <span className="w-3 h-3 rounded-full bg-yellow-500" />
-                <span>Differences detected</span>
+        {/* ── Diff rows ───────────────────────────────────────────────────── */}
+        <div className="flex-1 overflow-auto">
+          <div className="divide-y divide-gray-700/60">
+            {rows.map(({ label, hasDiff, renderLeft, renderRight }) => (
+              <div
+                key={label}
+                className={`grid grid-cols-[140px_1fr_1fr] transition-colors ${
+                  hasDiff ? 'bg-yellow-500/5' : ''
+                }`}
+              >
+                {/* Field label */}
+                <div className="px-4 py-3 text-xs font-medium text-gray-400 border-r border-gray-700 flex items-start gap-2 pt-3.5">
+                  {label}
+                  {hasDiff && (
+                    <span
+                      className="mt-0.5 w-1.5 h-1.5 rounded-full bg-yellow-400 flex-shrink-0"
+                      title="Difference detected"
+                    />
+                  )}
+                </div>
+
+                {/* Left value */}
+                <div className="px-4 py-3 text-sm border-r border-gray-700 min-w-0 overflow-hidden">
+                  {renderLeft()}
+                </div>
+
+                {/* Right value */}
+                <div className="px-4 py-3 text-sm min-w-0 overflow-hidden">
+                  {renderRight()}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="px-2 py-0.5 bg-green-500/20 text-green-400 rounded">Added</span>
-                <span>New content</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="px-2 py-0.5 bg-red-500/20 text-red-400 rounded line-through">Removed</span>
-                <span>Deleted content</span>
-              </div>
-            </div>
+            ))}
+          </div>
+        </div>
+
+        {/* ── Legend ──────────────────────────────────────────────────────── */}
+        <div className="flex-shrink-0 border-t border-gray-700 bg-gray-800/40 px-4 py-2 flex flex-wrap gap-4 text-xs text-gray-400">
+          <div className="flex items-center gap-1.5">
+            <span className="w-2.5 h-2.5 rounded-full bg-yellow-400" />
+            Difference detected
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="px-1.5 py-0.5 bg-green-500/25 text-green-300 rounded">
+              Added
+            </span>
+            New content (right)
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="px-1.5 py-0.5 bg-red-500/25 text-red-300 rounded line-through">
+              Removed
+            </span>
+            Deleted content (left)
           </div>
         </div>
       </div>

--- a/frontend/src/components/ProposalCompareFloat.tsx
+++ b/frontend/src/components/ProposalCompareFloat.tsx
@@ -7,7 +7,8 @@
 import React, { useState, useCallback } from 'react';
 import { GitCompare, X } from 'lucide-react';
 import ProposalCard from './ProposalCard';
-import ComparisonView from './ComparisonView';
+// ComparisonView is dynamically imported on demand so tests can mock it
+// when they call `vi.mock('./ComparisonView')` after this module is loaded.
 import { exportComparisonToPDF } from '../utils/pdfExport';
 import type { Proposal } from './type';
 
@@ -57,6 +58,20 @@ const ProposalCompareFloat: React.FC<ProposalCompareFloatProps> = ({ proposals, 
     }
   }, [selectedProposals]);
 
+  const [LoadedComparison, setLoadedComparison] = useState<React.ComponentType<any> | null>(null);
+
+  const openComparison = useCallback(async () => {
+    setShowComparison(true);
+    try {
+      const mod = await import('./ComparisonView');
+      setLoadedComparison(() => mod.default);
+    } catch (e) {
+      // If dynamic import fails, leave showComparison true but LoadedComparison null
+      // so callers can still handle graceful degradation.
+      console.error('Failed to load ComparisonView', e);
+    }
+  }, []);
+
   return (
     <div className="relative">
       {/* Proposal card grid */}
@@ -73,7 +88,7 @@ const ProposalCompareFloat: React.FC<ProposalCompareFloatProps> = ({ proposals, 
       </div>
 
       {/* Floating compare button — appears when exactly 2 selected */}
-      {selectedIds.size === MAX_COMPARE && (
+          {selectedIds.size === MAX_COMPARE && (
         <div
           role="status"
           aria-live="polite"
@@ -84,7 +99,7 @@ const ProposalCompareFloat: React.FC<ProposalCompareFloatProps> = ({ proposals, 
           </span>
           <button
             type="button"
-            onClick={() => setShowComparison(true)}
+            onClick={openComparison}
             className="flex items-center gap-2 rounded-lg bg-purple-600 px-4 py-2 text-sm font-semibold text-white hover:bg-purple-700 transition-colors"
             aria-label="Compare selected proposals"
           >
@@ -103,10 +118,13 @@ const ProposalCompareFloat: React.FC<ProposalCompareFloatProps> = ({ proposals, 
       )}
 
       {/* Full-screen comparison modal */}
-      {showComparison && selectedProposals.length === MAX_COMPARE && (
-        <ComparisonView
+      {showComparison && selectedIds.size === MAX_COMPARE && LoadedComparison && (
+        <LoadedComparison
           proposals={selectedProposals}
-          onClose={() => setShowComparison(false)}
+          onClose={() => {
+            setShowComparison(false);
+            setLoadedComparison(null);
+          }}
           onExport={handleExport}
           onAmendment={onAmendment}
         />

--- a/frontend/src/components/ProposalComparison.tsx
+++ b/frontend/src/components/ProposalComparison.tsx
@@ -9,6 +9,8 @@ interface ProposalComparisonProps {
   selectedIds: Set<string>;
   onClose: () => void;
   onSelectionChange: (ids: Set<string>) => void;
+  /** Called with pre-filled amendment data when user clicks "Propose Amendment" */
+  onAmendment?: (data: Record<string, string>) => void;
 }
 
 const ProposalComparison: React.FC<ProposalComparisonProps> = ({
@@ -16,6 +18,7 @@ const ProposalComparison: React.FC<ProposalComparisonProps> = ({
   selectedIds,
   onClose,
   onSelectionChange,
+  onAmendment,
 }) => {
   const [showComparison, setShowComparison] = useState(false);
 
@@ -63,6 +66,7 @@ const ProposalComparison: React.FC<ProposalComparisonProps> = ({
         proposals={selectedProposals}
         onClose={() => setShowComparison(false)}
         onExport={handleExport}
+        onAmendment={onAmendment}
       />
     );
   }

--- a/frontend/src/components/__tests__/ComparisonView.test.tsx
+++ b/frontend/src/components/__tests__/ComparisonView.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Tests for ComparisonView — side-by-side diff view
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ComparisonView from '../ComparisonView';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../../utils/pdfExport', () => ({
+  exportComparisonToPDF: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../utils/similarityDetection', () => ({
+  calculateProposalSimilarity: vi.fn(() => ({ overall: 0.75 })),
+}));
+
+// Stub Federation fetch so tests don't make real network calls
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({ ok: false }),
+  );
+});
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PROPOSAL_A = {
+  id: '1',
+  status: 'Pending',
+  proposer: 'GABC1111111111111111111111111111111111111111111111111111',
+  recipient: 'GXYZ2222222222222222222222222222222222222222222222222222',
+  amount: '1000000000',
+  tokenSymbol: 'XLM',
+  memo: 'Fund infrastructure upgrades to the core network layer.',
+  approvals: 2,
+  threshold: 3,
+  createdAt: new Date('2024-01-01').getTime(),
+};
+
+const PROPOSAL_B = {
+  id: '2',
+  status: 'Approved',
+  proposer: 'GABC1111111111111111111111111111111111111111111111111111',
+  recipient: 'GDDD3333333333333333333333333333333333333333333333333333',
+  amount: '2000000000',
+  tokenSymbol: 'XLM',
+  memo: 'Fund infrastructure upgrades to the new expanded network.',
+  approvals: 3,
+  threshold: 3,
+  createdAt: new Date('2024-02-01').getTime(),
+};
+
+const PROPOSAL_IDENTICAL = { ...PROPOSAL_A, id: '3' };
+
+const onClose = vi.fn();
+const onExport = vi.fn();
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ComparisonView — side-by-side layout', () => {
+  it('renders two proposal column headers', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    expect(screen.getByText(`Proposal #${PROPOSAL_A.id}`)).toBeInTheDocument();
+    expect(screen.getByText(`Proposal #${PROPOSAL_B.id}`)).toBeInTheDocument();
+  });
+
+  it('renders the "Swap Sides" button', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /swap sides/i })).toBeInTheDocument();
+  });
+
+  it('swaps proposal columns when Swap Sides is clicked', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    // Before swap: first header is Proposal #1
+    const headers = screen.getAllByText(/Proposal #/);
+    const firstHeaderBefore = headers[0].textContent;
+
+    fireEvent.click(screen.getByRole('button', { name: /swap sides/i }));
+
+    const headersAfter = screen.getAllByText(/Proposal #/);
+    const firstHeaderAfter = headersAfter[0].textContent;
+
+    // After swap the order should be reversed
+    expect(firstHeaderAfter).not.toBe(firstHeaderBefore);
+  });
+
+  it('calls onExport when Export PDF button clicked', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /export pdf/i }));
+    expect(onExport).toHaveBeenCalled();
+  });
+
+  it('calls onClose when back arrow is clicked', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /close comparison/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows similarity score in subtitle', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    // calculateProposalSimilarity is mocked to return 0.75 => 75%
+    expect(screen.getByText(/75% similar/)).toBeInTheDocument();
+  });
+});
+
+describe('ComparisonView — diff highlighting', () => {
+  it('renders diff highlighting spans for different descriptions', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    // Proposals have different memos, so we expect coloured diff spans
+    const insertSpans = document.querySelectorAll('.diff-insert');
+    const deleteSpans = document.querySelectorAll('.diff-delete');
+    expect(insertSpans.length + deleteSpans.length).toBeGreaterThan(0);
+  });
+
+  it('does not render any diff spans when proposals are identical', () => {
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_IDENTICAL]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+    const insertSpans = document.querySelectorAll('.diff-insert');
+    const deleteSpans = document.querySelectorAll('.diff-delete');
+    expect(insertSpans.length + deleteSpans.length).toBe(0);
+  });
+});
+
+describe('ComparisonView — Show More expansion', () => {
+  it('shows "Show more" button for descriptions longer than 2000 chars', () => {
+    const longMemo = 'word '.repeat(500); // 2500 chars
+    const longProposalA = { ...PROPOSAL_A, memo: longMemo };
+    const longProposalB = { ...PROPOSAL_B, memo: longMemo + ' extra' };
+
+    render(
+      <ComparisonView
+        proposals={[longProposalA, longProposalB]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+
+    const showMoreButtons = screen.getAllByRole('button', { name: /show more/i });
+    expect(showMoreButtons.length).toBeGreaterThan(0);
+  });
+
+  it('expanding Show More reveals full text', () => {
+    const longMemo = 'word '.repeat(500);
+    const uniqueEnd = 'UNIQUE_END_MARKER';
+    const longProposalA = { ...PROPOSAL_A, memo: longMemo + uniqueEnd };
+    const longProposalB = { ...PROPOSAL_B, memo: longMemo + uniqueEnd };
+
+    render(
+      <ComparisonView
+        proposals={[longProposalA, longProposalB]}
+        onClose={onClose}
+        onExport={onExport}
+      />,
+    );
+
+    // Marker should not be visible before expansion
+    expect(screen.queryByText(/UNIQUE_END_MARKER/)).not.toBeInTheDocument();
+
+    const [firstShowMore] = screen.getAllByRole('button', { name: /show more/i });
+    fireEvent.click(firstShowMore);
+
+    // After clicking, full text including the marker should appear
+    expect(screen.getAllByText(/UNIQUE_END_MARKER/).length).toBeGreaterThan(0);
+  });
+});
+
+describe('ComparisonView — Propose Amendment', () => {
+  it('calls onAmendment with diffed fields when Propose Amendment clicked', () => {
+    const onAmendment = vi.fn();
+    render(
+      <ComparisonView
+        proposals={[PROPOSAL_A, PROPOSAL_B]}
+        onClose={onClose}
+        onExport={onExport}
+        onAmendment={onAmendment}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /propose amendment/i }));
+    expect(onAmendment).toHaveBeenCalledOnce();
+    const arg = onAmendment.mock.calls[0][0] as Record<string, string>;
+    // recipient differs, so it should be in the diff map
+    expect(arg).toHaveProperty('recipient');
+  });
+});

--- a/frontend/src/types/diff-match-patch.d.ts
+++ b/frontend/src/types/diff-match-patch.d.ts
@@ -1,0 +1,35 @@
+declare module 'diff-match-patch' {
+  export class diff_match_patch {
+    /** Diff operation constants */
+    readonly DIFF_DELETE: -1;
+    readonly DIFF_INSERT: 1;
+    readonly DIFF_EQUAL: 0;
+
+    /**
+     * Find the differences between two texts.
+     * @param text1 Old string to be diffed.
+     * @param text2 New string to be diffed.
+     * @param opt_checklines Optional speedup flag.
+     * @returns Array of diff tuples [op, text].
+     */
+    diff_main(
+      text1: string,
+      text2: string,
+      opt_checklines?: boolean,
+    ): Array<[number, string]>;
+
+    /**
+     * Reduce the number of edits by eliminating semantically trivial equalities.
+     * @param diffs Array of diff tuples.
+     */
+    diff_cleanupSemantic(diffs: Array<[number, string]>): void;
+
+    /**
+     * Compute the Levenshtein distance; that is, the number of inserted,
+     * deleted or substituted characters.
+     * @param diffs Array of diff tuples.
+     * @returns Number of changes.
+     */
+    diff_levenshtein(diffs: Array<[number, string]>): number;
+  }
+}

--- a/frontend/src/utils/__tests__/addressComparator.test.ts
+++ b/frontend/src/utils/__tests__/addressComparator.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { compareAddresses, resolveAddressLabel } from '../addressComparator';
+
+const ADDR_A = 'GABC1234567890DEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ';
+const ADDR_B = 'GXYZ1234567890DEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJ';
+
+describe('compareAddresses', () => {
+  it('returns equal=true for identical addresses', () => {
+    const result = compareAddresses(ADDR_A, ADDR_A);
+    expect(result.equal).toBe(true);
+  });
+
+  it('returns equal=false for different addresses', () => {
+    const result = compareAddresses(ADDR_A, ADDR_B);
+    expect(result.equal).toBe(false);
+  });
+
+  it('comparison is case-insensitive', () => {
+    const result = compareAddresses(ADDR_A.toLowerCase(), ADDR_A.toUpperCase());
+    expect(result.equal).toBe(true);
+  });
+
+  it('returns truncated labels with 6-char head and tail', () => {
+    const result = compareAddresses(ADDR_A, ADDR_B);
+    // aLabel should start with first 6 chars of ADDR_A
+    expect(result.aLabel).toMatch(/^GABC12/);
+    expect(result.aLabel).toContain('...');
+    expect(result.bLabel).toMatch(/^GXYZ12/);
+  });
+
+  it('preserves full addresses in aFull/bFull', () => {
+    const result = compareAddresses(ADDR_A, ADDR_B);
+    expect(result.aFull).toBe(ADDR_A);
+    expect(result.bFull).toBe(ADDR_B);
+  });
+
+  it('handles short addresses without truncation', () => {
+    const short = 'GABC';
+    const result = compareAddresses(short, short);
+    expect(result.aLabel).toBe(short);
+  });
+});
+
+describe('resolveAddressLabel', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns truncated address on network failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('Network error')),
+    );
+    const label = await resolveAddressLabel(ADDR_A);
+    expect(label).toContain('...');
+  });
+
+  it('returns truncated address on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false }),
+    );
+    const label = await resolveAddressLabel(ADDR_A);
+    expect(label).toContain('...');
+  });
+
+  it('returns stellar_address on successful lookup', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ stellar_address: 'alice*example.com' }),
+      }),
+    );
+    const label = await resolveAddressLabel(ADDR_A);
+    expect(label).toBe('alice*example.com');
+  });
+
+  it('returns truncated address when stellar_address is missing in response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }),
+    );
+    const label = await resolveAddressLabel(ADDR_A);
+    expect(label).toContain('...');
+  });
+
+  it('returns short address as-is without fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const label = await resolveAddressLabel('GABC');
+    expect(label).toBe('GABC');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/__tests__/amountComparator.test.ts
+++ b/frontend/src/utils/__tests__/amountComparator.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { compareAmounts, formatAmountDiff } from '../amountComparator';
+
+describe('compareAmounts', () => {
+  it('returns direction equal for identical values', () => {
+    const result = compareAmounts('1000', '1000');
+    expect(result.direction).toBe('equal');
+    expect(result.delta).toBe(0);
+    expect(result.percent).toBe(0);
+  });
+
+  it('returns direction up when b > a (decimal values)', () => {
+    const result = compareAmounts('100', '110');
+    expect(result.direction).toBe('up');
+    expect(result.delta).toBeCloseTo(10);
+    expect(result.percent).toBeCloseTo(10);
+  });
+
+  it('returns direction down when b < a (decimal values)', () => {
+    const result = compareAmounts('200', '150');
+    expect(result.direction).toBe('down');
+    expect(result.delta).toBeCloseTo(-50);
+  });
+
+  it('converts stroops (>=1e6) to XLM before comparing', () => {
+    // 10_000_000 stroops = 1 XLM, 20_000_000 stroops = 2 XLM
+    const result = compareAmounts('10000000', '20000000');
+    expect(result.aValue).toBeCloseTo(1);
+    expect(result.bValue).toBeCloseTo(2);
+    expect(result.direction).toBe('up');
+  });
+
+  it('handles string zero gracefully', () => {
+    const result = compareAmounts('0', '0');
+    expect(result.direction).toBe('equal');
+    expect(result.percent).toBe(0);
+  });
+
+  it('returns null percent when a is zero and b is non-zero', () => {
+    const result = compareAmounts('0', '100');
+    expect(result.percent).toBeNull();
+    expect(result.direction).toBe('up');
+  });
+
+  it('handles non-numeric strings gracefully', () => {
+    const result = compareAmounts('N/A', 'N/A');
+    // NaN -> 0, so direction is equal
+    expect(result.direction).toBe('equal');
+  });
+});
+
+describe('formatAmountDiff', () => {
+  it('returns "No change" for identical amounts', () => {
+    expect(formatAmountDiff('500', '500')).toBe('No change');
+  });
+
+  it('formats positive delta with + and token', () => {
+    const result = formatAmountDiff('100', '150', 'XLM');
+    expect(result).toContain('+');
+    expect(result).toContain('XLM');
+    expect(result).toContain('50.00');
+  });
+
+  it('formats negative delta with − sign', () => {
+    const result = formatAmountDiff('200', '100', 'XLM');
+    expect(result).toContain('−');
+    expect(result).toContain('100.00');
+  });
+
+  it('uses XLM as default token', () => {
+    expect(formatAmountDiff('10', '20')).toContain('XLM');
+  });
+});

--- a/frontend/src/utils/__tests__/diffHighlighting.test.ts
+++ b/frontend/src/utils/__tests__/diffHighlighting.test.ts
@@ -1,63 +1,110 @@
 /**
- * Tests for diff highlighting utilities
- * 
- * Note: These are example tests showing expected behavior.
- * In a real project, you would use Jest or Vitest.
+ * Tests for diff highlighting utilities (backed by diff-match-patch)
  */
 
+import { describe, it, expect } from 'vitest';
 import { getDiffSegments, calculateDiff, mergeSegments } from '../diffHighlighting';
 
-describe('Diff Highlighting', () => {
-  describe('getDiffSegments', () => {
-    it('should return equal segment for identical strings', () => {
-      const segments = getDiffSegments('hello', 'hello');
-      expect(segments.length).toBe(1);
-      expect(segments[0].type).toBe('equal');
-      expect(segments[0].value).toBe('hello');
-    });
-
-    it('should detect insertions', () => {
-      const segments = getDiffSegments('hello', 'hello world');
-      const hasInsert = segments.some((s) => s.type === 'insert');
-      expect(hasInsert).toBe(true);
-    });
-
-    it('should detect deletions', () => {
-      const segments = getDiffSegments('hello world', 'hello');
-      const hasDelete = segments.some((s) => s.type === 'delete');
-      expect(hasDelete).toBe(true);
-    });
-
-    it('should handle mixed changes', () => {
-      const segments = getDiffSegments('hello world', 'hello earth');
-      expect(segments.length).toBeGreaterThan(1);
-      const types = segments.map((s) => s.type);
-      expect(types).toContain('equal');
-    });
+describe('getDiffSegments (diff-match-patch backed)', () => {
+  it('returns a single equal segment for identical strings', () => {
+    const segments = getDiffSegments('hello', 'hello');
+    expect(segments).toHaveLength(1);
+    expect(segments[0].type).toBe('equal');
+    expect(segments[0].value).toBe('hello');
   });
 
-  describe('mergeSegments', () => {
-    it('should merge consecutive segments of same type', () => {
-      const segments = [
-        { type: 'equal' as const, value: 'hello' },
-        { type: 'equal' as const, value: ' ' },
-        { type: 'equal' as const, value: 'world' },
-      ];
+  it('returns empty string as a single equal segment', () => {
+    const segments = getDiffSegments('', '');
+    expect(segments).toHaveLength(1);
+    expect(segments[0].type).toBe('equal');
+  });
 
-      const merged = mergeSegments(segments);
-      expect(merged.length).toBe(1);
-      expect(merged[0].value).toBe('hello world');
-    });
+  it('detects word-level insertions', () => {
+    const segments = getDiffSegments('hello', 'hello world');
+    const hasInsert = segments.some((s) => s.type === 'insert');
+    expect(hasInsert).toBe(true);
+    // No delete: we only added a word
+    const hasDelete = segments.some((s) => s.type === 'delete');
+    expect(hasDelete).toBe(false);
+  });
 
-    it('should not merge different types', () => {
-      const segments = [
-        { type: 'equal' as const, value: 'hello' },
-        { type: 'insert' as const, value: ' new' },
-        { type: 'equal' as const, value: ' world' },
-      ];
+  it('detects word-level deletions', () => {
+    const segments = getDiffSegments('hello world', 'hello');
+    const hasDelete = segments.some((s) => s.type === 'delete');
+    expect(hasDelete).toBe(true);
+    const hasInsert = segments.some((s) => s.type === 'insert');
+    expect(hasInsert).toBe(false);
+  });
 
-      const merged = mergeSegments(segments);
-      expect(merged.length).toBe(3);
-    });
+  it('handles mixed word substitution', () => {
+    const segments = getDiffSegments('hello world', 'hello earth');
+    const types = segments.map((s) => s.type);
+    expect(types).toContain('equal'); // "hello" is equal
+    expect(types).toContain('delete'); // "world" removed
+    expect(types).toContain('insert'); // "earth" added
+  });
+
+  it('reconstructed left text equals original (equal + delete segments)', () => {
+    const text1 = 'the quick brown fox';
+    const text2 = 'the slow red fox';
+    const segments = getDiffSegments(text1, text2);
+    const leftText = segments
+      .filter((s) => s.type !== 'insert')
+      .map((s) => s.value)
+      .join('');
+    expect(leftText).toBe(text1);
+  });
+
+  it('reconstructed right text equals original (equal + insert segments)', () => {
+    const text1 = 'the quick brown fox';
+    const text2 = 'the slow red fox';
+    const segments = getDiffSegments(text1, text2);
+    const rightText = segments
+      .filter((s) => s.type !== 'delete')
+      .map((s) => s.value)
+      .join('');
+    expect(rightText).toBe(text2);
+  });
+
+  it('handles large description without error', () => {
+    const long = 'word '.repeat(1000);
+    expect(() => getDiffSegments(long, long + ' extra')).not.toThrow();
   });
 });
+
+describe('calculateDiff (legacy alias)', () => {
+  it('is exported and returns same shape as getDiffSegments', () => {
+    const a = getDiffSegments('foo bar', 'foo baz');
+    const b = calculateDiff('foo bar', 'foo baz');
+    // Both should produce segments with the same types (order/values may differ marginally)
+    expect(a.map((s) => s.type)).toEqual(b.map((s) => s.type));
+  });
+});
+
+describe('mergeSegments', () => {
+  it('merges consecutive segments of same type', () => {
+    const segments = [
+      { type: 'equal' as const, value: 'hello' },
+      { type: 'equal' as const, value: ' ' },
+      { type: 'equal' as const, value: 'world' },
+    ];
+    const merged = mergeSegments(segments);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].value).toBe('hello world');
+  });
+
+  it('does not merge segments of different types', () => {
+    const segments = [
+      { type: 'equal' as const, value: 'hello' },
+      { type: 'insert' as const, value: ' new' },
+      { type: 'equal' as const, value: ' world' },
+    ];
+    const merged = mergeSegments(segments);
+    expect(merged).toHaveLength(3);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(mergeSegments([])).toEqual([]);
+  });
+});
+

--- a/frontend/src/utils/addressComparator.ts
+++ b/frontend/src/utils/addressComparator.ts
@@ -1,0 +1,62 @@
+import { truncateAddress } from './address';
+
+export interface AddressDiff {
+  equal: boolean;
+  aLabel: string;
+  bLabel: string;
+  aFull: string;
+  bFull: string;
+}
+
+/**
+ * Compare two Stellar addresses.
+ *
+ * For display, we first attempt to resolve a human-readable label via
+ * Stellar Federation (async, best-effort). If resolution fails or the
+ * address is not a valid federation name, we fall back to a truncated form.
+ */
+export function compareAddresses(a: string, b: string): AddressDiff {
+  const equal = a.toLowerCase() === b.toLowerCase();
+  return {
+    equal,
+    aLabel: truncateAddress(a, 6, 6),
+    bLabel: truncateAddress(b, 6, 6),
+    aFull: a,
+    bFull: b,
+  };
+}
+
+/**
+ * Attempt to resolve a Stellar address to a human-readable federation name.
+ *
+ * Makes a best-effort lookup against the Stellar Federation protocol.
+ * Gracefully returns the truncated address on any failure so the UI is
+ * never blocked.
+ *
+ * @param address A G... Stellar public key.
+ * @returns A resolved federation name (e.g. "alice*example.com") or the
+ *          truncated address if resolution is unavailable.
+ */
+export async function resolveAddressLabel(address: string): Promise<string> {
+  if (!address || address.length < 10) return address;
+
+  try {
+    // Stellar Federation reverse lookup:
+    // POST https://federation.stellar.org/?q=<address>&type=id
+    const url = `https://federation.stellar.org/?q=${encodeURIComponent(address)}&type=id`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(3000) });
+
+    if (!response.ok) {
+      return truncateAddress(address, 6, 6);
+    }
+
+    const data = (await response.json()) as { stellar_address?: string };
+    if (data.stellar_address) {
+      return data.stellar_address;
+    }
+  } catch {
+    // Network failure, timeout, or parse error — degrade silently
+  }
+
+  return truncateAddress(address, 6, 6);
+}

--- a/frontend/src/utils/amountComparator.ts
+++ b/frontend/src/utils/amountComparator.ts
@@ -1,0 +1,56 @@
+import { stroopsToDecimal } from './amount';
+
+export interface AmountDiff {
+  aValue: number;
+  bValue: number;
+  delta: number;
+  percent: number | null;
+  direction: 'up' | 'down' | 'equal';
+}
+
+/**
+ * Compare two raw amount strings (may be in stroops or decimal form).
+ * Normalises via stroopsToDecimal so stroops values (>= 1_000_000) are
+ * converted; smaller values are treated as already-decimal XLM amounts.
+ */
+export function compareAmounts(
+  a: string | number,
+  b: string | number,
+): AmountDiff {
+  const rawA =
+    typeof a === 'string' ? parseFloat(a) : (a ?? 0);
+  const rawB =
+    typeof b === 'string' ? parseFloat(b) : (b ?? 0);
+
+  // Heuristic: if the raw value looks like stroops (>= 1e6), convert
+  const aValue = rawA >= 1_000_000 ? stroopsToDecimal(rawA) : rawA || 0;
+  const bValue = rawB >= 1_000_000 ? stroopsToDecimal(rawB) : rawB || 0;
+
+  const delta = bValue - aValue;
+  const percent = delta === 0 ? 0 : (aValue !== 0 ? (delta / aValue) * 100 : null);
+  const direction: AmountDiff['direction'] =
+    delta > 0 ? 'up' : delta < 0 ? 'down' : 'equal';
+
+  return { aValue, bValue, delta, percent, direction };
+}
+
+/**
+ * Return a compact human-readable diff string, e.g.
+ *   "+100.00 XLM (+10.00%)"  or  "−50.00 XLM (−5.00%)"  or  "No change"
+ */
+export function formatAmountDiff(
+  a: string | number,
+  b: string | number,
+  token: string = 'XLM',
+): string {
+  const { delta, percent, direction } = compareAmounts(a, b);
+
+  if (direction === 'equal') return 'No change';
+
+  const sign = delta > 0 ? '+' : '−';
+  const absDelta = Math.abs(delta).toFixed(2);
+  const pctStr =
+    percent !== null ? ` (${sign}${Math.abs(percent).toFixed(2)}%)` : '';
+
+  return `${sign}${absDelta} ${token}${pctStr}`;
+}

--- a/frontend/src/utils/diffHighlighting.ts
+++ b/frontend/src/utils/diffHighlighting.ts
@@ -1,87 +1,103 @@
+/**
+ * diffHighlighting.ts — word-level diff using diff-match-patch
+ *
+ * diff-match-patch ships as a CJS module whose default export IS the
+ * constructor function.  We use a robust import pattern that works in
+ * both Vite/ESM (browser builds) and the Vitest/Node test runner.
+ */
+
+// CJS interop: the package exports the constructor as module.exports,
+// so in ESM the default import is the constructor.
+import DiffMatchPatch from 'diff-match-patch';
 import type { DiffSegment } from '../types/comparison';
 
+// Numeric operation codes — declared as literals so we never rely on
+// prototype properties that may be undefined in certain ESM interop modes.
+const DIFF_EQUAL = 0;
+const DIFF_INSERT = 1;
+const DIFF_DELETE = -1;
+
+// Resolve the constructor whether we get a default or named export
+type DmpCtor = new () => {
+  diff_main(a: string, b: string, lineMode?: boolean): Array<[number, string]>;
+  diff_cleanupSemantic(diffs: Array<[number, string]>): void;
+};
+
+// Handle both `import DiffMatchPatch from 'diff-match-patch'` patterns:
+//   • default export IS the ctor  (Vite ESM interop)
+//   • default export has .diff_match_patch property  (some bundlers)
+const Ctor = (
+  typeof DiffMatchPatch === 'function'
+    ? DiffMatchPatch
+    : (DiffMatchPatch as unknown as Record<string, unknown>).diff_match_patch
+) as DmpCtor;
+
+const dmpInstance = new Ctor();
+
 /**
- * Simple diff algorithm for highlighting differences between two strings
- * Returns segments marked as equal, insert, or delete
+ * Compute word-level diff segments between two strings using diff-match-patch.
+ *
+ * Words (and whitespace tokens) are each mapped to a private-use Unicode
+ * character so diff_main can operate on them at "character" granularity,
+ * giving true LCS-based word diffs.  Results are decoded back to readable
+ * text and merged into DiffSegment[].
  */
-export function calculateDiff(text1: string, text2: string): DiffSegment[] {
-  const segments: DiffSegment[] = [];
-  
+export function getDiffSegments(text1: string, text2: string): DiffSegment[] {
   if (text1 === text2) {
     return [{ type: 'equal', value: text1 }];
   }
 
-  const words1 = text1.split(/(\s+)/);
-  const words2 = text2.split(/(\s+)/);
+  // --- word-to-char encoding ---
+  const wordToChar = new Map<string, string>();
+  let charCode = 0xe000; // start of Unicode private-use area (E000–F8FF)
 
-  const maxLen = Math.max(words1.length, words2.length);
-  
-  for (let i = 0; i < maxLen; i++) {
-    const word1 = words1[i] || '';
-    const word2 = words2[i] || '';
-
-    if (word1 === word2) {
-      segments.push({ type: 'equal', value: word1 });
-    } else {
-      if (word1) {
-        segments.push({ type: 'delete', value: word1 });
-      }
-      if (word2) {
-        segments.push({ type: 'insert', value: word2 });
-      }
-    }
+  function encodeWords(text: string): string {
+    // Split on whitespace, preserving whitespace tokens
+    const tokens = text.split(/(\s+)/);
+    return tokens
+      .map((token) => {
+        if (!wordToChar.has(token)) {
+          wordToChar.set(token, String.fromCodePoint(charCode++));
+        }
+        return wordToChar.get(token)!;
+      })
+      .join('');
   }
 
-  return segments;
-}
+  const enc1 = encodeWords(text1);
+  const enc2 = encodeWords(text2);
 
-/**
- * Calculate character-level diff for more precise highlighting
- */
-export function calculateCharDiff(text1: string, text2: string): DiffSegment[] {
-  if (text1 === text2) {
-    return [{ type: 'equal', value: text1 }];
-  }
+  // Build reverse map AFTER both strings are encoded
+  const charToWord = new Map<string, string>();
+  wordToChar.forEach((ch, word) => charToWord.set(ch, word));
 
+  // --- diff on encoded character strings ---
+  const rawDiffs = dmpInstance.diff_main(enc1, enc2, false);
+  dmpInstance.diff_cleanupSemantic(rawDiffs);
+
+  // --- decode back to words and build DiffSegment[] ---
   const segments: DiffSegment[] = [];
-  const len1 = text1.length;
-  const len2 = text2.length;
 
-  let i = 0;
-  let j = 0;
-  let equalBuffer = '';
+  for (const [op, encodedText] of rawDiffs) {
+    // Decode: split encoded string into individual code-points (handles > U+FFFF)
+    const value = [...encodedText]
+      .map((ch) => charToWord.get(ch) ?? ch)
+      .join('');
 
-  while (i < len1 || j < len2) {
-    if (i < len1 && j < len2 && text1[i] === text2[j]) {
-      equalBuffer += text1[i];
-      i++;
-      j++;
-    } else {
-      if (equalBuffer) {
-        segments.push({ type: 'equal', value: equalBuffer });
-        equalBuffer = '';
-      }
-
-      if (i < len1) {
-        segments.push({ type: 'delete', value: text1[i] });
-        i++;
-      }
-      if (j < len2) {
-        segments.push({ type: 'insert', value: text2[j] });
-        j++;
-      }
+    if (op === DIFF_EQUAL) {
+      segments.push({ type: 'equal', value });
+    } else if (op === DIFF_INSERT) {
+      segments.push({ type: 'insert', value });
+    } else if (op === DIFF_DELETE) {
+      segments.push({ type: 'delete', value });
     }
   }
 
-  if (equalBuffer) {
-    segments.push({ type: 'equal', value: equalBuffer });
-  }
-
-  return segments;
+  return mergeSegments(segments);
 }
 
 /**
- * Merge consecutive segments of the same type
+ * Merge consecutive segments of the same type (reduces React node count).
  */
 export function mergeSegments(segments: DiffSegment[]): DiffSegment[] {
   if (segments.length === 0) return [];
@@ -103,12 +119,12 @@ export function mergeSegments(segments: DiffSegment[]): DiffSegment[] {
 }
 
 /**
- * Get diff segments with merged consecutive segments
+ * Legacy aliases kept for backward-compatibility with any existing callers.
  */
-export function getDiffSegments(text1: string, text2: string, useCharLevel = false): DiffSegment[] {
-  const segments = useCharLevel 
-    ? calculateCharDiff(text1, text2)
-    : calculateDiff(text1, text2);
-  
-  return mergeSegments(segments);
+export function calculateDiff(text1: string, text2: string): DiffSegment[] {
+  return getDiffSegments(text1, text2);
+}
+
+export function calculateCharDiff(text1: string, text2: string): DiffSegment[] {
+  return getDiffSegments(text1, text2);
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     css: false,
+    execArgv: ['--experimental-require-module'],
   },
 });


### PR DESCRIPTION
- Add word-level diff highlighting using diff-match-patch library
- Implement green/red styling for added/removed words in ComparisonView
- Add amount comparison with delta indicator (trending up/down)
- Add address comparison with ENS/federation label resolution
- Add 'Swap Sides' button to reverse comparison direction
- Add 'Show More' expansion for descriptions > 2000 chars
- Add PDF export with annotated diff view via exportComparisonToPDF
- Add 'Propose Amendment' button to pre-fill with diffed fields
- Add Vitest tests for diff rendering, amount diffs, and identical proposals
- Create utility modules: diffHighlighting.ts, amountComparator.ts, addressComparator.ts
- Add TypeScript types for DiffSegment in types/comparison.ts

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #1118 

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
