### PR TITLE
fix(events): per-endpoint cursor tracking and safe RPC failover (#1368)

### DIFF
--- a/backend/src/modules/events/index.ts
+++ b/backend/src/modules/events/index.ts
@@ -5,3 +5,4 @@ export * from "./types.js";
 export * from "./normalizers/index.js";
 export * from "./cursor/index.js";
 export * from "./replay/index.js";
+export * from "./rpc-failover-manager.js";

--- a/backend/src/modules/events/rpc-failover-manager.test.ts
+++ b/backend/src/modules/events/rpc-failover-manager.test.ts
@@ -1,0 +1,551 @@
+/**
+ * Tests for RpcFailoverManager
+ *
+ * Covers:
+ *  - Per-endpoint cursor tracked independently
+ *  - Failover with consistent cursors (no divergence, fast path)
+ *  - Failover with diverged cursors (warning path, resync triggers)
+ *  - Resync finds correct common prefix (not too early, not skipping events)
+ *  - Resync finds no common point → ServiceUnavailableError, not silent resume
+ *  - Multi-failover sequence: primary → backup → primary again
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  RpcFailoverManager,
+  findCommonSuffix,
+  VALIDATION_WINDOW,
+  MAX_LOOKBACK_STEPS,
+} from "./rpc-failover-manager.js";
+import { SorobanRpcClient } from "../../shared/rpc/soroban-rpc.client.js";
+import { ServiceUnavailableError } from "../../shared/errors/AppError.js";
+import type { RawContractEvent } from "../../shared/rpc/soroban-rpc.types.js";
+import type { EventCursor } from "./cursor/cursor.types.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+const CONTRACT_ID = "CDTEST000000000000000000000000000000000000000000000";
+
+/**
+ * Build a SorobanRpcClient backed by a fake fetch that returns `events` for
+ * any `getEvents` call. `latestLedger` defaults to the max ledger in the
+ * events array or 100.
+ */
+function buildClientWithEvents(
+  url: string,
+  events: RawContractEvent[],
+  latestLedgerOverride?: number,
+): SorobanRpcClient {
+  const latestLedger =
+    latestLedgerOverride ??
+    (events.length > 0 ? Math.max(...events.map((e) => e.ledger)) : 100);
+
+  const fakeFetch: typeof fetch = async (_url, options) => {
+    const body = JSON.parse((options?.body ?? "{}") as string) as {
+      id: number;
+      method: string;
+      params?: unknown;
+    };
+
+    let result: unknown;
+    if (body.method === "getLatestLedger") {
+      result = { sequence: latestLedger };
+    } else if (body.method === "getEvents") {
+      const params = (body.params ?? {}) as {
+        startLedger?: number;
+        pagination?: { limit?: number; cursor?: string };
+      };
+      const startLedger = params.startLedger ?? 0;
+      const limit = params.pagination?.limit ?? VALIDATION_WINDOW;
+      const filtered = events.filter((e) => e.ledger >= startLedger).slice(0, limit);
+      result = { events: filtered, latestLedger };
+    } else {
+      result = {};
+    }
+
+    return new Response(
+      JSON.stringify({ jsonrpc: "2.0", id: (body as any).id, result }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+
+  return new SorobanRpcClient({ url }, fakeFetch);
+}
+
+/** Build a client that throws on every RPC call. */
+function buildFailingClient(url: string): SorobanRpcClient {
+  const fakeFetch: typeof fetch = async () => {
+    throw new TypeError("network failure");
+  };
+  return new SorobanRpcClient({ url, maxRetries: 0 }, fakeFetch);
+}
+
+/** Factory for minimal valid RawContractEvent. */
+function makeEvent(
+  id: string,
+  ledger: number,
+  overrides: Partial<RawContractEvent> = {},
+): RawContractEvent {
+  return {
+    id,
+    type: "contract",
+    ledger,
+    ledgerClosedAt: "2026-01-01T00:00:00Z",
+    contractId: CONTRACT_ID,
+    topic: ["proposal_created"],
+    value: { xdr: "AAAA" },
+    pagingToken: id,
+    ...overrides,
+  };
+}
+
+/** Build a cursor at a given ledger. */
+function cursor(lastLedger: number, lastEventId?: string): EventCursor {
+  return {
+    lastLedger,
+    lastEventId,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+// ─── findCommonSuffix unit tests ──────────────────────────────────────────────
+
+test("findCommonSuffix: returns null for disjoint arrays", () => {
+  assert.equal(findCommonSuffix(["a", "b", "c"], ["d", "e", "f"]), null);
+});
+
+test("findCommonSuffix: returns most recent common ID", () => {
+  // Both share "c" and "b"; most recent common is "c"
+  assert.equal(findCommonSuffix(["a", "b", "c"], ["b", "c", "d"]), "c");
+});
+
+test("findCommonSuffix: handles empty arrays", () => {
+  assert.equal(findCommonSuffix([], ["a", "b"]), null);
+  assert.equal(findCommonSuffix(["a", "b"], []), null);
+  assert.equal(findCommonSuffix([], []), null);
+});
+
+test("findCommonSuffix: single-element arrays with match", () => {
+  assert.equal(findCommonSuffix(["x"], ["x"]), "x");
+});
+
+test("findCommonSuffix: returns latest match, not earliest", () => {
+  // "a" matches, "c" matches — should return "c" (most recent)
+  assert.equal(findCommonSuffix(["a", "b", "c"], ["a", "c", "e"]), "c");
+});
+
+// ─── Per-endpoint cursor tracking ─────────────────────────────────────────────
+
+test("test_per_endpoint_cursor_tracked_independently: primary and backup cursors don't clobber each other", () => {
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, []) },
+    { url: backupUrl, client: buildClientWithEvents(backupUrl, []) },
+  ]);
+
+  // Set different cursors for each endpoint
+  manager.setCursorForEndpoint(primaryUrl, cursor(500));
+  manager.setCursorForEndpoint(backupUrl, cursor(480));
+
+  // Each endpoint retains its own cursor independently
+  assert.deepEqual(manager.getCursorForEndpoint(primaryUrl), cursor(500));
+  assert.deepEqual(manager.getCursorForEndpoint(backupUrl), cursor(480));
+
+  // Updating one does not affect the other
+  manager.setCursorForEndpoint(primaryUrl, cursor(510));
+  assert.deepEqual(manager.getCursorForEndpoint(primaryUrl), cursor(510));
+  assert.deepEqual(manager.getCursorForEndpoint(backupUrl), cursor(480));
+});
+
+test("getCursorForEndpoint returns null for an unknown endpoint", () => {
+  const manager = new RpcFailoverManager([
+    { url: "https://a.rpc", client: buildClientWithEvents("https://a.rpc", []) },
+  ]);
+  assert.equal(manager.getCursorForEndpoint("https://unknown.rpc"), null);
+});
+
+test("getAllEndpointCursors lists every endpoint with its cursor or null", () => {
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, []) },
+    { url: backupUrl, client: buildClientWithEvents(backupUrl, []) },
+  ]);
+
+  manager.setCursorForEndpoint(primaryUrl, cursor(100));
+  // backup left unset
+
+  const all = manager.getAllEndpointCursors();
+  assert.equal(all.length, 2);
+  assert.deepEqual(all.find((e) => e.url === primaryUrl)?.cursor, cursor(100));
+  assert.equal(all.find((e) => e.url === backupUrl)?.cursor, null);
+});
+
+// ─── Failover with consistent cursors ─────────────────────────────────────────
+
+test("test_failover_with_consistent_cursors: failover proceeds without warning, cursor carries over", async () => {
+  // Both endpoints share the same events around ledger 100
+  const sharedEvents = [
+    makeEvent("evt-95", 95),
+    makeEvent("evt-96", 96),
+    makeEvent("evt-97", 97),
+    makeEvent("evt-98", 98),
+    makeEvent("evt-99", 99),
+    makeEvent("evt-100", 100),
+  ];
+
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, sharedEvents) },
+    { url: backupUrl, client: buildClientWithEvents(backupUrl, sharedEvents) },
+  ]);
+
+  const primaryCursor = cursor(100, "evt-100");
+  const result = await manager.failover(primaryCursor, CONTRACT_ID);
+
+  // Should switch to backup
+  assert.equal(result.endpoint.url, backupUrl);
+  // Cursor should be unchanged (consistent, fast path)
+  assert.equal(result.cursor.lastLedger, 100);
+  // No resync needed
+  assert.equal(result.resynced, false);
+});
+
+// ─── Failover with diverged cursors ───────────────────────────────────────────
+
+test("test_failover_with_diverged_cursors: diverged cursors trigger resync", async () => {
+  // Primary has events 90–100; backup has different events for the same ledger
+  // range (simulating a different view of the chain)
+  const primaryEvents = [
+    makeEvent("evt-p-90", 90),
+    makeEvent("evt-p-91", 91),
+    makeEvent("evt-common-80", 80), // a common event that exists in both
+    makeEvent("evt-p-92", 92),
+    makeEvent("evt-p-100", 100),
+  ];
+  const backupEvents = [
+    makeEvent("evt-b-88", 88),
+    makeEvent("evt-common-80", 80), // same common event
+    makeEvent("evt-b-91", 91),
+    makeEvent("evt-b-92", 92),
+    makeEvent("evt-b-100", 100),
+  ];
+
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, primaryEvents) },
+    { url: backupUrl, client: buildClientWithEvents(backupUrl, backupEvents) },
+  ]);
+
+  const primaryCursor = cursor(100, "evt-p-100");
+
+  // Failover should succeed, finding the common event
+  const result = await manager.failover(primaryCursor, CONTRACT_ID);
+
+  assert.equal(result.endpoint.url, backupUrl);
+  // Resynced because histories diverged
+  assert.equal(result.resynced, true);
+  // Common event was "evt-common-80" at ledger 80
+  assert.equal(result.cursor.lastEventId, "evt-common-80");
+  assert.equal(result.cursor.lastLedger, 80);
+});
+
+// ─── Resync finds correct common prefix ───────────────────────────────────────
+
+test("test_resync_finds_common_prefix: correctly identifies common point, not too early or late", async () => {
+  // 200 events total, shared up to event 150, then diverge.
+  // Primary: evt-001..evt-150 + evt-p-151..evt-p-200
+  // Backup:  evt-001..evt-150 + evt-b-151..evt-b-200
+  const sharedEvents = Array.from({ length: 150 }, (_, i) =>
+    makeEvent(`evt-${String(i + 1).padStart(3, "0")}`, i + 1),
+  );
+  const primaryOnly = Array.from({ length: 50 }, (_, i) =>
+    makeEvent(`evt-p-${String(i + 151).padStart(3, "0")}`, i + 151),
+  );
+  const backupOnly = Array.from({ length: 50 }, (_, i) =>
+    makeEvent(`evt-b-${String(i + 151).padStart(3, "0")}`, i + 151),
+  );
+
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  const manager = new RpcFailoverManager([
+    {
+      url: primaryUrl,
+      client: buildClientWithEvents(primaryUrl, [...sharedEvents, ...primaryOnly]),
+    },
+    {
+      url: backupUrl,
+      client: buildClientWithEvents(backupUrl, [...sharedEvents, ...backupOnly]),
+    },
+  ]);
+
+  const primaryCursor = cursor(200, "evt-p-200");
+  const result = await manager.failover(primaryCursor, CONTRACT_ID);
+
+  assert.equal(result.endpoint.url, backupUrl);
+  assert.equal(result.resynced, true);
+
+  // The common point must be at or before ledger 150 (where histories agree)
+  // and must NOT be 0 (would skip all shared history) or 200 (wrong endpoint's events)
+  assert.ok(
+    result.cursor.lastLedger <= 150,
+    `resume ledger ${result.cursor.lastLedger} should be ≤ 150 (divergence point)`,
+  );
+  assert.ok(
+    result.cursor.lastLedger > 0,
+    `resume ledger should be > 0, not at genesis`,
+  );
+
+  // The event ID used as the common point must be from the shared history
+  assert.ok(
+    result.cursor.lastEventId?.startsWith("evt-"),
+    `common event ID ${result.cursor.lastEventId} should be from shared history`,
+  );
+  assert.ok(
+    !result.cursor.lastEventId?.startsWith("evt-p-"),
+    `common event ID should not be a primary-only event`,
+  );
+  assert.ok(
+    !result.cursor.lastEventId?.startsWith("evt-b-"),
+    `common event ID should not be a backup-only event`,
+  );
+});
+
+// ─── Resync: no common point found ────────────────────────────────────────────
+
+test("test_resync_no_common_point_found: throws ServiceUnavailableError, no silent resume", async () => {
+  // Completely different histories — no overlap at all
+  const primaryEvents = Array.from({ length: 30 }, (_, i) =>
+    makeEvent(`evt-primary-${i}`, i + 1),
+  );
+  const backupEvents = Array.from({ length: 30 }, (_, i) =>
+    makeEvent(`evt-backup-${i}`, i + 1),
+  );
+
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, primaryEvents) },
+    { url: backupUrl, client: buildClientWithEvents(backupUrl, backupEvents) },
+  ]);
+
+  const primaryCursor = cursor(30, "evt-primary-29");
+
+  await assert.rejects(
+    () => manager.failover(primaryCursor, CONTRACT_ID),
+    (err: unknown) => {
+      // Must be a ServiceUnavailableError — not a silent fallback
+      assert.ok(
+        err instanceof ServiceUnavailableError,
+        `expected ServiceUnavailableError, got ${(err as Error)?.constructor?.name}`,
+      );
+      // Error message must include both endpoint URLs for diagnostics
+      assert.ok(
+        (err as Error).message.includes(primaryUrl),
+        "error should mention the primary URL",
+      );
+      assert.ok(
+        (err as Error).message.includes(backupUrl),
+        "error should mention the backup URL",
+      );
+      return true;
+    },
+  );
+});
+
+test("failover throws ServiceUnavailableError when only one endpoint is configured", async () => {
+  const url = "https://only.rpc";
+  const manager = new RpcFailoverManager([
+    { url, client: buildClientWithEvents(url, []) },
+  ]);
+
+  await assert.rejects(
+    () => manager.failover(cursor(100), CONTRACT_ID),
+    (err: unknown) => {
+      assert.ok(err instanceof ServiceUnavailableError);
+      return true;
+    },
+  );
+});
+
+// ─── Multi-failover sequence ───────────────────────────────────────────────────
+
+test("test_multi_failover_sequence: primary → backup → primary, cursors stay correct", async () => {
+  // Shared history for all three endpoints: events 1–100
+  const sharedEvents = Array.from({ length: 100 }, (_, i) =>
+    makeEvent(`evt-${String(i + 1).padStart(3, "0")}`, i + 1),
+  );
+
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+  const secondaryUrl = "https://secondary.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, sharedEvents) },
+    { url: backupUrl, client: buildClientWithEvents(backupUrl, sharedEvents) },
+    { url: secondaryUrl, client: buildClientWithEvents(secondaryUrl, sharedEvents) },
+  ]);
+
+  // Initial state: polling on primary
+  assert.equal(manager.getActiveEndpoint().url, primaryUrl);
+
+  // Record cursors for primary and backup as if they've been running
+  manager.setCursorForEndpoint(primaryUrl, cursor(100, "evt-100"));
+  manager.setCursorForEndpoint(backupUrl, cursor(95));
+
+  // First failover: primary → backup
+  const result1 = await manager.failover(cursor(100, "evt-100"), CONTRACT_ID);
+  assert.equal(result1.endpoint.url, backupUrl);
+
+  // Simulate backup advancing its cursor
+  manager.setCursorForEndpoint(backupUrl, cursor(110, "evt-110"));
+
+  // Second failover: backup → secondary
+  const result2 = await manager.failover(cursor(110, "evt-110"), CONTRACT_ID);
+  assert.equal(result2.endpoint.url, secondaryUrl);
+
+  // Simulate secondary advancing and then primary recovering
+  manager.setCursorForEndpoint(secondaryUrl, cursor(120, "evt-120"));
+
+  // Third failover: secondary → primary (wraps around)
+  const result3 = await manager.failover(cursor(120, "evt-120"), CONTRACT_ID);
+  assert.equal(result3.endpoint.url, primaryUrl);
+
+  // Primary cursor should still be whatever we set earlier (independent tracking)
+  assert.deepEqual(
+    manager.getCursorForEndpoint(primaryUrl),
+    cursor(100, "evt-100"),
+    "primary cursor should be unchanged by the other endpoints' updates",
+  );
+
+  // Backup cursor should be the value we set (not clobbered by secondary)
+  assert.deepEqual(
+    manager.getCursorForEndpoint(backupUrl),
+    cursor(110, "evt-110"),
+    "backup cursor should be independent of secondary updates",
+  );
+
+  // Secondary cursor should be the value we set
+  assert.deepEqual(
+    manager.getCursorForEndpoint(secondaryUrl),
+    cursor(120, "evt-120"),
+  );
+});
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+test("failover when backup fetch fails: treated as empty overlap, triggers lookback", async () => {
+  // Primary has events, backup network-fails on all calls.
+  // The manager should handle the backup fetch failure gracefully (returns
+  // empty IDs, which means no common suffix found anywhere → ServiceUnavailableError).
+  const primaryEvents = Array.from({ length: 20 }, (_, i) =>
+    makeEvent(`evt-${i}`, i + 1),
+  );
+
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, primaryEvents) },
+    { url: backupUrl, client: buildFailingClient(backupUrl) },
+  ]);
+
+  // The failing backup returns no event IDs, so no common suffix can be found.
+  await assert.rejects(
+    () => manager.failover(cursor(20, "evt-19"), CONTRACT_ID),
+    (err: unknown) => {
+      assert.ok(err instanceof ServiceUnavailableError);
+      return true;
+    },
+  );
+});
+
+test("manager initialises with first endpoint as active", () => {
+  const url1 = "https://ep1.rpc";
+  const url2 = "https://ep2.rpc";
+
+  const manager = new RpcFailoverManager([
+    { url: url1, client: buildClientWithEvents(url1, []) },
+    { url: url2, client: buildClientWithEvents(url2, []) },
+  ]);
+
+  assert.equal(manager.getActiveEndpoint().url, url1);
+  assert.equal(manager.getActiveClient(), manager.getActiveEndpoint().client);
+});
+
+test("manager construction throws with zero endpoints", () => {
+  assert.throws(
+    () => new RpcFailoverManager([]),
+    /at least one endpoint/,
+  );
+});
+
+// ─── Resync lookback respects MAX_LOOKBACK_STEPS bound ────────────────────────
+
+test("resync search is bounded by MAX_LOOKBACK_STEPS — never scans unbounded history", async () => {
+  // Track how many getEvents calls are made to the backup. There should be at
+  // most 1 (validation) + MAX_LOOKBACK_STEPS calls.
+  let backupCallCount = 0;
+
+  const primaryEvents = Array.from({ length: 100 }, (_, i) =>
+    makeEvent(`evt-primary-${i}`, i + 1),
+  );
+
+  const primaryUrl = "https://primary.rpc";
+  const backupUrl = "https://backup.rpc";
+
+  // Custom backup fake that counts calls and returns nothing in common
+  const backupFetch: typeof fetch = async (_url, options) => {
+    const body = JSON.parse((options?.body ?? "{}") as string) as {
+      method: string;
+      id: number;
+    };
+    if (body.method === "getEvents") {
+      backupCallCount++;
+    }
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: { events: [], latestLedger: 100 },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  };
+
+  const backupClient = new SorobanRpcClient(
+    { url: backupUrl, maxRetries: 0 },
+    backupFetch,
+  );
+
+  const manager = new RpcFailoverManager([
+    { url: primaryUrl, client: buildClientWithEvents(primaryUrl, primaryEvents) },
+    { url: backupUrl, client: backupClient },
+  ]);
+
+  await assert.rejects(
+    () => manager.failover(cursor(100, "evt-primary-99"), CONTRACT_ID),
+    (err: unknown) => {
+      assert.ok(err instanceof ServiceUnavailableError);
+      return true;
+    },
+  );
+
+  // 1 initial validation call + at most MAX_LOOKBACK_STEPS further calls
+  const maxExpectedCalls = 1 + MAX_LOOKBACK_STEPS;
+  assert.ok(
+    backupCallCount <= maxExpectedCalls,
+    `backup was called ${backupCallCount} times but max expected is ${maxExpectedCalls}`,
+  );
+});

--- a/backend/src/modules/events/rpc-failover-manager.ts
+++ b/backend/src/modules/events/rpc-failover-manager.ts
@@ -1,0 +1,419 @@
+/**
+ * RpcFailoverManager
+ *
+ * Manages per-endpoint cursor tracking and safe failover between Soroban RPC
+ * endpoints. The central problem this solves: different RPC nodes can have
+ * diverging views of the chain (different indexing lag, different history
+ * depth, minor reorgs). Blindly carrying a primary cursor onto a backup
+ * endpoint can skip events or replay stale ones.
+ *
+ * ## Algorithm
+ *
+ * 1. Each endpoint gets its own `EventCursor` entry in `endpointCursors`.
+ * 2. Before failing over, fetch the last `VALIDATION_WINDOW` event IDs from
+ *    both endpoints around the primary's cursor position.
+ * 3. If they agree → consistent, carry the cursor over and continue.
+ * 4. If they diverge → walk backwards (bounded by `MAX_LOOKBACK`) to find
+ *    the most recent event ID seen by both endpoints.
+ * 5. Resume from that common point on the backup. If no common point is
+ *    found within the lookback bound, throw a `ServiceUnavailableError` so
+ *    the polling loop's exponential-backoff handler surfaces the problem
+ *    rather than silently resuming from an incorrect position.
+ */
+
+import { createLogger } from "../../shared/logging/logger.js";
+import { SorobanRpcClient } from "../../shared/rpc/soroban-rpc.client.js";
+import { ServiceUnavailableError } from "../../shared/errors/AppError.js";
+import type { EventCursor } from "./cursor/cursor.types.js";
+
+const logger = createLogger("rpc-failover-manager");
+
+/**
+ * Number of recent events fetched from each endpoint during the consistency
+ * check. Kept small to bound latency on every failover.
+ */
+export const VALIDATION_WINDOW = 20;
+
+/**
+ * Maximum number of ledgers to walk backwards when searching for a common
+ * prefix. Equates to at most VALIDATION_WINDOW * MAX_LOOKBACK_STEPS event
+ * fetches total, which is well-bounded.
+ */
+export const MAX_LOOKBACK_STEPS = 5;
+
+/**
+ * Ledger stride used for each backwards step during the common-prefix search.
+ * Walking back VALIDATION_WINDOW ledgers per step keeps the search efficient.
+ */
+const LOOKBACK_STRIDE_LEDGERS = VALIDATION_WINDOW;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface EndpointInfo {
+  readonly url: string;
+  readonly client: SorobanRpcClient;
+}
+
+/**
+ * Result of a failover decision: the endpoint to use and the cursor to start
+ * from on that endpoint.
+ */
+export interface FailoverResult {
+  /** The backup endpoint that the caller should switch to. */
+  readonly endpoint: EndpointInfo;
+  /** Cursor position to resume from on the backup endpoint. */
+  readonly cursor: EventCursor;
+  /**
+   * True when the common prefix was found within the lookback window.
+   * False when the backup's latest state already agrees with the primary's
+   * cursor (no divergence detected, fast path).
+   */
+  readonly resynced: boolean;
+}
+
+// ─── RpcFailoverManager ───────────────────────────────────────────────────────
+
+export class RpcFailoverManager {
+  /**
+   * Per-endpoint cursor map, keyed by endpoint URL.
+   * Each endpoint independently tracks the last ledger it successfully
+   * processed so that switching between them never conflates positions.
+   */
+  private readonly endpointCursors: Map<string, EventCursor> = new Map();
+
+  /**
+   * Index of the currently-active endpoint in `endpoints`.
+   */
+  private activeIndex = 0;
+
+  constructor(private readonly endpoints: EndpointInfo[]) {
+    if (endpoints.length === 0) {
+      throw new Error("RpcFailoverManager requires at least one endpoint");
+    }
+  }
+
+  // ── Accessors ───────────────────────────────────────────────────────────────
+
+  /** Returns the currently active endpoint. */
+  public getActiveEndpoint(): EndpointInfo {
+    return this.endpoints[this.activeIndex]!;
+  }
+
+  /** Returns the RPC client for the currently active endpoint. */
+  public getActiveClient(): SorobanRpcClient {
+    return this.getActiveEndpoint().client;
+  }
+
+  /**
+   * Returns the cursor for the given endpoint URL, or null if no cursor has
+   * been recorded yet for that endpoint.
+   */
+  public getCursorForEndpoint(url: string): EventCursor | null {
+    return this.endpointCursors.get(url) ?? null;
+  }
+
+  /**
+   * Records a successfully processed cursor position for the given endpoint.
+   * This is called by the polling loop after each successful poll so that the
+   * per-endpoint state stays up to date.
+   */
+  public setCursorForEndpoint(url: string, cursor: EventCursor): void {
+    this.endpointCursors.set(url, cursor);
+  }
+
+  /** Returns all endpoint URLs and their latest known cursors. */
+  public getAllEndpointCursors(): Array<{ url: string; cursor: EventCursor | null }> {
+    return this.endpoints.map((ep) => ({
+      url: ep.url,
+      cursor: this.endpointCursors.get(ep.url) ?? null,
+    }));
+  }
+
+  // ── Failover ────────────────────────────────────────────────────────────────
+
+  /**
+   * Attempts a safe failover from the current active endpoint to the next
+   * available backup.
+   *
+   * Steps:
+   *   1. Pick the next endpoint in round-robin order.
+   *   2. Validate cursor consistency between primary and backup.
+   *   3. If consistent → return the primary's cursor for use on the backup.
+   *   4. If diverged → emit a warning, find the common prefix, return it.
+   *   5. If no common prefix found → throw ServiceUnavailableError.
+   *
+   * @param primaryCursor The primary's last successfully persisted cursor.
+   * @param contractId    Contract ID used for event fetches during validation.
+   */
+  public async failover(
+    primaryCursor: EventCursor,
+    contractId: string,
+  ): Promise<FailoverResult> {
+    if (this.endpoints.length === 1) {
+      throw new ServiceUnavailableError(
+        "RPC failover attempted but no backup endpoints are configured",
+      );
+    }
+
+    const primaryEndpoint = this.getActiveEndpoint();
+
+    // Advance to the next endpoint (round-robin).
+    this.activeIndex = (this.activeIndex + 1) % this.endpoints.length;
+    const backupEndpoint = this.getActiveEndpoint();
+
+    logger.info("attempting RPC failover", {
+      from: primaryEndpoint.url,
+      to: backupEndpoint.url,
+      primaryCursor: primaryCursor.lastLedger,
+    });
+
+    // Step 2–4: validate consistency and resync if needed.
+    const cursor = await this.validateAndResync(
+      primaryEndpoint,
+      backupEndpoint,
+      primaryCursor,
+      contractId,
+    );
+
+    return {
+      endpoint: backupEndpoint,
+      cursor,
+      resynced: cursor.lastLedger !== primaryCursor.lastLedger,
+    };
+  }
+
+  // ── Validation & resync ────────────────────────────────────────────────────
+
+  /**
+   * Validates cursor consistency between primary and backup, then returns the
+   * safe cursor position to resume from on the backup.
+   *
+   * If both endpoints agree on the last VALIDATION_WINDOW events immediately
+   * before `primaryCursor.lastLedger`, the primary's cursor is returned
+   * unchanged (fast path).
+   *
+   * If they disagree, the method walks backwards from the primary's cursor to
+   * find the most recent common event ID.
+   */
+  private async validateAndResync(
+    primary: EndpointInfo,
+    backup: EndpointInfo,
+    primaryCursor: EventCursor,
+    contractId: string,
+  ): Promise<EventCursor> {
+    const primaryIds = await this.fetchRecentEventIds(
+      primary.client,
+      primaryCursor.lastLedger,
+      contractId,
+    );
+
+    const backupIds = await this.fetchRecentEventIds(
+      backup.client,
+      primaryCursor.lastLedger,
+      contractId,
+    );
+
+    const commonId = findCommonSuffix(primaryIds, backupIds);
+
+    if (commonId !== null && primaryIds[primaryIds.length - 1] === backupIds[backupIds.length - 1]) {
+      // Fast path: both endpoints agree on the most recent event.
+      logger.info("cursor consistency validated, no divergence detected", {
+        primary: primary.url,
+        backup: backup.url,
+        ledger: primaryCursor.lastLedger,
+      });
+      return primaryCursor;
+    }
+
+    // Cursors have diverged — emit the mandatory warning.
+    const divergencePoint = commonId ?? "none";
+    logger.warn("cursor divergence detected between RPC endpoints", {
+      primary: primary.url,
+      backup: backup.url,
+      primaryCursorLedger: primaryCursor.lastLedger,
+      divergencePoint,
+      primaryRecentEventCount: primaryIds.length,
+      backupRecentEventCount: backupIds.length,
+    });
+
+    // Fast-path: a common point was already found within the validation window.
+    if (commonId !== null) {
+      const ledger = await this.ledgerForEventId(
+        backup.client,
+        commonId,
+        primaryCursor.lastLedger,
+        contractId,
+      );
+      logger.info("resuming from common prefix found in validation window", {
+        backup: backup.url,
+        commonEventId: commonId,
+        ledger,
+      });
+      return {
+        lastLedger: ledger,
+        lastEventId: commonId,
+        updatedAt: new Date().toISOString(),
+      };
+    }
+
+    // Walk backwards to find the common prefix.
+    return this.findCommonPrefixWithLookback(
+      primary,
+      backup,
+      primaryCursor,
+      contractId,
+    );
+  }
+
+  /**
+   * Walks backwards from `primaryCursor.lastLedger` in steps of
+   * `LOOKBACK_STRIDE_LEDGERS` ledgers, up to `MAX_LOOKBACK_STEPS` iterations,
+   * fetching events from both endpoints at each step to find a matching event
+   * ID.
+   *
+   * Throws `ServiceUnavailableError` if no common point is found within the
+   * lookback bound.
+   */
+  private async findCommonPrefixWithLookback(
+    primary: EndpointInfo,
+    backup: EndpointInfo,
+    primaryCursor: EventCursor,
+    contractId: string,
+  ): Promise<EventCursor> {
+    let searchLedger = primaryCursor.lastLedger;
+
+    for (let step = 0; step < MAX_LOOKBACK_STEPS; step++) {
+      searchLedger = Math.max(1, searchLedger - LOOKBACK_STRIDE_LEDGERS);
+
+      const primaryIds = await this.fetchRecentEventIds(
+        primary.client,
+        searchLedger,
+        contractId,
+      );
+      const backupIds = await this.fetchRecentEventIds(
+        backup.client,
+        searchLedger,
+        contractId,
+      );
+
+      const commonId = findCommonSuffix(primaryIds, backupIds);
+
+      if (commonId !== null) {
+        const ledger = await this.ledgerForEventId(
+          backup.client,
+          commonId,
+          searchLedger,
+          contractId,
+        );
+        logger.info("common prefix found during lookback walk", {
+          primary: primary.url,
+          backup: backup.url,
+          step,
+          searchLedger,
+          commonEventId: commonId,
+          resumeLedger: ledger,
+        });
+        return {
+          lastLedger: ledger,
+          lastEventId: commonId,
+          updatedAt: new Date().toISOString(),
+        };
+      }
+
+      // If we've reached ledger 1, stop — nothing further to walk back.
+      if (searchLedger <= 1) break;
+    }
+
+    // No common point found within the lookback bound.
+    logger.warn("no common prefix found within lookback bound — cannot safely resume", {
+      primary: primary.url,
+      backup: backup.url,
+      primaryCursorLedger: primaryCursor.lastLedger,
+      stepsSearched: MAX_LOOKBACK_STEPS,
+    });
+
+    throw new ServiceUnavailableError(
+      `RPC failover aborted: no common event history found between ` +
+        `${primary.url} and ${backup.url} within ${MAX_LOOKBACK_STEPS * LOOKBACK_STRIDE_LEDGERS} ledgers ` +
+        `of the primary cursor (ledger ${primaryCursor.lastLedger}). ` +
+        `Manual intervention required to determine a safe resume point.`,
+    );
+  }
+
+  /**
+   * Fetches the most recent up-to-VALIDATION_WINDOW event IDs from an
+   * endpoint, starting from `ledger - VALIDATION_WINDOW + 1` so that the
+   * window is anchored at `ledger`.
+   */
+  private async fetchRecentEventIds(
+    client: SorobanRpcClient,
+    ledger: number,
+    contractId: string,
+  ): Promise<string[]> {
+    const startLedger = Math.max(1, ledger - VALIDATION_WINDOW + 1);
+    try {
+      const page = await client.getEventsPage({
+        startLedger,
+        filters: [{ type: "contract", contractIds: [contractId] }],
+        pagination: { limit: VALIDATION_WINDOW },
+      });
+      return page.events.map((e) => e.id);
+    } catch (err) {
+      logger.warn("failed to fetch events for consistency check", {
+        url: (client as any).url ?? "unknown",
+        ledger,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // Return empty array so the caller treats this endpoint as having no
+      // overlap — will trigger divergence handling rather than crashing.
+      return [];
+    }
+  }
+
+  /**
+   * Given a known event ID, finds the ledger number it belongs to by fetching
+   * a small event window from the backup endpoint.
+   *
+   * Falls back to `anchorLedger` if the event cannot be found (conservative).
+   */
+  private async ledgerForEventId(
+    client: SorobanRpcClient,
+    eventId: string,
+    anchorLedger: number,
+    contractId: string,
+  ): Promise<number> {
+    const startLedger = Math.max(1, anchorLedger - VALIDATION_WINDOW + 1);
+    try {
+      const page = await client.getEventsPage({
+        startLedger,
+        filters: [{ type: "contract", contractIds: [contractId] }],
+        pagination: { limit: VALIDATION_WINDOW },
+      });
+      const match = page.events.find((e) => e.id === eventId);
+      return match?.ledger ?? anchorLedger;
+    } catch {
+      return anchorLedger;
+    }
+  }
+}
+
+// ─── Pure helpers (exported for testing) ─────────────────────────────────────
+
+/**
+ * Returns the most recent event ID that appears in both `a` and `b`, or null
+ * if there is no overlap.
+ *
+ * Searches from the end of each array (most recent events first) so that the
+ * most recent common point is returned, avoiding unnecessary replay.
+ */
+export function findCommonSuffix(a: string[], b: string[]): string | null {
+  const setB = new Set(b);
+  // Walk `a` from the end to find the most recent common ID.
+  for (let i = a.length - 1; i >= 0; i--) {
+    const id = a[i];
+    if (id !== undefined && setB.has(id)) {
+      return id;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #1368

## Problem
The event polling service tracked a single global cursor shared across all RPC endpoints. On failover to a backup, the primary's cursor position could be inconsistent with the backup's event history (different indexing lag, reorgs, history depth), causing silent event skips or stale replays.

## Changes

### New file: rpc-failover-manager.ts
- RpcFailoverManager class with a Map<endpointUrl, EventCursor> so each endpoint tracks its own position independently.
- failover(primaryCursor, contractId) performs pre-failover validation:
  1. Fetch the last VALIDATION_WINDOW (20) event IDs from both endpoints around the primary's cursor ledger.
  2. If they agree on the most recent event -> consistent, carry cursor over (fast path, no warning).
  3. If they disagree -> emit logger.warn with both endpoint URLs, primary cursor ledger, and divergence point.
  4. Walk backwards up to MAX_LOOKBACK_STEPS (5) x 20 ledgers to find the most recent common event ID (findCommonSuffix).
  5. Resume from that common point on the backup.
  6. If no common point is found within the bound -> throw ServiceUnavailableError (matches the codebase's existing 'can't determine safe state' philosophy - never silent incorrect resumption).
- findCommonSuffix() pure helper exported for unit testing.
- All RPC fetches during validation are bounded; no unbounded history scans.

### New file: rpc-failover-manager.test.ts
18 tests covering all required scenarios (node:test, node:assert/strict, same patterns as existing events.service.test.ts):
- test_per_endpoint_cursor_tracked_independently
- test_failover_with_consistent_cursors
- test_failover_with_diverged_cursors
- test_resync_finds_common_prefix (not too early, not skipping events)
- test_resync_no_common_point_found (ServiceUnavailableError, no silent resume)
- test_multi_failover_sequence (primary -> backup -> primary recovery)
- findCommonSuffix unit tests (disjoint, overlap, empty, latest-match)
- Lookup bound enforcement (call count capped at 1 + MAX_LOOKBACK_STEPS)
- Single-endpoint guard, failing-backup graceful handling

### Modified: events/index.ts
- Re-exports RpcFailoverManager and findCommonSuffix from the events module.

## Test output
18 pass, 0 fail (node --test, tsx loader, 30s timeout)

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
