### PR TITLE
feat: implement semantic snapshot diff (#1160) and jitter-aware due-d…

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -31,6 +31,8 @@ export interface BackendEnv {
   readonly rateLimitProposalsPerMin: number;
   readonly rateLimitExecutePerMin: number;
   readonly rateLimitDefaultPerMin: number;
+  /** Maximum ledger jitter window for due-payment queries (default: 10 ledgers). */
+  readonly jitterWindowMax: number;
 }
 
 const DEFAULT_CONTRACT_ID =
@@ -236,6 +238,7 @@ export function createTestEnv(overrides: Partial<BackendEnv> = {}): BackendEnv {
     rateLimitProposalsPerMin: 100,
     rateLimitExecutePerMin: 10,
     rateLimitDefaultPerMin: 60,
+    jitterWindowMax: 10,
     ...overrides,
   };
 }
@@ -322,6 +325,7 @@ export function loadEnv(): BackendEnv {
     60,
     issues,
   );
+  const jitterWindowMax = readPort("JITTER_WINDOW_MAX", 10, issues);
 
   validateRequiredString("HOST", host, issues);
   validateAllowedValue("NODE_ENV", nodeEnv, ALLOWED_NODE_ENVS, issues);
@@ -405,5 +409,6 @@ export function loadEnv(): BackendEnv {
     rateLimitProposalsPerMin,
     rateLimitExecutePerMin,
     rateLimitDefaultPerMin,
+    jitterWindowMax,
   };
 }

--- a/backend/src/modules/health/metrics.registry.ts
+++ b/backend/src/modules/health/metrics.registry.ts
@@ -139,3 +139,52 @@ export class MetricsRegistry {
     return PrometheusFormatter.format(this.snapshot());
   }
 }
+
+// ── Due-Payment Keeper Metric Names ──────────────────────────────────────────
+
+/** Counter: payments triggered with exact ledger match. */
+export const DUE_PAYMENT_EXACT_COUNTER = "due_payments_triggered_exact_total";
+/** Counter: payments triggered via early jitter window. */
+export const DUE_PAYMENT_JITTER_EARLY_COUNTER =
+  "due_payments_triggered_jitter_early_total";
+/** Counter: payments triggered via late jitter window. */
+export const DUE_PAYMENT_JITTER_LATE_COUNTER =
+  "due_payments_triggered_jitter_late_total";
+/** Counter: payments skipped due to idempotency set hit. */
+export const DUE_PAYMENT_IDEMPOTENCY_HIT_COUNTER =
+  "due_payments_idempotency_hits_total";
+/** Gauge: number of payments processed in the last batch. */
+export const DUE_PAYMENT_BATCH_SIZE_GAUGE = "due_payments_batch_size";
+
+/**
+ * Register all due-payment keeper metrics on the given registry.
+ *
+ * Call once at startup (idempotent — re-registration overwrites metadata).
+ */
+export function registerDuePaymentMetrics(registry: MetricsRegistry): void {
+  registry.register(
+    DUE_PAYMENT_EXACT_COUNTER,
+    "Total recurring payments triggered at their exact due ledger",
+    "counter",
+  );
+  registry.register(
+    DUE_PAYMENT_JITTER_EARLY_COUNTER,
+    "Total recurring payments triggered early via on-chain jitter window",
+    "counter",
+  );
+  registry.register(
+    DUE_PAYMENT_JITTER_LATE_COUNTER,
+    "Total recurring payments triggered late via on-chain jitter window",
+    "counter",
+  );
+  registry.register(
+    DUE_PAYMENT_IDEMPOTENCY_HIT_COUNTER,
+    "Total payment triggers skipped due to idempotency set (duplicate prevention)",
+    "counter",
+  );
+  registry.register(
+    DUE_PAYMENT_BATCH_SIZE_GAUGE,
+    "Number of due payments processed in the most recent keeper invocation",
+    "gauge",
+  );
+}

--- a/backend/src/modules/jobs/recurring/due-payments-job.test.ts
+++ b/backend/src/modules/jobs/recurring/due-payments-job.test.ts
@@ -3,11 +3,16 @@ import test from "node:test";
 import {
   createDuePaymentsScheduledJob,
   registerDuePaymentsJob,
+  IdempotencySet,
 } from "./due-payments-job.js";
 import { RecurringStatus } from "../../recurring/types.js";
 import type { BackendEnv } from "../../../config/env.js";
 import type { NotificationEvent } from "../../notifications/notification.types.js";
 import type { RecurringPaymentDueNotification } from "../../notifications/notification.types.js";
+import { MetricsRegistry } from "../../health/metrics.registry.js";
+import type { DuePaymentResult } from "../../recurring/recurring.service.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function makeEnv(overrides?: Partial<BackendEnv>): BackendEnv {
   return {
@@ -33,6 +38,7 @@ function makeEnv(overrides?: Partial<BackendEnv>): BackendEnv {
     apiKey: "test-api-key",
     cursorStorageType: "file",
     databasePath: "./test.sqlite",
+    jitterWindowMax: 10,
     ...overrides,
   } as BackendEnv;
 }
@@ -49,6 +55,9 @@ const basePayment = {
   paymentCount: 0,
   status: RecurringStatus.DUE,
   events: [],
+  computedStatus: "active" as const,
+  ledgersUntilDue: 0,
+  missedPayments: 0,
   metadata: {
     id: "p-1",
     contractId: "C1",
@@ -57,6 +66,15 @@ const basePayment = {
     ledger: 70,
   },
 };
+
+function makeDueResult(
+  payment: typeof basePayment,
+  trigger_reason: DuePaymentResult["trigger_reason"],
+): DuePaymentResult {
+  return { payment, trigger_reason };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
 
 test("registerDuePaymentsJob registers only when enabled and uses configured interval", () => {
   const registered: Array<{ name: string; intervalMs: number }> = [];
@@ -67,7 +85,7 @@ test("registerDuePaymentsJob registers only when enabled and uses configured int
   };
   const recurringService = {
     getStatus: () => ({ lastLedgerProcessed: 100 }),
-    getDuePaymentsAtLedger: async () => [],
+    getDuePaymentsInWindow: async () => [],
     getPayment: async () => null,
   };
   const queue = { publish: async (_event: NotificationEvent) => {} };
@@ -97,7 +115,9 @@ test("due-payments job publishes enriched notification with full payment details
 
   const recurringService = {
     getStatus: () => ({ lastLedgerProcessed: 77 }),
-    getDuePaymentsAtLedger: async () => [basePayment],
+    getDuePaymentsInWindow: async () => [
+      makeDueResult(basePayment, "exact"),
+    ],
     getPayment: async (id: string) => {
       if (id === "p-1") return basePayment;
       return null;
@@ -135,7 +155,9 @@ test("due-payments job publishes degraded notification when enrichment fails", a
 
   const recurringService = {
     getStatus: () => ({ lastLedgerProcessed: 77 }),
-    getDuePaymentsAtLedger: async () => [basePayment],
+    getDuePaymentsInWindow: async () => [
+      makeDueResult(basePayment, "exact"),
+    ],
     getPayment: async (_id: string) => {
       throw new Error("RPC unavailable");
     },
@@ -169,7 +191,8 @@ test("due-payments job publishes one notification per due payment", async () => 
 
   const recurringService = {
     getStatus: () => ({ lastLedgerProcessed: 77 }),
-    getDuePaymentsAtLedger: async () => payments,
+    getDuePaymentsInWindow: async () =>
+      payments.map((p) => makeDueResult(p, "exact")),
     getPayment: async (id: string) =>
       payments.find((p) => p.paymentId === id) ?? null,
   };
@@ -188,4 +211,179 @@ test("due-payments job publishes one notification per due payment", async () => 
   assert.equal(published.length, 2);
   assert.equal((published[0]!.payload as any).paymentId, "p-1");
   assert.equal((published[1]!.payload as any).paymentId, "p-2");
+});
+
+// ── Jitter Window Tests ───────────────────────────────────────────────────────
+
+test("due-payments job: exact due payment has trigger_reason = 'exact'", async () => {
+  const published: NotificationEvent[] = [];
+
+  const exactPayment = { ...basePayment, nextPaymentLedger: 100 };
+  const recurringService = {
+    getStatus: () => ({ lastLedgerProcessed: 100 }),
+    getDuePaymentsInWindow: async () => [makeDueResult(exactPayment, "exact")],
+    getPayment: async () => exactPayment,
+  };
+  const queue = { publish: async (e: NotificationEvent) => { published.push(e); } };
+
+  const job = createDuePaymentsScheduledJob(recurringService as any, queue as any);
+  await job.run({ now: () => new Date() });
+
+  assert.equal(published.length, 1);
+  assert.equal((published[0]!.payload as any).trigger_reason, "exact");
+});
+
+test("due-payments job: jitter-early payment has trigger_reason = 'jitter_early'", async () => {
+  const published: NotificationEvent[] = [];
+
+  // Payment due at ledger 105, current ledger is 100 — early jitter
+  const earlyPayment = { ...basePayment, paymentId: "p-early", nextPaymentLedger: 105 };
+  const recurringService = {
+    getStatus: () => ({ lastLedgerProcessed: 100 }),
+    getDuePaymentsInWindow: async () => [makeDueResult(earlyPayment, "jitter_early")],
+    getPayment: async () => earlyPayment,
+  };
+  const queue = { publish: async (e: NotificationEvent) => { published.push(e); } };
+
+  const job = createDuePaymentsScheduledJob(recurringService as any, queue as any);
+  await job.run({ now: () => new Date() });
+
+  assert.equal(published.length, 1);
+  assert.equal((published[0]!.payload as any).trigger_reason, "jitter_early");
+});
+
+test("due-payments job: jitter-late payment has trigger_reason = 'jitter_late'", async () => {
+  const published: NotificationEvent[] = [];
+
+  // Payment due at ledger 97, current ledger is 100 — late jitter
+  const latePayment = { ...basePayment, paymentId: "p-late", nextPaymentLedger: 97 };
+  const recurringService = {
+    getStatus: () => ({ lastLedgerProcessed: 100 }),
+    getDuePaymentsInWindow: async () => [makeDueResult(latePayment, "jitter_late")],
+    getPayment: async () => latePayment,
+  };
+  const queue = { publish: async (e: NotificationEvent) => { published.push(e); } };
+
+  const job = createDuePaymentsScheduledJob(recurringService as any, queue as any);
+  await job.run({ now: () => new Date() });
+
+  assert.equal(published.length, 1);
+  assert.equal((published[0]!.payload as any).trigger_reason, "jitter_late");
+});
+
+// ── Idempotency Tests ─────────────────────────────────────────────────────────
+
+test("due-payments job: double-trigger prevention — same payment not published twice", async () => {
+  const published: NotificationEvent[] = [];
+  const idempotencySet = new IdempotencySet();
+
+  const recurringService = {
+    getStatus: () => ({ lastLedgerProcessed: 100 }),
+    getDuePaymentsInWindow: async () => [makeDueResult(basePayment, "exact")],
+    getPayment: async () => basePayment,
+  };
+  const queue = { publish: async (e: NotificationEvent) => { published.push(e); } };
+
+  const job = createDuePaymentsScheduledJob(
+    recurringService as any,
+    queue as any,
+    { idempotencySet },
+  );
+
+  // First run — should publish
+  await job.run({ now: () => new Date() });
+  assert.equal(published.length, 1, "first run should publish");
+
+  // Second run (same payment) — should be skipped
+  await job.run({ now: () => new Date() });
+  assert.equal(published.length, 1, "second run should NOT re-publish (idempotency)");
+});
+
+test("IdempotencySet: respects TTL and allows re-trigger after expiry", async () => {
+  const set = new IdempotencySet(50); // 50ms TTL for testing
+
+  set.add("payment-1");
+  assert.ok(set.has("payment-1"), "should be present immediately after add");
+
+  // Wait for TTL to expire
+  await new Promise((resolve) => setTimeout(resolve, 60));
+
+  assert.ok(!set.has("payment-1"), "should be gone after TTL expiry");
+});
+
+// ── Metrics Tests ─────────────────────────────────────────────────────────────
+
+test("due-payments job: metrics are emitted for exact, jitter_early, and jitter_late", async () => {
+  const registry = new MetricsRegistry();
+
+  const payments = [
+    makeDueResult({ ...basePayment, paymentId: "pm-exact" }, "exact"),
+    makeDueResult({ ...basePayment, paymentId: "pm-early", nextPaymentLedger: 105 }, "jitter_early"),
+    makeDueResult({ ...basePayment, paymentId: "pm-late", nextPaymentLedger: 97 }, "jitter_late"),
+  ];
+
+  const recurringService = {
+    getStatus: () => ({ lastLedgerProcessed: 100 }),
+    getDuePaymentsInWindow: async () => payments,
+    getPayment: async (id: string) =>
+      payments.find((p) => p.payment.paymentId === id)?.payment ?? null,
+  };
+  const queue = { publish: async () => {} };
+
+  const job = createDuePaymentsScheduledJob(
+    recurringService as any,
+    queue as any,
+    { metricsRegistry: registry },
+  );
+  await job.run({ now: () => new Date() });
+
+  const snap = registry.snapshot();
+
+  assert.equal(
+    snap.values.get("due_payments_triggered_exact_total"),
+    1,
+    "exact counter should be 1",
+  );
+  assert.equal(
+    snap.values.get("due_payments_triggered_jitter_early_total"),
+    1,
+    "jitter_early counter should be 1",
+  );
+  assert.equal(
+    snap.values.get("due_payments_triggered_jitter_late_total"),
+    1,
+    "jitter_late counter should be 1",
+  );
+  assert.equal(
+    snap.values.get("due_payments_batch_size"),
+    3,
+    "batch size gauge should be 3",
+  );
+});
+
+test("due-payments job: batch is capped at MAX_BATCH_SIZE (10)", async () => {
+  const published: NotificationEvent[] = [];
+
+  // Create 15 payments — only 10 should be processed
+  const payments = Array.from({ length: 15 }, (_, i) => ({
+    ...basePayment,
+    paymentId: `p-${i}`,
+  }));
+
+  const recurringService = {
+    getStatus: () => ({ lastLedgerProcessed: 100 }),
+    getDuePaymentsInWindow: async () =>
+      payments.map((p) => makeDueResult(p, "exact")),
+    getPayment: async (id: string) =>
+      payments.find((p) => p.paymentId === id) ?? null,
+  };
+  const queue = { publish: async (e: NotificationEvent) => { published.push(e); } };
+
+  const job = createDuePaymentsScheduledJob(recurringService as any, queue as any);
+  await job.run({ now: () => new Date() });
+
+  assert.ok(
+    published.length <= 10,
+    `should process at most 10 payments, got ${published.length}`,
+  );
 });

--- a/backend/src/modules/jobs/recurring/due-payments-job.ts
+++ b/backend/src/modules/jobs/recurring/due-payments-job.ts
@@ -1,3 +1,15 @@
+/**
+ * Due Payments Job — Recurring Payment Keeper
+ *
+ * Polls for payments that are due within a ledger window (accounts for
+ * on-chain jitter), batches them, enforces idempotency via a TTL set,
+ * and emits Prometheus metrics.
+ *
+ * Window: current_ledger - JITTER_WINDOW_MAX <= due_at <= current_ledger + 1
+ * Batch:  max 10 payments per keeper invocation
+ * Idempotency: in-memory Set with 1-hour TTL per payment ID
+ */
+
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../../../shared/logging/logger.js";
 import type { BackendEnv } from "../../../config/env.js";
@@ -8,8 +20,75 @@ import type {
   ScheduledJob,
   ScheduledJobRunner,
 } from "../scheduled-job-runner.js";
+import type { MetricsRegistry } from "../../health/metrics.registry.js";
+import {
+  registerDuePaymentMetrics,
+  DUE_PAYMENT_EXACT_COUNTER,
+  DUE_PAYMENT_JITTER_EARLY_COUNTER,
+  DUE_PAYMENT_JITTER_LATE_COUNTER,
+  DUE_PAYMENT_IDEMPOTENCY_HIT_COUNTER,
+  DUE_PAYMENT_BATCH_SIZE_GAUGE,
+} from "../../health/metrics.registry.js";
 
 const logger = createLogger("due-payments-job");
+
+/** Maximum payments to process per keeper invocation. */
+const MAX_BATCH_SIZE = 10;
+
+/** TTL for idempotency entries in milliseconds (1 hour). */
+const IDEMPOTENCY_TTL_MS = 60 * 60 * 1_000;
+
+// ── Idempotency store ────────────────────────────────────────────────────────
+
+interface IdempotencyEntry {
+  triggeredAt: number;
+}
+
+/**
+ * In-memory idempotency set with per-entry TTL.
+ * Prevents duplicate triggers for the same payment within the TTL window.
+ */
+export class IdempotencySet {
+  private readonly store = new Map<string, IdempotencyEntry>();
+  private readonly ttlMs: number;
+
+  constructor(ttlMs: number = IDEMPOTENCY_TTL_MS) {
+    this.ttlMs = ttlMs;
+  }
+
+  /** Returns true if the ID has been seen within the TTL window. */
+  has(id: string): boolean {
+    const entry = this.store.get(id);
+    if (!entry) return false;
+    if (Date.now() - entry.triggeredAt > this.ttlMs) {
+      this.store.delete(id);
+      return false;
+    }
+    return true;
+  }
+
+  /** Mark an ID as triggered. */
+  add(id: string): void {
+    this.store.set(id, { triggeredAt: Date.now() });
+  }
+
+  /** Evict all expired entries. */
+  evictExpired(): void {
+    const now = Date.now();
+    for (const [id, entry] of this.store) {
+      if (now - entry.triggeredAt > this.ttlMs) {
+        this.store.delete(id);
+      }
+    }
+  }
+
+  /** Current number of tracked entries (may include some expired). */
+  size(): number {
+    return this.store.size;
+  }
+}
+
+// ── Job factory ──────────────────────────────────────────────────────────────
 
 function getCurrentLedger(service: RecurringIndexerService): number {
   const { lastLedgerProcessed } = service.getStatus();
@@ -19,21 +98,75 @@ function getCurrentLedger(service: RecurringIndexerService): number {
 export function createDuePaymentsScheduledJob(
   recurringService: RecurringIndexerService,
   notificationQueue: NotificationQueue,
+  options: {
+    jitterWindowMax?: number;
+    metricsRegistry?: MetricsRegistry;
+    idempotencySet?: IdempotencySet;
+  } = {},
 ): ScheduledJob {
+  const jitterWindowMax = options.jitterWindowMax ?? 10;
+  const metricsRegistry = options.metricsRegistry;
+  const idempotencySet = options.idempotencySet ?? new IdempotencySet();
+
+  // Register metrics if a registry was provided
+  if (metricsRegistry) {
+    registerDuePaymentMetrics(metricsRegistry);
+  }
+
   return {
     name: "due-payments",
     intervalMs: 60_000,
     runOnStart: false,
     async run(_context) {
       const currentLedger = getCurrentLedger(recurringService);
-      const duePayments =
-        await recurringService.getDuePaymentsAtLedger(currentLedger);
 
-      for (const payment of duePayments) {
+      // Evict stale idempotency entries before each run
+      idempotencySet.evictExpired();
+
+      // Query within the jitter window (handles on-chain timing variance)
+      const dueResults = await recurringService.getDuePaymentsInWindow(
+        currentLedger,
+        jitterWindowMax,
+      );
+
+      // Enforce batch size limit
+      const batch = dueResults.slice(0, MAX_BATCH_SIZE);
+
+      // Filter out already-triggered payments (idempotency)
+      const toProcess = batch.filter(({ payment }) => {
+        if (idempotencySet.has(payment.paymentId)) {
+          logger.debug("skipping already-triggered payment (idempotency)", {
+            paymentId: payment.paymentId,
+          });
+          metricsRegistry?.incrementCounter(DUE_PAYMENT_IDEMPOTENCY_HIT_COUNTER);
+          return false;
+        }
+        return true;
+      });
+
+      // Emit batch size metric
+      metricsRegistry?.setGauge(DUE_PAYMENT_BATCH_SIZE_GAUGE, toProcess.length);
+
+      for (const { payment, trigger_reason } of toProcess) {
+        // Mark as triggered before publishing to prevent re-trigger on partial failures
+        idempotencySet.add(payment.paymentId);
+
+        // Increment the appropriate trigger reason counter
+        if (trigger_reason === "exact") {
+          metricsRegistry?.incrementCounter(DUE_PAYMENT_EXACT_COUNTER);
+        } else if (trigger_reason === "jitter_early") {
+          metricsRegistry?.incrementCounter(DUE_PAYMENT_JITTER_EARLY_COUNTER);
+        } else {
+          metricsRegistry?.incrementCounter(DUE_PAYMENT_JITTER_LATE_COUNTER);
+        }
+
         logger.info("due payment found", {
           paymentId: payment.paymentId,
           recipient: payment.recipient,
           amount: payment.amount,
+          trigger_reason,
+          currentLedger,
+          nextPaymentLedger: payment.nextPaymentLedger,
         });
 
         let payload: RecurringPaymentDueNotification & Record<string, unknown>;
@@ -60,6 +193,7 @@ export function createDuePaymentsScheduledJob(
             intervalLedgers: enriched.intervalLedgers,
             nextPaymentLedger: enriched.nextPaymentLedger,
             missedCount,
+            trigger_reason,
           };
         } catch (err) {
           logger.warn(
@@ -80,6 +214,7 @@ export function createDuePaymentsScheduledJob(
             nextPaymentLedger: payment.nextPaymentLedger,
             missedCount: 0,
             enrichmentFailed: true,
+            trigger_reason,
           };
         }
 
@@ -100,6 +235,7 @@ export function registerDuePaymentsJob(
   env: BackendEnv,
   recurringService: RecurringIndexerService,
   notificationQueue: NotificationQueue,
+  metricsRegistry?: MetricsRegistry,
 ): void {
   if (!env.duePaymentsJobEnabled) {
     return;
@@ -108,6 +244,10 @@ export function registerDuePaymentsJob(
   const job = createDuePaymentsScheduledJob(
     recurringService,
     notificationQueue,
+    {
+      jitterWindowMax: env.jitterWindowMax,
+      metricsRegistry,
+    },
   );
   runner.register({
     ...job,

--- a/backend/src/modules/recurring/recurring.service.ts
+++ b/backend/src/modules/recurring/recurring.service.ts
@@ -10,6 +10,17 @@ import {
   RecurringStatus,
 } from "./types.js";
 
+/**
+ * A due payment enriched with the reason it was triggered.
+ * - exact       : next_payment_ledger === current_ledger
+ * - jitter_early: payment was within the jitter window before its due date
+ * - jitter_late : payment is past due but within the jitter look-back window
+ */
+export interface DuePaymentResult {
+  readonly payment: NormalizedRecurringPayment;
+  readonly trigger_reason: "exact" | "jitter_early" | "jitter_late";
+}
+
 const logger = createLogger("recurring-indexer");
 
 /**
@@ -471,6 +482,7 @@ export class RecurringIndexerService {
 
   /**
    * Get payments that are ready for execution at a specific ledger.
+   * (Exact match — legacy method retained for backward compatibility.)
    */
   public async getDuePaymentsAtLedger(
     currentLedger: number,
@@ -481,6 +493,46 @@ export class RecurringIndexerService {
         payment.status !== RecurringStatus.CANCELLED &&
         payment.nextPaymentLedger <= currentLedger,
     );
+  }
+
+  /**
+   * Get payments due within a ledger window to account for on-chain jitter.
+   *
+   * Window: [currentLedger - jitterWindowMax, currentLedger + 1]
+   *
+   * Returns DuePaymentResult entries with a trigger_reason indicating
+   * whether the payment was triggered exactly on time, early (jitter_early),
+   * or late (jitter_late).
+   *
+   * @param currentLedger  - Current on-chain ledger
+   * @param jitterWindowMax - Width of the jitter look-back/ahead window
+   */
+  public async getDuePaymentsInWindow(
+    currentLedger: number,
+    jitterWindowMax: number,
+  ): Promise<DuePaymentResult[]> {
+    const windowStart = currentLedger - jitterWindowMax;
+    const windowEnd = currentLedger + 1; // inclusive upper bound
+
+    const all = await this.storage.getAll();
+    const inWindow = all.filter(
+      (payment) =>
+        payment.status !== RecurringStatus.CANCELLED &&
+        payment.nextPaymentLedger >= windowStart &&
+        payment.nextPaymentLedger <= windowEnd,
+    );
+
+    return inWindow.map((payment) => {
+      let trigger_reason: DuePaymentResult["trigger_reason"];
+      if (payment.nextPaymentLedger === currentLedger) {
+        trigger_reason = "exact";
+      } else if (payment.nextPaymentLedger > currentLedger) {
+        trigger_reason = "jitter_early";
+      } else {
+        trigger_reason = "jitter_late";
+      }
+      return { payment, trigger_reason };
+    });
   }
 
   /**

--- a/backend/src/modules/snapshots/semantic-diff-config.ts
+++ b/backend/src/modules/snapshots/semantic-diff-config.ts
@@ -1,0 +1,189 @@
+/**
+ * Semantic Diff Rules Configuration
+ *
+ * Defines rules for classifying snapshot field changes into semantic changes
+ * with severity levels. Rules are evaluated in declaration order; the first
+ * matching rule wins for each changed field.
+ *
+ * Adding new rules here requires no code change in the service.
+ */
+
+import type { SemanticChangeSeverity } from "./types.js";
+
+export interface SemanticRule {
+  /**
+   * The snapshot field this rule applies to. Use "*" to match any field
+   * not covered by a more specific rule (catch-all/default).
+   */
+  readonly field: string;
+
+  /**
+   * Optional predicate on the old value. If omitted, any old value matches.
+   */
+  readonly when?: (oldValue: unknown, newValue: unknown) => boolean;
+
+  /** Severity to assign when this rule matches. */
+  readonly severity: SemanticChangeSeverity;
+
+  /**
+   * Human-readable description factory. Receives old and new values so it
+   * can produce context-aware messages.
+   */
+  readonly describe: (oldValue: unknown, newValue: unknown) => string;
+}
+
+/**
+ * Counts the number of keys in a record-like value.
+ * Returns 0 if the value is not an object.
+ */
+function keyCount(value: unknown): number {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return Object.keys(value as object).length;
+  }
+  return 0;
+}
+
+/**
+ * Attempts to extract a numeric threshold from a snapshot field value.
+ * Handles plain numbers, strings like "2/3" (returns numerator), and
+ * objects with a `threshold` property.
+ */
+function extractThreshold(value: unknown): number | null {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    // e.g. "2/3" → 2
+    const match = /^(\d+)\/(\d+)$/.exec(value);
+    if (match) return Number(match[1]);
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    if ("threshold" in obj) return extractThreshold(obj["threshold"]);
+  }
+  return null;
+}
+
+/**
+ * Default semantic rules.
+ *
+ * Rules are evaluated in order; the first matching rule for a given field wins.
+ * The `*` catch-all must always be last.
+ */
+export const DEFAULT_SEMANTIC_RULES: SemanticRule[] = [
+  // ── Threshold changes ─────────────────────────────────────────────────────
+
+  {
+    field: "threshold",
+    when: (oldVal, newVal) => {
+      const oldN = extractThreshold(oldVal);
+      const newN = extractThreshold(newVal);
+      return oldN !== null && newN !== null && newN < oldN;
+    },
+    severity: "critical",
+    describe: (oldVal, newVal) =>
+      `Approval threshold reduced from ${oldVal} to ${newVal}. This lowers the security bar for transaction approvals.`,
+  },
+  {
+    field: "threshold",
+    when: (oldVal, newVal) => {
+      const oldN = extractThreshold(oldVal);
+      const newN = extractThreshold(newVal);
+      return oldN !== null && newN !== null && newN > oldN;
+    },
+    severity: "info",
+    describe: (oldVal, newVal) =>
+      `Approval threshold increased from ${oldVal} to ${newVal}.`,
+  },
+  {
+    field: "threshold",
+    severity: "warning",
+    describe: (oldVal, newVal) =>
+      `Approval threshold changed from ${oldVal} to ${newVal}.`,
+  },
+
+  // ── Signer set changes ────────────────────────────────────────────────────
+
+  {
+    field: "signers",
+    when: (oldVal, newVal) => keyCount(newVal) > keyCount(oldVal),
+    severity: "warning",
+    describe: (oldVal, newVal) => {
+      const added = keyCount(newVal) - keyCount(oldVal);
+      return `${added} new signer(s) added to the vault. Signer count changed from ${keyCount(oldVal)} to ${keyCount(newVal)}.`;
+    },
+  },
+  {
+    field: "signers",
+    when: (oldVal, newVal) => keyCount(newVal) < keyCount(oldVal),
+    severity: "critical",
+    describe: (oldVal, newVal) => {
+      const removed = keyCount(oldVal) - keyCount(newVal);
+      return `${removed} signer(s) removed from the vault. Signer count changed from ${keyCount(oldVal)} to ${keyCount(newVal)}.`;
+    },
+  },
+  {
+    field: "signers",
+    severity: "info",
+    describe: (_oldVal, _newVal) => `Signer set updated.`,
+  },
+
+  // ── Signer count scalar ───────────────────────────────────────────────────
+
+  {
+    field: "totalSigners",
+    when: (oldVal, newVal) =>
+      typeof oldVal === "number" &&
+      typeof newVal === "number" &&
+      newVal < oldVal,
+    severity: "critical",
+    describe: (oldVal, newVal) =>
+      `Total signer count decreased from ${oldVal} to ${newVal}.`,
+  },
+  {
+    field: "totalSigners",
+    when: (oldVal, newVal) =>
+      typeof oldVal === "number" &&
+      typeof newVal === "number" &&
+      newVal > oldVal,
+    severity: "warning",
+    describe: (oldVal, newVal) =>
+      `Total signer count increased from ${oldVal} to ${newVal}.`,
+  },
+  {
+    field: "totalSigners",
+    severity: "info",
+    describe: (oldVal, newVal) =>
+      `Total signer count changed from ${oldVal} to ${newVal}.`,
+  },
+
+  // ── Role changes ──────────────────────────────────────────────────────────
+
+  {
+    field: "roles",
+    severity: "warning",
+    describe: (oldVal, newVal) => {
+      const oldCount = keyCount(oldVal);
+      const newCount = keyCount(newVal);
+      if (newCount !== oldCount) {
+        return `Role assignments changed from ${oldCount} to ${newCount} entries.`;
+      }
+      return `Role assignment(s) updated.`;
+    },
+  },
+  {
+    field: "totalRoleAssignments",
+    severity: "info",
+    describe: (oldVal, newVal) =>
+      `Total role assignments changed from ${oldVal} to ${newVal}.`,
+  },
+
+  // ── Catch-all ─────────────────────────────────────────────────────────────
+
+  {
+    field: "*",
+    severity: "info",
+    describe: (oldVal, newVal) =>
+      `Field changed from ${JSON.stringify(oldVal)} to ${JSON.stringify(newVal)}.`,
+  },
+];

--- a/backend/src/modules/snapshots/snapshot-diff.service.test.ts
+++ b/backend/src/modules/snapshots/snapshot-diff.service.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   SnapshotDiffService,
   InMemorySnapshotDiffAdapter,
+  SemanticSnapshotDiffService,
 } from "./snapshot-diff.service.js";
 import type { SerializableContractSnapshot } from "./types.js";
 
@@ -191,3 +192,149 @@ test("SnapshotDiffService: saveDiff falls back to base when no history exists", 
   assert.ok(diff !== null);
   assert.strictEqual(diff!.isBase, true, "should create base when no history exists");
 });
+
+// ── Semantic Diff Tests ───────────────────────────────────────────────────────
+
+function makeSemanticService() {
+  return new SemanticSnapshotDiffService(new InMemorySnapshotDiffAdapter());
+}
+
+test("SemanticSnapshotDiffService: threshold reduction is classified critical", async () => {
+  const svc = makeSemanticService();
+
+  // Base snapshot: totalSigners = 3
+  const base = makeSnapshot({ lastProcessedLedger: 100, totalSigners: 3 });
+  await svc.saveBaseSnapshot(base);
+
+  // Diff snapshot: totalSigners reduced to 1
+  const next = makeSnapshot({ lastProcessedLedger: 110, totalSigners: 1 });
+  await svc.saveDiff(next);
+
+  const result = await svc.computeSemanticDiff("CONTRACT-A", 100, 110);
+  assert.ok(result !== null, "should produce a semantic diff result");
+  assert.strictEqual(result!.hasCritical, true, "should have critical changes");
+
+  const criticals = result!.changes.filter((c) => c.severity === "critical");
+  assert.ok(criticals.length > 0, "should have at least one critical change");
+  assert.ok(
+    criticals.some((c) => c.field === "totalSigners"),
+    "totalSigners decrease should be critical",
+  );
+  assert.ok(
+    criticals[0]!.description.length > 0,
+    "critical change should have a description",
+  );
+});
+
+test("SemanticSnapshotDiffService: signer addition is classified warning", async () => {
+  const svc = makeSemanticService();
+
+  const base = makeSnapshot({
+    lastProcessedLedger: 200,
+    signers: {},
+    totalSigners: 0,
+  });
+  await svc.saveBaseSnapshot(base);
+
+  // Add a new signer
+  const next = makeSnapshot({
+    lastProcessedLedger: 210,
+    signers: {
+      SIGNER_A: {
+        address: "SIGNER_A",
+        role: 1,
+        addedAt: new Date().toISOString(),
+        addedAtLedger: 210,
+        isActive: true,
+      },
+    },
+    totalSigners: 1,
+  });
+  await svc.saveDiff(next);
+
+  const result = await svc.computeSemanticDiff("CONTRACT-A", 200, 210);
+  assert.ok(result !== null, "should produce a result");
+
+  const warnings = result!.changes.filter((c) => c.severity === "warning");
+  assert.ok(warnings.length > 0, "signer addition should produce a warning");
+  assert.ok(
+    warnings.some((c) => c.field === "signers" || c.field === "totalSigners"),
+    "the warning should be on the signers or totalSigners field",
+  );
+});
+
+test("SemanticSnapshotDiffService: label/catch-all field change is classified info", async () => {
+  const svc = makeSemanticSnapshotDiffService_custom();
+
+  const base = makeSnapshot({ lastProcessedLedger: 300, lastProcessedEventId: "evt-1" });
+  await svc.saveBaseSnapshot(base);
+
+  const next = makeSnapshot({ lastProcessedLedger: 310, lastProcessedEventId: "evt-2" });
+  await svc.saveDiff(next);
+
+  const result = await svc.computeSemanticDiff("CONTRACT-A", 300, 310);
+  assert.ok(result !== null);
+
+  const infoChanges = result!.changes.filter((c) => c.severity === "info");
+  assert.ok(infoChanges.length > 0, "non-critical field change should be info");
+  assert.strictEqual(result!.hasCritical, false, "should not have critical changes");
+});
+
+test("SemanticSnapshotDiffService: webhook is triggered for critical changes", async () => {
+  const delivered: unknown[] = [];
+  const mockWebhook = {
+    deliver: async (event: unknown) => {
+      delivered.push(event);
+    },
+  };
+
+  const svc = new SemanticSnapshotDiffService(
+    new InMemorySnapshotDiffAdapter(),
+    mockWebhook as any,
+  );
+
+  const base = makeSnapshot({ lastProcessedLedger: 400, totalSigners: 5 });
+  await svc.saveBaseSnapshot(base);
+
+  // Drastically reduce signers — triggers critical
+  const next = makeSnapshot({ lastProcessedLedger: 410, totalSigners: 1 });
+  await svc.saveDiff(next);
+
+  const result = await svc.computeSemanticDiff("CONTRACT-A", 400, 410);
+  assert.ok(result !== null);
+  assert.strictEqual(result!.hasCritical, true);
+
+  // Give the fire-and-forget a tick to resolve
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.ok(delivered.length > 0, "webhook should have been triggered");
+  assert.ok(
+    (delivered[0] as any).topic === "snapshot:critical-change",
+    "webhook event topic should be snapshot:critical-change",
+  );
+});
+
+test("SemanticSnapshotDiffService: classifyChanges respects rule order (first match wins)", () => {
+  const svc = makeSemanticService();
+
+  // threshold decrease → critical (first matching rule)
+  const changes = [
+    { field: "totalSigners", before: 5, after: 2 },
+    { field: "lastProcessedLedger", before: 100, after: 110 },
+  ];
+
+  const classified = svc.classifyChanges(changes);
+  assert.strictEqual(classified.length, 2);
+  assert.strictEqual(classified[0]!.severity, "critical", "totalSigners decrease should be critical");
+  assert.strictEqual(classified[1]!.severity, "info", "ledger change should be info via catch-all");
+});
+
+test("SemanticSnapshotDiffService: computeSemanticDiff returns null when no snapshots exist", async () => {
+  const svc = makeSemanticService();
+  const result = await svc.computeSemanticDiff("NONEXISTENT-VAULT", 100, 200);
+  assert.strictEqual(result, null);
+});
+
+/** Helper to create a service with default rules but no webhook. */
+function makeSemanticSnapshotDiffService_custom() {
+  return new SemanticSnapshotDiffService(new InMemorySnapshotDiffAdapter());
+}

--- a/backend/src/modules/snapshots/snapshot-diff.service.ts
+++ b/backend/src/modules/snapshots/snapshot-diff.service.ts
@@ -17,11 +17,18 @@
 import { randomUUID } from "node:crypto";
 import { createLogger } from "../../shared/logging/logger.js";
 import type {
+  SemanticChange,
+  SemanticDiffResult,
   SerializableContractSnapshot,
   SnapshotDiff,
   SnapshotDiffStorageAdapter,
   SnapshotFieldChange,
 } from "./types.js";
+import {
+  DEFAULT_SEMANTIC_RULES,
+  type SemanticRule,
+} from "./semantic-diff-config.js";
+import type { WebhookDeliveryService } from "../notifications/webhook.service.js";
 
 const logger = createLogger("snapshot-diff-service");
 
@@ -103,7 +110,7 @@ function applyChanges(
 // ── Service ───────────────────────────────────────────────────────────────────
 
 export class SnapshotDiffService {
-  constructor(private readonly storage: SnapshotDiffStorageAdapter) {}
+  constructor(protected readonly storage: SnapshotDiffStorageAdapter) {}
 
   /**
    * Record a base snapshot (full state). Call this every 24 hours or on first
@@ -300,5 +307,222 @@ export class SnapshotDiffService {
 
     logger.info("compact completed", { contractId, deleted });
     return deleted;
+  }
+}
+
+// ── Semantic Diff Service ──────────────────────────────────────────────────────────────
+
+/**
+ * SemanticSnapshotDiffService
+ *
+ * Extends SnapshotDiffService with semantic change classification.
+ * Rules are loaded from semantic-diff-config.ts; adding new rules
+ * requires no code changes here (open/closed principle).
+ *
+ * Critical changes trigger an immediate webhook delivery (not batched).
+ */
+export class SemanticSnapshotDiffService extends SnapshotDiffService {
+  private readonly rules: SemanticRule[];
+
+  constructor(
+    storage: SnapshotDiffStorageAdapter,
+    private readonly webhookService?: WebhookDeliveryService,
+    rules: SemanticRule[] = DEFAULT_SEMANTIC_RULES,
+  ) {
+    super(storage);
+    this.rules = rules;
+  }
+
+  // ── Classification ──────────────────────────────────────────────────────────
+
+  /**
+   * Classify a list of raw field changes into SemanticChange entries.
+   *
+   * Rules are evaluated in declaration order; the first matching rule wins.
+   * The special "*" field acts as a catch-all for unmatched fields.
+   */
+  public classifyChanges(changes: SnapshotFieldChange[]): SemanticChange[] {
+    return changes.map((change) => {
+      // Find the first matching rule for this specific field
+      const rule =
+        this.rules.find(
+          (r) =>
+            r.field === change.field &&
+            (r.when === undefined || r.when(change.before, change.after)),
+        ) ??
+        // Fall back to catch-all
+        this.rules.find(
+          (r) =>
+            r.field === "*" &&
+            (r.when === undefined || r.when(change.before, change.after)),
+        );
+
+      if (!rule) {
+        return {
+          field: change.field,
+          old_value: change.before,
+          new_value: change.after,
+          severity: "info" as const,
+          description: `Field "${change.field}" changed.`,
+        };
+      }
+
+      return {
+        field: change.field,
+        old_value: change.before,
+        new_value: change.after,
+        severity: rule.severity,
+        description: rule.describe(change.before, change.after),
+      };
+    });
+  }
+
+  // ── Semantic diff between two ledger snapshots ─────────────────────────────────
+
+  /**
+   * Compute the semantic diff between snapshots spanning fromLedger to toLedger
+   * for a given vault.
+   *
+   * - Reconstructs the "from" and "to" states from the diff chain.
+   * - Classifies each field change with a semantic rule.
+   * - Fires webhook immediately for any critical changes.
+   *
+   * @param vaultAddress - Stellar contract address (vault)
+   * @param fromLedger   - Starting ledger (inclusive)
+   * @param toLedger     - Ending ledger (inclusive)
+   * @returns SemanticDiffResult or null if snapshots are not found
+   */
+  public async computeSemanticDiff(
+    vaultAddress: string,
+    fromLedger: number,
+    toLedger: number,
+  ): Promise<SemanticDiffResult | null> {
+    const allDiffs = await this.storage.listDiffs(vaultAddress);
+
+    // Find the most recent diff at or before each ledger boundary
+    const fromCandidates = allDiffs.filter((d) => d.ledger <= fromLedger);
+    const toCandidates = allDiffs.filter((d) => d.ledger <= toLedger);
+
+    if (fromCandidates.length === 0 || toCandidates.length === 0) {
+      logger.warn("computeSemanticDiff: no snapshots found in ledger range", {
+        vaultAddress,
+        fromLedger,
+        toLedger,
+      });
+      return null;
+    }
+
+    const fromSnap = fromCandidates[fromCandidates.length - 1]!;
+    const toSnap = toCandidates[toCandidates.length - 1]!;
+
+    const [fromState, toState] = await Promise.all([
+      this.reconstructSnapshot(fromSnap.snapshotId),
+      this.reconstructSnapshot(toSnap.snapshotId),
+    ]);
+
+    if (!fromState || !toState) {
+      logger.warn("computeSemanticDiff: could not reconstruct snapshot states", {
+        vaultAddress,
+        fromSnapshotId: fromSnap.snapshotId,
+        toSnapshotId: toSnap.snapshotId,
+      });
+      return null;
+    }
+
+    const rawChanges = computeChangedFields(fromState, toState);
+    const semanticChanges = this.classifyChanges(rawChanges);
+    const hasCritical = semanticChanges.some((c) => c.severity === "critical");
+
+    const result: SemanticDiffResult = {
+      vaultAddress,
+      fromLedger: fromSnap.ledger,
+      toLedger: toSnap.ledger,
+      changes: semanticChanges,
+      hasCritical,
+      computedAt: new Date().toISOString(),
+    };
+
+    // Fire webhook immediately for critical changes (not batched)
+    if (hasCritical && this.webhookService) {
+      const criticals = semanticChanges.filter((c) => c.severity === "critical");
+      logger.warn("critical semantic changes detected — triggering webhook", {
+        vaultAddress,
+        fromLedger,
+        toLedger,
+        criticalCount: criticals.length,
+      });
+      void this.webhookService.deliver({
+        id: randomUUID(),
+        topic: "snapshot:critical-change",
+        source: "snapshot-diff-service",
+        createdAt: new Date().toISOString(),
+        payload: result as unknown as Record<string, unknown>,
+      });
+    }
+
+    return result;
+  }
+
+  // ── Critical change endpoint support ──────────────────────────────────────────────
+
+  /**
+   * Scan recent diffs across all known vaults and return only those
+   * containing at least one critical semantic change.
+   *
+   * Intended for: GET /api/v1/snapshots/diff/critical (admin endpoint).
+   *
+   * @param knownVaults   - List of vault addresses to scan
+   * @param currentLedger - Current ledger for age filtering
+   * @param maxAgeLedgers - How many ledgers back to scan (default: all)
+   */
+  public async getCriticalChanges(
+    knownVaults: string[],
+    currentLedger?: number,
+    maxAgeLedgers?: number,
+  ): Promise<SemanticDiffResult[]> {
+    const results: SemanticDiffResult[] = [];
+
+    for (const vault of knownVaults) {
+      const diffs = await this.storage.listDiffs(vault);
+      if (diffs.length < 2) continue;
+
+      const relevant =
+        currentLedger !== undefined && maxAgeLedgers !== undefined
+          ? diffs.filter((d) => d.ledger >= currentLedger - maxAgeLedgers)
+          : diffs;
+
+      if (relevant.length < 2) continue;
+
+      for (let i = 1; i < relevant.length; i++) {
+        const prev = relevant[i - 1]!;
+        const curr = relevant[i]!;
+
+        const [prevState, currState] = await Promise.all([
+          this.reconstructSnapshot(prev.snapshotId),
+          this.reconstructSnapshot(curr.snapshotId),
+        ]);
+
+        if (!prevState || !currState) continue;
+
+        const rawChanges = computeChangedFields(prevState, currState);
+        const semanticChanges = this.classifyChanges(rawChanges);
+        const criticals = semanticChanges.filter(
+          (c) => c.severity === "critical",
+        );
+
+        if (criticals.length > 0) {
+          results.push({
+            vaultAddress: vault,
+            fromLedger: prev.ledger,
+            toLedger: curr.ledger,
+            changes: criticals,
+            hasCritical: true,
+            computedAt: new Date().toISOString(),
+          });
+        }
+      }
+    }
+
+    return results;
   }
 }

--- a/backend/src/modules/snapshots/snapshots.routes.ts
+++ b/backend/src/modules/snapshots/snapshots.routes.ts
@@ -62,7 +62,7 @@ export function createSnapshotRouter(
      * Returns the incremental diff from the previous snapshot.
      */
     router.get("/:id/diff", async (req: Request, res: Response) => {
-      const id = String(req.params.id ?? "");
+      const id = String(req.params["id"] ?? "");
       const diff = await diffService.getDiffFromPrevious(id);
       if (!diff) {
         error(res, {
@@ -73,6 +73,125 @@ export function createSnapshotRouter(
       }
       success(res, diff);
     });
+
+    /**
+     * GET /api/v1/snapshots/diff?from=<ledger>&to=<ledger>&vault=<address>
+     *
+     * Returns the semantic diff between two ledger snapshots for a vault.
+     * Each changed field is classified with severity (critical/warning/info)
+     * and a human-readable description.
+     *
+     * Query parameters:
+     *   from  - Starting ledger (integer)
+     *   to    - Ending ledger (integer)
+     *   vault - Vault contract address
+     */
+    router.get("/diff", async (req: Request, res: Response) => {
+      const from = req.query["from"] as string | undefined;
+      const to = req.query["to"] as string | undefined;
+      const vault = req.query["vault"] as string | undefined;
+
+      if (!from || !to || !vault) {
+        error(res, {
+          message:
+            "Query parameters 'from', 'to', and 'vault' are required",
+          status: 400,
+        });
+        return;
+      }
+
+      const fromLedger = Number(from);
+      const toLedger = Number(to);
+
+      if (!Number.isInteger(fromLedger) || !Number.isInteger(toLedger)) {
+        error(res, {
+          message: "'from' and 'to' must be integer ledger numbers",
+          status: 400,
+        });
+        return;
+      }
+
+      if (fromLedger > toLedger) {
+        error(res, {
+          message:
+            "'from' ledger must be less than or equal to 'to' ledger",
+          status: 400,
+        });
+        return;
+      }
+
+      // Use semantic diff if the service supports it (SemanticSnapshotDiffService)
+      const semanticService = diffService as any;
+      if (typeof semanticService.computeSemanticDiff === "function") {
+        const result = await semanticService.computeSemanticDiff(
+          vault,
+          fromLedger,
+          toLedger,
+        );
+        if (!result) {
+          error(res, {
+            message:
+              "No snapshots found for the specified ledger range and vault",
+            status: 404,
+          });
+          return;
+        }
+        success(res, result);
+        return;
+      }
+
+      error(res, { message: "Semantic diff not supported", status: 501 });
+    });
+
+    /**
+     * GET /api/v1/snapshots/diff/critical  (admin-only)
+     *
+     * Returns all critical semantic changes (severity = "critical") across
+     * all vaults provided via the `vaults` query parameter.
+     *
+     * Query parameters:
+     *   vaults        - Comma-separated list of vault addresses to scan
+     *   currentLedger - (optional) Current ledger for age-based filtering
+     *   maxAgeLedgers - (optional) How many ledgers back to scan
+     */
+    router.get(
+      "/diff/critical",
+      adminAuthMiddleware,
+      async (req: Request, res: Response) => {
+        const semanticService = diffService as any;
+        if (typeof semanticService.getCriticalChanges !== "function") {
+          error(res, {
+            message: "Semantic diff not supported",
+            status: 501,
+          });
+          return;
+        }
+
+        const currentLedger =
+          req.query["currentLedger"] !== undefined
+            ? Number(req.query["currentLedger"])
+            : undefined;
+        const maxAgeLedgers =
+          req.query["maxAgeLedgers"] !== undefined
+            ? Number(req.query["maxAgeLedgers"])
+            : undefined;
+
+        const vaultsParam = req.query["vaults"];
+        const vaults: string[] =
+          typeof vaultsParam === "string" && vaultsParam.length > 0
+            ? vaultsParam.split(",").map((v) => v.trim())
+            : [];
+
+        const criticalChanges: unknown[] =
+          await semanticService.getCriticalChanges(
+            vaults,
+            currentLedger,
+            maxAgeLedgers,
+          );
+
+        success(res, { criticalChanges, count: criticalChanges.length });
+      },
+    );
 
     /**
      * POST /api/v1/snapshots/compact (admin-only)

--- a/backend/src/modules/snapshots/types.ts
+++ b/backend/src/modules/snapshots/types.ts
@@ -203,6 +203,37 @@ export interface SnapshotFieldChange {
 }
 
 /**
+ * Severity levels for semantic changes.
+ * - critical: security-relevant changes (e.g. threshold reduction)
+ * - warning:  notable but not immediately dangerous (e.g. new signer)
+ * - info:     informational/cosmetic changes (e.g. label update)
+ */
+export type SemanticChangeSeverity = "critical" | "warning" | "info";
+
+/**
+ * A semantically classified change between two snapshots.
+ */
+export interface SemanticChange {
+  readonly field: string;
+  readonly old_value: unknown;
+  readonly new_value: unknown;
+  readonly severity: SemanticChangeSeverity;
+  readonly description: string;
+}
+
+/**
+ * Result of a semantic diff operation between two ledger snapshots.
+ */
+export interface SemanticDiffResult {
+  readonly vaultAddress: string;
+  readonly fromLedger: number;
+  readonly toLedger: number;
+  readonly changes: SemanticChange[];
+  readonly hasCritical: boolean;
+  readonly computedAt: string;
+}
+
+/**
  * Incremental diff between two consecutive snapshots.
  * Only fields that changed since the previous snapshot are stored.
  */


### PR DESCRIPTION
## Summary

This PR implements two backend features in a single branch:

- **#1160** — Snapshot Diff Service with Semantic Change Detection
- **#1154** — Recurring Payment Due-Date Keeper with Jitter Handling

---

## #1160 — Snapshot Diff Service with Semantic Change Detection

### What was done

Extended the existing `SnapshotDiffService` with a full semantic classification layer. Field-level diffs are now enriched with human-readable descriptions and severity levels, enabling downstream consumers to distinguish security-relevant changes from noise.

### Changes

#### `backend/src/modules/snapshots/types.ts`
- Added `SemanticChangeSeverity` union type: `"critical" | "warning" | "info"`
- Added `SemanticChange` interface: `{ field, old_value, new_value, severity, description }`
- Added `SemanticDiffResult` interface: `{ vaultAddress, fromLedger, toLedger, changes, hasCritical, computedAt }`

#### `backend/src/modules/snapshots/semantic-diff-config.ts` *(new file)*
- Defines the `SemanticRule` interface with `field`, optional `when` predicate, `severity`, and `describe` factory
- Ships `DEFAULT_SEMANTIC_RULES` — the canonical rule set:
  - Threshold reduction → `critical`
  - Signer removed → `critical`
  - Signer added → `warning`
  - Role changes → `warning`
  - All other fields → `info` (catch-all `"*"` rule)
- **No code change required to add new rules** — drop a new entry into the array

#### `backend/src/modules/snapshots/snapshot-diff.service.ts`
- Changed `SnapshotDiffService.storage` from `private` to `protected` to support inheritance
- Added `SemanticSnapshotDiffService extends SnapshotDiffService`:
  - `classifyChanges(changes)` — maps raw `SnapshotFieldChange[]` to `SemanticChange[]` using the rule engine (first-match-wins, with catch-all fallback)
  - `computeSemanticDiff(vaultAddress, fromLedger, toLedger)` — reconstructs both ledger states, computes field diff, classifies changes, and fires webhook immediately if `hasCritical === true`
  - `getCriticalChanges(knownVaults, currentLedger?, maxAgeLedgers?)` — scans adjacent diff pairs across all vaults and returns only critical results (used by the admin endpoint)

#### `backend/src/modules/snapshots/snapshots.routes.ts`
- Added `GET /api/v1/snapshots/diff?from=<ledger>&to=<ledger>&vault=<address>`
  - Returns `SemanticDiffResult` with full change list and `hasCritical` flag
  - Returns `404` if no snapshots exist in the specified ledger range
- Added `GET /api/v1/snapshots/diff/critical` *(admin-only, requires API key)*
  - Accepts `vaults` (comma-separated), `currentLedger`, and `maxAgeLedgers` query params
  - Returns `{ criticalChanges: SemanticDiffResult[], count: number }`
- Existing `GET /:id/diff` and `POST /compact` endpoints preserved unchanged

#### `backend/src/modules/snapshots/snapshot-diff.service.test.ts`
- Added 6 new test cases:
  - `totalSigners` decrease → classified `critical`
  - Signer object added → classified `warning`
  - Non-critical field (`lastProcessedEventId`) → classified `info` via catch-all
  - Critical change → webhook `deliver()` called with topic `snapshot:critical-change`
  - Rule ordering: first matching rule wins, catch-all is last resort
  - `computeSemanticDiff` returns `null` when vault has no snapshots

### Semantic rules summary

| Field | Condition | Severity |
|---|---|---|
| `threshold` | value decreases | `critical` |
| `threshold` | value increases | `info` |
| `signers` | count decreases | `critical` |
| `signers` | count increases | `warning` |
| `totalSigners` | value decreases | `critical` |
| `totalSigners` | value increases | `warning` |
| `roles` | any change | `warning` |
| `totalRoleAssignments` | any change | `info` |
| `*` (catch-all) | any other field | `info` |

### Constraints satisfied
- [x] Semantic rules defined in config file (`semantic-diff-config.ts`), not hardcoded in service
- [x] Critical changes trigger webhook immediately, not batched
- [x] Severity classification is extensible — new rules added without code change

---

## #1154 — Recurring Payment Due-Date Keeper with Jitter Handling

### What was done

Rewrote the due-payments keeper to query a configurable ledger window instead of an exact ledger match, preventing missed payments caused by on-chain jitter. Added batch capping, idempotency protection, and Prometheus metrics.

### Changes

#### `backend/src/config/env.ts`
- Added `jitterWindowMax: number` to `BackendEnv` interface
- Reads from env var `JITTER_WINDOW_MAX` (default: `10` ledgers)
- Included in `loadEnv()` return value and `createTestEnv()` defaults

#### `backend/src/modules/recurring/recurring.service.ts`
- Added `DuePaymentResult` interface: `{ payment: NormalizedRecurringPayment, trigger_reason: "exact" | "jitter_early" | "jitter_late" }`
- Added `getDuePaymentsInWindow(currentLedger, jitterWindowMax)`:
  - Query window: `currentLedger - jitterWindowMax <= nextPaymentLedger <= currentLedger + 1`
  - Assigns `trigger_reason`:
    - `"exact"` — due ledger equals current ledger
    - `"jitter_early"` — due ledger is ahead of current (triggered early)
    - `"jitter_late"` — due ledger is behind current (triggered late, within window)
- Existing `getDuePaymentsAtLedger()` retained for backward compatibility

#### `backend/src/modules/health/metrics.registry.ts`
- Exported metric name constants:
  - `DUE_PAYMENT_EXACT_COUNTER`
  - `DUE_PAYMENT_JITTER_EARLY_COUNTER`
  - `DUE_PAYMENT_JITTER_LATE_COUNTER`
  - `DUE_PAYMENT_IDEMPOTENCY_HIT_COUNTER`
  - `DUE_PAYMENT_BATCH_SIZE_GAUGE`
- Added `registerDuePaymentMetrics(registry)` helper — registers all five metrics on the shared `MetricsRegistry` instance at startup

#### `backend/src/modules/jobs/recurring/due-payments-job.ts` *(full rewrite)*
- Added `IdempotencySet` class:
  - In-memory `Map<paymentId, { triggeredAt }>`
  - Configurable TTL (default: 1 hour)
  - `has(id)` auto-evicts expired entries
  - `evictExpired()` called at the start of each keeper run
- `createDuePaymentsScheduledJob()` now accepts `options`:
  - `jitterWindowMax` — passed to `getDuePaymentsInWindow()`
  - `metricsRegistry` — optional `MetricsRegistry` for counter/gauge emission
  - `idempotencySet` — injectable for testing
- Keeper run logic:
  1. Evict expired idempotency entries
  2. Query payments in jitter window
  3. Slice to `MAX_BATCH_SIZE = 10`
  4. Skip payments already in idempotency set (increments `DUE_PAYMENT_IDEMPOTENCY_HIT_COUNTER`)
  5. Mark remaining payments in idempotency set before publishing (prevents partial re-trigger)
  6. Increment `exact`/`jitter_early`/`jitter_late` counter per payment
  7. Set `DUE_PAYMENT_BATCH_SIZE_GAUGE` to processed count
  8. Publish notification with `trigger_reason` in payload
- `registerDuePaymentsJob()` passes `env.jitterWindowMax` and optional `metricsRegistry`

#### `backend/src/modules/jobs/recurring/due-payments-job.test.ts` *(full rewrite)*
- Retained all original tests (adapted to new `getDuePaymentsInWindow` API)
- Added new test cases:
  - Exact due payment → `trigger_reason === "exact"` in payload
  - Early jitter payment → `trigger_reason === "jitter_early"` in payload
  - Late jitter payment → `trigger_reason === "jitter_late"` in payload
  - Double-trigger prevention: second run for same payment produces no second notification
  - `IdempotencySet` TTL: entry becomes invisible after expiry, allowing re-trigger
  - Metrics: `exact`, `jitter_early`, `jitter_late` counters each incremented once; `batch_size` gauge set correctly
  - Batch cap: 15 payments in window → only 10 notifications published

### Constraints satisfied
- [x] Jitter window max read from `JITTER_WINDOW_MAX` env var (default: 10)
- [x] Batch size capped at 10 payments per keeper invocation
- [x] Idempotency set with 1-hour TTL prevents double-trigger
- [x] Metrics emitted to existing `MetricsRegistry` (prom-client compatible)

---

Closes #1160 
Closes #1154 
Closes #1175 
Closes #1159 