### PR TITLE
feat(#1379): implement API request signing for enhanced security

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -33,6 +33,13 @@ REQUEST_BODY_LIMIT=10kb
 # Type: string | Required: Yes (production)
 API_KEY=
 
+# HMAC signing secret for request body integrity verification (issue #1379)
+# Shared between the server and trusted API clients. Used by
+# createHmacSigningMiddleware to verify that request bodies have not been
+# tampered with in transit. MUST be distinct from API_KEY.
+# Type: string | Recommended: >= 32 random chars | Optional (passthrough when unset)
+VAULT_HMAC_SECRET=
+
 # ------------------------------------------------------------------------------
 # 2. Stellar Network & Contract
 # ------------------------------------------------------------------------------

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -27,6 +27,7 @@ import { createJobsRouter } from "./modules/jobs/jobs.routes.js";
 import { error, success } from "./shared/http/response.js";
 import { createRateLimitMiddleware } from "./shared/http/rateLimit.js";
 import { createAuthMiddleware, requireApiKey } from "./shared/http/auth.js";
+import { createJsonWithRawBody, createHmacSigningMiddleware } from "./shared/http/hmac.js";
 import { ErrorCode } from "./shared/http/errorCodes.js";
 import {
   REQUEST_ID_HEADER,
@@ -203,9 +204,18 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   });
 
   const v1Router = express.Router();
-  v1Router.use(express.json({ limit: env.requestBodyLimit }));
+  // Replace bare express.json() with the raw-body-capturing variant so that
+  // createHmacSigningMiddleware can read (req as any).rawBody for verification.
+  v1Router.use(createJsonWithRawBody({ limit: env.requestBodyLimit }));
 
-  v1Router.get("/admin/key-status", adminAuthMiddleware, (_req, res) => {
+  // HMAC request-signing verification — runs after body parsing but before any
+  // business logic. When VAULT_HMAC_SECRET is not set the middleware is a no-op
+  // (passthrough), matching the existing API-key passthrough behaviour in dev.
+  const hmacMiddleware = createHmacSigningMiddleware(
+    () => env.hmacSecret,
+  );
+
+  v1Router.get("/admin/key-status", adminAuthMiddleware, hmacMiddleware, (_req, res) => {
     const rotationPending = Boolean(authKeyState.next);
     res.status(200).json({
       success: true,
@@ -216,7 +226,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     });
   });
 
-  v1Router.post("/admin/rotate-key", adminAuthMiddleware, (_req, res) => {
+  v1Router.post("/admin/rotate-key", adminAuthMiddleware, hmacMiddleware, (_req, res) => {
     if (!authKeyState.next) {
       error(res, {
         message: "No pending API key rotation",
@@ -238,17 +248,17 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     });
   });
 
-  v1Router.get("/admin/cors/origins", adminAuthMiddleware, getCorsOriginsController(corsAllowlist));
-  v1Router.post("/admin/cors/origins", adminAuthMiddleware, addCorsOriginController(corsAllowlist));
-  v1Router.delete("/admin/cors/origins", adminAuthMiddleware, removeCorsOriginController(corsAllowlist));
+  v1Router.get("/admin/cors/origins", adminAuthMiddleware, hmacMiddleware, getCorsOriginsController(corsAllowlist));
+  v1Router.post("/admin/cors/origins", adminAuthMiddleware, hmacMiddleware, addCorsOriginController(corsAllowlist));
+  v1Router.delete("/admin/cors/origins", adminAuthMiddleware, hmacMiddleware, removeCorsOriginController(corsAllowlist));
 
-  v1Router.post("/admin/cursor/migrate", adminAuthMiddleware, triggerCursorMigrationController(runtime.dbCursorAdapter));
-  v1Router.post("/admin/cursor/rollback", adminAuthMiddleware, rollbackCursorMigrationController(runtime.dbCursorAdapter));
+  v1Router.post("/admin/cursor/migrate", adminAuthMiddleware, hmacMiddleware, triggerCursorMigrationController(runtime.dbCursorAdapter));
+  v1Router.post("/admin/cursor/rollback", adminAuthMiddleware, hmacMiddleware, rollbackCursorMigrationController(runtime.dbCursorAdapter));
 
   v1Router.use("/status", createStatusRouter(env, runtime));
   v1Router.use("/metrics", createMetricsRouter(runtime, adminAuthMiddleware));
   v1Router.use("/health", createDetailedHealthRouter(env, runtime));
-  v1Router.use("/events", authMiddleware, createEventsRouter());
+  v1Router.use("/events", authMiddleware, hmacMiddleware, createEventsRouter());
 
   // Contracts listing
   const registry = new (
@@ -270,7 +280,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     }
   }
 
-  v1Router.get("/admin/config", adminAuthMiddleware, (_req, res) => {
+  v1Router.get("/admin/config", adminAuthMiddleware, hmacMiddleware, (_req, res) => {
     success(res, {
       nodeEnv: env.nodeEnv,
       stellarNetwork: env.stellarNetwork,
@@ -299,7 +309,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     });
   });
 
-  v1Router.get("/admin/jobs/graph", adminAuthMiddleware, (_req, res) => {
+  v1Router.get("/admin/jobs/graph", adminAuthMiddleware, hmacMiddleware, (_req, res) => {
     try {
       const graph = (runtime as any).jobManager?.getDependencyGraph?.() ?? {};
       success(res, graph);
@@ -313,29 +323,30 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   });
 
   // ── Feature Flags Admin ──────────────────────────────────────────────────────
-  v1Router.get("/admin/features", adminAuthMiddleware, (_req, res) => {
+  v1Router.get("/admin/features", adminAuthMiddleware, hmacMiddleware, (_req, res) => {
     success(res, getFeatureFlags().list());
   });
 
-  v1Router.post("/admin/features/:flag/enable", adminAuthMiddleware, (req, res) => {
+  v1Router.post("/admin/features/:flag/enable", adminAuthMiddleware, hmacMiddleware, (req, res) => {
     const { flag } = req.params as { flag: string };
     getFeatureFlags().enable(flag);
     success(res, { flag, enabled: true });
   });
 
-  v1Router.post("/admin/features/:flag/disable", adminAuthMiddleware, (req, res) => {
+  v1Router.post("/admin/features/:flag/disable", adminAuthMiddleware, hmacMiddleware, (req, res) => {
     const { flag } = req.params as { flag: string };
     getFeatureFlags().disable(flag);
     success(res, { flag, enabled: false });
   });
 
   // ── RPC Pool Status ──────────────────────────────────────────────────────────
-  v1Router.get("/rpc/pool/status", adminAuthMiddleware, (_req, res) => {
+  v1Router.get("/rpc/pool/status", adminAuthMiddleware, hmacMiddleware, (_req, res) => {
     success(res, { endpoints: rpcPool.getStatus() });
   });
 
   v1Router.use(
     "/contracts",
+    hmacMiddleware,
     createContractsRouter(registry, adminAuthMiddleware, (runtime as any).contractStateValidator),
   );
 
@@ -343,6 +354,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   if (runtime.jobManager && runtime.scheduledJobRunner) {
     v1Router.use(
       "/jobs",
+      hmacMiddleware,
       createJobsRouter(runtime.jobManager, runtime.scheduledJobRunner, adminAuthMiddleware),
     );
   }
@@ -351,7 +363,8 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     v1Router.use(
       "/notifications",
       authMiddleware,
-      express.json({ limit: env.notificationsRequestBodyLimit }),
+      hmacMiddleware,
+      createJsonWithRawBody({ limit: env.notificationsRequestBodyLimit }),
       createNotificationsRouter(runtime.notificationQueue),
     );
   }
@@ -360,7 +373,8 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     v1Router.use(
       "/webhooks",
       authMiddleware,
-      express.json({ limit: env.webhooksRequestBodyLimit }),
+      hmacMiddleware,
+      createJsonWithRawBody({ limit: env.webhooksRequestBodyLimit }),
       createWebhookRouter(runtime.webhookDeliveryService),
     );
   }
@@ -368,7 +382,8 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   v1Router.use(
     "/snapshots",
     authMiddleware,
-    express.json({ limit: env.snapshotsRequestBodyLimit }),
+    hmacMiddleware,
+    createJsonWithRawBody({ limit: env.snapshotsRequestBodyLimit }),
     createSnapshotRouter(
       runtime.snapshotService,
       adminAuthMiddleware,
@@ -380,6 +395,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   v1Router.use(
     "/proposals",
     authMiddleware,
+    hmacMiddleware,
     createProposalsRouter(
       runtime.proposalActivityAggregator,
       runtime.proposalActivityPersistence,
@@ -389,6 +405,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   v1Router.use(
     "/recurring",
     authMiddleware,
+    hmacMiddleware,
     createRecurringRouter(
       runtime.recurringIndexerService,
       authMiddleware,
@@ -399,6 +416,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   v1Router.use(
     "/transactions",
     authMiddleware,
+    hmacMiddleware,
     createTransactionsRouter(
       runtime.transactionsService,
       env.contractId,
@@ -409,6 +427,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   v1Router.use(
     "/audit",
     authMiddleware,
+    hmacMiddleware,
     createAuditRouter(env.sorobanRpcUrl, adminAuthMiddleware),
   );
 
@@ -416,6 +435,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     v1Router.use(
       "/cache",
       authMiddleware,
+      hmacMiddleware,
       createCacheRouter(runtime.cacheManager, adminAuthMiddleware),
     );
   }
@@ -423,6 +443,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   if (runtime.dbCursorAdapter) {
     v1Router.use(
       "/cursors",
+      hmacMiddleware,
       createCursorsRouter(runtime.dbCursorAdapter, adminAuthMiddleware),
     );
   }
@@ -440,6 +461,7 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   v1Router.use(
     "/vault",
     authMiddleware,
+    hmacMiddleware,
     createVaultRouter(env.sorobanRpcUrl, passphrase, runtime.cacheManager, (runtime as any).vaultRegistry, adminAuthMiddleware),
   );
 

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -23,6 +23,22 @@ export interface BackendEnv {
   readonly webhooksRequestBodyLimit: string;
   readonly apiKey?: string;
   readonly apiKeyNext?: string;
+  /**
+   * Shared HMAC-SHA256 signing secret.
+   *
+   * Used by `createHmacSigningMiddleware` to verify that incoming request
+   * bodies have not been tampered with in transit. This secret is shared
+   * between the server and trusted API clients.
+   *
+   * IMPORTANT: This must be distinct from `apiKey` / `VAULT_API_KEY`.
+   * Mixing the two secrets would weaken both — one proves identity, the
+   * other proves payload integrity.
+   *
+   * Env var: `VAULT_HMAC_SECRET`
+   * When absent the HMAC middleware runs in passthrough mode (same behaviour
+   * as the API-key auth middleware when no key is configured).
+   */
+  readonly hmacSecret?: string;
   readonly cursorStorageType: "file" | "database";
   readonly databasePath: string;
   readonly rateLimitEnabled: boolean;
@@ -303,6 +319,7 @@ export function loadEnv(): BackendEnv {
   );
   const apiKey = readValue("VAULT_API_KEY") ?? readValue("API_KEY");
   const apiKeyNext = readValue("VAULT_API_KEY_NEXT");
+  const hmacSecret = readValue("VAULT_HMAC_SECRET");
   const cursorStorageType = readString("CURSOR_STORAGE_TYPE", "file") as
     | "file"
     | "database";
@@ -401,6 +418,7 @@ export function loadEnv(): BackendEnv {
     webhooksRequestBodyLimit,
     apiKey,
     apiKeyNext,
+    hmacSecret,
     cursorStorageType,
     databasePath,
     rateLimitEnabled,

--- a/backend/src/shared/http/hmac.test.ts
+++ b/backend/src/shared/http/hmac.test.ts
@@ -1,0 +1,428 @@
+/**
+ * Tests for HMAC-SHA256 request-signing middleware (issue #1379).
+ *
+ * Covers:
+ *   1.  Valid signature + fresh timestamp → request proceeds (200)
+ *   2.  Tampered body → rejected (401)
+ *   3.  Tampered timestamp → rejected (401)
+ *   4.  Missing X-Signature header → rejected (401)
+ *   5.  Missing X-Timestamp header → rejected (401)
+ *   6.  Stale timestamp (> 5 min old) → rejected (401)
+ *   7.  Timestamp too far in the future (> 5 min) → rejected (401)
+ *   8.  Malformed / non-numeric timestamp → rejected (401), no crash
+ *   9.  No HMAC secret configured → passthrough (middleware disabled)
+ *   10. GET request with no body → correct canonical string uses ""
+ *   11. computeSignature / safeEqual unit tests
+ *   12. Existing authenticated endpoint tests still pass (regression guard)
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createHmac } from "node:crypto";
+import express from "express";
+import { Server } from "node:http";
+import { once } from "node:events";
+
+import {
+  createHmacSigningMiddleware,
+  createJsonWithRawBody,
+  computeSignature,
+  safeEqual,
+  MAX_SKEW_MS,
+  TIMESTAMP_HEADER,
+  SIGNATURE_HEADER,
+} from "./hmac.js";
+
+// ── Unit Tests ────────────────────────────────────────────────────────────────
+
+test("computeSignature produces sha256= prefixed hex string", () => {
+  const sig = computeSignature("secret", "1000.hello");
+  assert.ok(sig.startsWith("sha256="), `Expected sha256= prefix, got: ${sig}`);
+  // Hex part should be 64 chars (32 bytes SHA-256)
+  assert.strictEqual(sig.slice(7).length, 64);
+  // Should be deterministic
+  assert.strictEqual(computeSignature("secret", "1000.hello"), sig);
+  // Different inputs → different output
+  assert.notStrictEqual(computeSignature("secret", "1000.world"), sig);
+  assert.notStrictEqual(computeSignature("other", "1000.hello"), sig);
+});
+
+test("computeSignature matches manual HMAC-SHA256 computation", () => {
+  const secret = "my-test-secret";
+  const canonical = "1721900000000.{\"key\":\"value\"}";
+  const expected =
+    "sha256=" +
+    createHmac("sha256", secret).update(canonical, "utf8").digest("hex");
+  assert.strictEqual(computeSignature(secret, canonical), expected);
+});
+
+test("safeEqual returns true for identical strings", () => {
+  assert.ok(safeEqual("abc", "abc"));
+  assert.ok(safeEqual("", ""));
+  assert.ok(safeEqual("sha256=abcdef", "sha256=abcdef"));
+});
+
+test("safeEqual returns false for different strings", () => {
+  assert.ok(!safeEqual("abc", "xyz"));
+  assert.ok(!safeEqual("abc", "abcd"));
+  assert.ok(!safeEqual("", "x"));
+});
+
+test("safeEqual returns false for different-length strings (no throw)", () => {
+  // Must not throw even when lengths differ
+  assert.ok(!safeEqual("short", "much-longer-string-here"));
+});
+
+// ── Integration helpers ───────────────────────────────────────────────────────
+
+const TEST_SECRET = "test-hmac-secret-32chars-minimum!";
+
+/** Build headers for a signed request. */
+function signRequest(
+  body: string,
+  opts: {
+    secret?: string;
+    timestamp?: number;
+    /** Override the X-Signature header value directly. */
+    overrideSignature?: string;
+    /** Override the X-Timestamp header value directly. */
+    overrideTimestamp?: string;
+    omitSignature?: boolean;
+    omitTimestamp?: boolean;
+  } = {},
+): Record<string, string> {
+  const ts = opts.timestamp ?? Date.now();
+  const canonical = `${ts}.${body}`;
+  const sig = computeSignature(opts.secret ?? TEST_SECRET, canonical);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!opts.omitSignature) {
+    headers[SIGNATURE_HEADER] = opts.overrideSignature ?? sig;
+  }
+  if (!opts.omitTimestamp) {
+    headers[TIMESTAMP_HEADER] = opts.overrideTimestamp ?? String(ts);
+  }
+  return headers;
+}
+
+/** Spin up a minimal Express app with the HMAC middleware wired in. */
+async function startTestServer(secret?: string): Promise<{
+  baseUrl: string;
+  server: Server;
+  close: () => Promise<void>;
+}> {
+  const app = express();
+
+  // Raw-body capture + JSON parsing (same pattern as production app.ts)
+  app.use(createJsonWithRawBody({ limit: "1mb" }));
+
+  // HMAC middleware
+  app.use(createHmacSigningMiddleware(secret));
+
+  // Simple echo endpoint
+  app.post("/echo", (req, res) => {
+    res.status(200).json({ ok: true, body: req.body });
+  });
+
+  // Bodyless GET endpoint
+  app.get("/ping", (_req, res) => {
+    res.status(200).json({ ok: true });
+  });
+
+  const server = app.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const addr = server.address() as { port: number };
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+  const close = () =>
+    new Promise<void>((resolve) => {
+      if (typeof (server as any).closeAllConnections === "function") {
+        (server as any).closeAllConnections();
+      }
+      server.close(() => resolve());
+    });
+
+  return { baseUrl, server, close };
+}
+
+// ── Integration Tests ─────────────────────────────────────────────────────────
+
+test("HMAC middleware — 1. valid signature + fresh timestamp → 200", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ action: "transfer", amount: 100 });
+  const headers = signRequest(body);
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers,
+    body,
+  });
+  assert.strictEqual(res.status, 200);
+  const json = (await res.json()) as any;
+  assert.strictEqual(json.ok, true);
+});
+
+test("HMAC middleware — 2. tampered body → 401", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  // Sign the original body, then send a different body
+  const originalBody = JSON.stringify({ amount: 100 });
+  const tamperedBody = JSON.stringify({ amount: 999 });
+  const headers = signRequest(originalBody); // signature is over originalBody
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers,
+    body: tamperedBody, // body doesn't match signature
+  });
+  assert.strictEqual(res.status, 401);
+  const json = (await res.json()) as any;
+  assert.strictEqual(json.success, false);
+  assert.ok(
+    json.error.message.includes("Invalid request signature"),
+    `Unexpected message: ${json.error.message}`,
+  );
+});
+
+test("HMAC middleware — 3. tampered timestamp → 401", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ action: "transfer" });
+  const realTs = Date.now();
+  const canonical = `${realTs}.${body}`;
+  const sig = computeSignature(TEST_SECRET, canonical);
+
+  // Send a different timestamp value in the header — sig won't match
+  const tamperedTs = realTs + 1000;
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      [SIGNATURE_HEADER]: sig,
+      [TIMESTAMP_HEADER]: String(tamperedTs),
+    },
+    body,
+  });
+  assert.strictEqual(res.status, 401);
+  const json = (await res.json()) as any;
+  assert.ok(
+    json.error.message.includes("Invalid request signature"),
+    `Unexpected message: ${json.error.message}`,
+  );
+});
+
+test("HMAC middleware — 4. missing X-Signature header → 401", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ foo: "bar" });
+  const headers = signRequest(body, { omitSignature: true });
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers,
+    body,
+  });
+  assert.strictEqual(res.status, 401);
+  const json = (await res.json()) as any;
+  assert.ok(
+    json.error.message.includes("Missing X-Signature"),
+    `Unexpected message: ${json.error.message}`,
+  );
+});
+
+test("HMAC middleware — 5. missing X-Timestamp header → 401", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ foo: "bar" });
+  const headers = signRequest(body, { omitTimestamp: true });
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers,
+    body,
+  });
+  assert.strictEqual(res.status, 401);
+  const json = (await res.json()) as any;
+  assert.ok(
+    json.error.message.includes("Missing X-Timestamp"),
+    `Unexpected message: ${json.error.message}`,
+  );
+});
+
+test("HMAC middleware — 6. stale timestamp (> 5 min old) → 401", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ foo: "bar" });
+  const staleTs = Date.now() - MAX_SKEW_MS - 1000; // 1 second past the tolerance
+  const headers = signRequest(body, { timestamp: staleTs });
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers,
+    body,
+  });
+  assert.strictEqual(res.status, 401);
+  const json = (await res.json()) as any;
+  assert.ok(
+    json.error.message.includes("too old"),
+    `Unexpected message: ${json.error.message}`,
+  );
+});
+
+test("HMAC middleware — 7. timestamp too far in the future → 401", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ foo: "bar" });
+  const futureTs = Date.now() + MAX_SKEW_MS + 1000; // 1 second past tolerance
+  const headers = signRequest(body, { timestamp: futureTs });
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers,
+    body,
+  });
+  assert.strictEqual(res.status, 401);
+  const json = (await res.json()) as any;
+  assert.ok(
+    json.error.message.includes("future"),
+    `Unexpected message: ${json.error.message}`,
+  );
+});
+
+test("HMAC middleware — 8. malformed timestamp (non-numeric) → 401, no crash", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ foo: "bar" });
+
+  for (const badTs of ["abc", "", "not-a-number", "1.5", "Infinity", "NaN"]) {
+    const res = await fetch(`${baseUrl}/echo`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNATURE_HEADER]: "sha256=doesnotmatter",
+        [TIMESTAMP_HEADER]: badTs,
+      },
+      body,
+    });
+    assert.strictEqual(
+      res.status,
+      401,
+      `Expected 401 for timestamp="${badTs}", got ${res.status}`,
+    );
+    const json = (await res.json()) as any;
+    // Empty string: req.get() returns undefined, so it's treated as missing.
+    // Non-empty non-numeric strings: reach the format validator.
+    // Both outcomes correctly produce 401 — we accept either rejection message.
+    const isExpectedMessage =
+      json.error.message.includes("X-Timestamp must be a valid") ||
+      json.error.message.includes("Missing X-Timestamp");
+    assert.ok(
+      isExpectedMessage,
+      `Unexpected message for ts="${badTs}": ${json.error.message}`,
+    );
+  }
+});
+
+test("HMAC middleware — 9. no HMAC secret configured → passthrough (disabled)", async (t) => {
+  // Start a server with no secret — middleware must be a no-op
+  const { baseUrl, close } = await startTestServer(undefined);
+  t.after(close);
+
+  const body = JSON.stringify({ foo: "bar" });
+
+  // No signing headers at all — should still reach the handler
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  assert.strictEqual(res.status, 200);
+});
+
+test("HMAC middleware — 10. GET request with no body uses empty canonical body", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const ts = Date.now();
+  const canonical = `${ts}.`; // empty body
+  const sig = computeSignature(TEST_SECRET, canonical);
+
+  const res = await fetch(`${baseUrl}/ping`, {
+    method: "GET",
+    headers: {
+      [SIGNATURE_HEADER]: sig,
+      [TIMESTAMP_HEADER]: String(ts),
+    },
+  });
+  assert.strictEqual(res.status, 200);
+});
+
+test("HMAC middleware — 10b. GET request with wrong body assumption → 401", async (t) => {
+  // Guard: if someone signs `${ts}.someBody` for a GET, the server must reject it
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const ts = Date.now();
+  // Client incorrectly signs with a non-empty body for a bodyless GET
+  const canonical = `${ts}.{"wrong":"assumption"}`;
+  const sig = computeSignature(TEST_SECRET, canonical);
+
+  const res = await fetch(`${baseUrl}/ping`, {
+    method: "GET",
+    headers: {
+      [SIGNATURE_HEADER]: sig,
+      [TIMESTAMP_HEADER]: String(ts),
+    },
+  });
+  assert.strictEqual(res.status, 401);
+});
+
+// ── Regression guard: existing auth flow unaffected ───────────────────────────
+
+test("Regression — existing routes work when HMAC secret is not set", async (t) => {
+  // Simulate production environment without VAULT_HMAC_SECRET (passthrough).
+  // Re-uses the test server but without a secret — mirrors the common case
+  // where deployments haven't yet set VAULT_HMAC_SECRET.
+  const { baseUrl, close } = await startTestServer(undefined);
+  t.after(close);
+
+  const body = JSON.stringify({ value: 42 });
+
+  // No HMAC headers needed when secret is unset
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  assert.strictEqual(res.status, 200);
+  const json = (await res.json()) as any;
+  assert.deepStrictEqual(json.body, { value: 42 });
+});
+
+test("Regression — wrong secret → 401 (different clients can't forge signatures)", async (t) => {
+  const { baseUrl, close } = await startTestServer(TEST_SECRET);
+  t.after(close);
+
+  const body = JSON.stringify({ action: "steal" });
+  // Sign with a different secret than the server expects
+  const headers = signRequest(body, { secret: "wrong-secret-attacker-knows" });
+
+  const res = await fetch(`${baseUrl}/echo`, {
+    method: "POST",
+    headers,
+    body,
+  });
+  assert.strictEqual(res.status, 401);
+});

--- a/backend/src/shared/http/hmac.ts
+++ b/backend/src/shared/http/hmac.ts
@@ -1,0 +1,259 @@
+/**
+ * HMAC-SHA256 Request Signing Middleware
+ *
+ * ## Purpose
+ * Provides body integrity verification on top of the existing API key
+ * authentication layer. A valid API key proves *identity*; this middleware
+ * proves *payload integrity* — a MITM that intercepts the request cannot
+ * silently modify the body without detection.
+ *
+ * ## Canonical Signing String
+ * Both the client and server MUST compute HMAC-SHA256 over the identical
+ * string. The format is:
+ *
+ *   `${timestamp}.${rawBody}`
+ *
+ * Where:
+ * - `timestamp` — a Unix epoch value **in milliseconds**, expressed as a
+ *   decimal integer string (e.g. `"1721900000000"`).
+ * - `rawBody`   — the exact UTF-8 request body bytes **as sent over the
+ *   wire**, before any JSON parsing. For requests with no body (GET, HEAD,
+ *   OPTIONS, etc.) this MUST be the empty string `""`.
+ * - The separator is a single ASCII period `.`.
+ *
+ * Example (Node.js client):
+ * ```ts
+ * import { createHmac } from "node:crypto";
+ * const timestamp = Date.now().toString();
+ * const rawBody   = JSON.stringify(payload); // or "" for bodyless requests
+ * const message   = `${timestamp}.${rawBody}`;
+ * const signature = "sha256=" + createHmac("sha256", sharedSecret)
+ *   .update(message, "utf8")
+ *   .digest("hex");
+ * // Send: X-Timestamp: <timestamp>  X-Signature: <signature>
+ * ```
+ *
+ * ## Header Scheme
+ * - `X-Timestamp: <unix-ms>`           — millisecond Unix epoch as a decimal
+ *   integer string. This is the same value interpolated into the canonical
+ *   string on the server side.
+ * - `X-Signature: sha256=<hex-digest>` — HMAC-SHA256 over the canonical
+ *   string, hex-encoded, prefixed with `sha256=`.
+ *
+ * The existing `Authorization: Bearer <api-key>` header is unchanged; this
+ * middleware adds a second, orthogonal verification layer.
+ *
+ * ## Replay Protection
+ * Timestamps more than MAX_SKEW_MS (5 minutes) in either direction — past
+ * or future — are rejected. This bounds the window for replay attacks even
+ * if an attacker captures a valid signed request.
+ *
+ * ## Timing Safety
+ * Signature comparison uses `crypto.timingSafeEqual` to prevent
+ * timing-oracle attacks that could leak the expected HMAC value byte-by-byte.
+ *
+ * ## Env Variable
+ * Set `VAULT_HMAC_SECRET` to a long random string (>= 32 chars recommended).
+ * This secret is shared between the server and its trusted API clients. It
+ * is DISTINCT from `VAULT_API_KEY` — do not reuse the API key here; mixing
+ * concerns would weaken both the identity check and the integrity check.
+ * When `VAULT_HMAC_SECRET` is not set, the middleware is a no-op (passes
+ * through), mirroring the existing API-key passthrough in development.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import express from "express";
+import type { Request, Response, NextFunction } from "express";
+import { error } from "./response.js";
+import { ErrorCode } from "./errorCodes.js";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** Maximum allowed clock skew in milliseconds (5 minutes in either direction). */
+export const MAX_SKEW_MS = 5 * 60 * 1000;
+
+/** Request header carrying the Unix-ms timestamp. Case-insensitive on read. */
+export const TIMESTAMP_HEADER = "x-timestamp";
+
+/** Request header carrying the HMAC-SHA256 signature. Case-insensitive on read. */
+export const SIGNATURE_HEADER = "x-signature";
+
+/** Prefix that MUST appear at the start of the X-Signature value. */
+const SIGNATURE_PREFIX = "sha256=";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Compute `"sha256=<hmac-hex>"` over `canonicalString` using `secret`. */
+export function computeSignature(secret: string, canonicalString: string): string {
+  return (
+    SIGNATURE_PREFIX +
+    createHmac("sha256", secret).update(canonicalString, "utf8").digest("hex")
+  );
+}
+
+/**
+ * Constant-time string equality. Returns `false` rather than throwing when
+ * lengths differ — the length difference is already public information once
+ * the signature-prefix length is known. What matters is that we never
+ * short-circuit on content.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  try {
+    const bufA = Buffer.from(a, "utf8");
+    const bufB = Buffer.from(b, "utf8");
+    if (bufA.length !== bufB.length) return false;
+    return timingSafeEqual(bufA, bufB);
+  } catch {
+    return false;
+  }
+}
+
+// ── Raw-body capture ──────────────────────────────────────────────────────────
+
+/**
+ * Returns an `express.json()` middleware that, as a side-effect, captures the
+ * raw request body bytes and attaches them to `req` as
+ * `(req as any).rawBody: Buffer` before JSON parsing occurs.
+ *
+ * This uses Express's built-in `verify` callback — the only supported way to
+ * intercept raw bytes without consuming the stream a second time. Both the raw
+ * buffer (for HMAC verification) and the parsed body (for route handlers) are
+ * available after this middleware runs.
+ *
+ * **Mount this instead of a bare `express.json()` call** wherever raw-body
+ * capture is needed:
+ * ```ts
+ * // Replace:  v1Router.use(express.json({ limit: "10kb" }))
+ * // With:
+ * v1Router.use(createJsonWithRawBody({ limit: "10kb" }));
+ * ```
+ *
+ * Sub-routes that override the body-size limit should also use this helper
+ * so the rawBody property is consistently populated:
+ * ```ts
+ * v1Router.use("/webhooks", createJsonWithRawBody({ limit: "32kb" }), ...);
+ * ```
+ */
+export function createJsonWithRawBody(options: Parameters<typeof express.json>[0] = {}) {
+  return express.json({
+    ...options,
+    verify(req: Request, _res: Response, buf: Buffer) {
+      (req as any).rawBody = buf;
+    },
+  });
+}
+
+// ── HMAC signing guard ────────────────────────────────────────────────────────
+
+/**
+ * Create an Express middleware that verifies HMAC-SHA256 request signing.
+ *
+ * @param secretOrProvider  The shared HMAC secret, or a zero-argument function
+ *   that returns it (for hot-reload / dynamic config). Pass `undefined` or an
+ *   empty string to run in passthrough mode (dev / unconfigured env).
+ * @param options.maxSkewMs Clock-skew tolerance in ms (default: 300 000 = 5 min).
+ *
+ * ### Prerequisites
+ * `createJsonWithRawBody()` must be mounted on the same router **before** this
+ * middleware so that `(req as any).rawBody` is a `Buffer` when this runs.
+ *
+ * ### Rejection reasons — all produce 401 UNAUTHORIZED
+ * | Condition | Message |
+ * |-----------|---------|
+ * | `X-Signature` header absent | "Missing X-Signature header" |
+ * | `X-Timestamp` header absent | "Missing X-Timestamp header" |
+ * | Timestamp not a finite integer | "X-Timestamp must be a valid Unix millisecond integer" |
+ * | Timestamp > maxSkewMs in the past | "Request timestamp is too old (replay protection)" |
+ * | Timestamp > maxSkewMs in the future | "Request timestamp is too far in the future (clock skew)" |
+ * | Signature does not match recomputed HMAC | "Invalid request signature" |
+ */
+export function createHmacSigningMiddleware(
+  secretOrProvider: string | undefined | (() => string | undefined),
+  options: { maxSkewMs?: number } = {},
+) {
+  const maxSkewMs = options.maxSkewMs ?? MAX_SKEW_MS;
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const secret =
+      typeof secretOrProvider === "function"
+        ? secretOrProvider()
+        : secretOrProvider;
+
+    // Passthrough when no secret is configured (mirrors API-key passthrough).
+    if (!secret) {
+      return next();
+    }
+
+    // ── 1. Extract headers ────────────────────────────────────────────────────
+    const signatureHeader = req.get(SIGNATURE_HEADER);
+    const timestampHeader = req.get(TIMESTAMP_HEADER);
+
+    if (!signatureHeader) {
+      error(res, {
+        message: "Unauthorized: Missing X-Signature header",
+        status: 401,
+        code: ErrorCode.UNAUTHORIZED,
+      });
+      return;
+    }
+
+    if (!timestampHeader) {
+      error(res, {
+        message: "Unauthorized: Missing X-Timestamp header",
+        status: 401,
+        code: ErrorCode.UNAUTHORIZED,
+      });
+      return;
+    }
+
+    // ── 2. Parse & validate timestamp ─────────────────────────────────────────
+    const tsNumber = Number(timestampHeader);
+
+    // Reject NaN, ±Infinity, floats, and empty strings.
+    if (!Number.isFinite(tsNumber) || !Number.isInteger(tsNumber)) {
+      error(res, {
+        message:
+          "Unauthorized: X-Timestamp must be a valid Unix millisecond integer",
+        status: 401,
+        code: ErrorCode.UNAUTHORIZED,
+      });
+      return;
+    }
+
+    const skew = Date.now() - tsNumber;
+    if (Math.abs(skew) > maxSkewMs) {
+      error(res, {
+        message:
+          skew > 0
+            ? "Unauthorized: Request timestamp is too old (replay protection)"
+            : "Unauthorized: Request timestamp is too far in the future (clock skew)",
+        status: 401,
+        code: ErrorCode.UNAUTHORIZED,
+      });
+      return;
+    }
+
+    // ── 3. Recompute HMAC & compare ───────────────────────────────────────────
+    // rawBody is a Buffer attached by createJsonWithRawBody's verify callback.
+    // For bodyless requests (GET etc.) rawBody is absent — canonical uses "".
+    const rawBodyStr: string =
+      (req as any).rawBody instanceof Buffer
+        ? ((req as any).rawBody as Buffer).toString("utf8")
+        : "";
+
+    const canonical = `${tsNumber}.${rawBodyStr}`;
+    const expected = computeSignature(secret, canonical);
+
+    // MUST use constant-time comparison — plain === leaks timing information.
+    if (!safeEqual(signatureHeader, expected)) {
+      error(res, {
+        message: "Unauthorized: Invalid request signature",
+        status: 401,
+        code: ErrorCode.UNAUTHORIZED,
+      });
+      return;
+    }
+
+    next();
+  };
+}


### PR DESCRIPTION
Closes #1379

---

- Add SHA256 HMAC signature verification guard/middleware
- Signs canonical string of request body + timestamp with shared secret
- Verifies signature before request body reaches business logic
- Rejects missing/invalid signatures and timestamps older than 5 minutes
- Add tests for signature validation and tampering detection

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
