### PR TITLE
feat(websocket): add per-client subscription rate limiting (#1372)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -119,3 +119,12 @@ RATE_LIMIT_REDIS_URL=
 RATE_LIMIT_PROPOSALS_PER_MIN=100
 RATE_LIMIT_EXECUTE_PER_MIN=10
 RATE_LIMIT_DEFAULT_PER_MIN=60
+
+# ------------------------------------------------------------------------------
+# 6. WebSocket
+# ------------------------------------------------------------------------------
+
+# Maximum number of topic subscriptions a single WebSocket client may hold.
+# Clients that exceed this limit receive an error with remaining quota = 0.
+# Type: number | Default: 100
+WS_MAX_SUBSCRIPTIONS_PER_CLIENT=100

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -33,6 +33,8 @@ export interface BackendEnv {
   readonly rateLimitDefaultPerMin: number;
   /** Maximum ledger jitter window for due-payment queries (default: 10 ledgers). */
   readonly jitterWindowMax: number;
+  /** Maximum number of topic subscriptions a single WebSocket client may hold (default: 100). */
+  readonly wsMaxSubscriptionsPerClient: number;
 }
 
 const DEFAULT_CONTRACT_ID =
@@ -239,6 +241,7 @@ export function createTestEnv(overrides: Partial<BackendEnv> = {}): BackendEnv {
     rateLimitExecutePerMin: 10,
     rateLimitDefaultPerMin: 60,
     jitterWindowMax: 10,
+    wsMaxSubscriptionsPerClient: 100,
     ...overrides,
   };
 }
@@ -326,6 +329,11 @@ export function loadEnv(): BackendEnv {
     issues,
   );
   const jitterWindowMax = readPort("JITTER_WINDOW_MAX", 10, issues);
+  const wsMaxSubscriptionsPerClient = readPort(
+    "WS_MAX_SUBSCRIPTIONS_PER_CLIENT",
+    100,
+    issues,
+  );
 
   validateRequiredString("HOST", host, issues);
   validateAllowedValue("NODE_ENV", nodeEnv, ALLOWED_NODE_ENVS, issues);
@@ -410,5 +418,6 @@ export function loadEnv(): BackendEnv {
     rateLimitExecutePerMin,
     rateLimitDefaultPerMin,
     jitterWindowMax,
+    wsMaxSubscriptionsPerClient,
   };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -29,6 +29,7 @@ logStartupConfig(env);
 
 const logger = createLogger("vaultdao-backend");
 const realtimeServer = new RealtimeServer({
+  maxSubscriptionsPerClient: env.wsMaxSubscriptionsPerClient,
   onConnected: (connectionId) => {
     logger.info("realtime connection opened", { connectionId });
   },

--- a/backend/src/modules/realtime/realtime-server.ts
+++ b/backend/src/modules/realtime/realtime-server.ts
@@ -12,6 +12,7 @@ import type {
   RealtimeConnection,
   RealtimeConnectionLifecycleHooks,
   RealtimeEnvelope,
+  RealtimeServerOptions,
 } from "./types.js";
 
 const logger = createLogger("realtime-server");
@@ -40,12 +41,15 @@ export class RealtimeServer {
     (clientId, message) => this.deliver(clientId, message),
   );
   private readonly hooks: RealtimeConnectionLifecycleHooks;
+  private readonly maxSubscriptionsPerClient: number;
   private wss: WebSocketServer | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private started = false;
 
-  constructor(hooks: RealtimeConnectionLifecycleHooks = {}) {
+  constructor(options: RealtimeServerOptions = {}) {
+    const { maxSubscriptionsPerClient = 100, ...hooks } = options;
     this.hooks = hooks;
+    this.maxSubscriptionsPerClient = maxSubscriptionsPerClient;
   }
 
   // ---------------------------------------------------------------------------
@@ -195,6 +199,24 @@ export class RealtimeServer {
 
   public subscribe(connectionId: string, topic: RealtimeTopic): boolean {
     if (!this.connections.has(connectionId)) return false;
+
+    const currentCount = this.subscriptions.getTopics(connectionId).size;
+    if (currentCount >= this.maxSubscriptionsPerClient) {
+      const remaining = 0;
+      this.deliver(connectionId, {
+        type: "error",
+        topic,
+        ts: new Date().toISOString(),
+        payload: {
+          code: "SUBSCRIPTION_LIMIT_REACHED",
+          message: `Maximum ${this.maxSubscriptionsPerClient} subscriptions per connection`,
+          limit: this.maxSubscriptionsPerClient,
+          remaining,
+        },
+      });
+      return false;
+    }
+
     const added = this.subscriptions.subscribe(connectionId, topic);
     if (!added) return false;
 

--- a/backend/src/modules/realtime/types.ts
+++ b/backend/src/modules/realtime/types.ts
@@ -26,3 +26,12 @@ export interface RealtimeConnectionLifecycleHooks {
   onSubscribed?(connectionId: string, topic: RealtimeTopic): void;
   onUnsubscribed?(connectionId: string, topic: RealtimeTopic): void;
 }
+
+export interface RealtimeServerOptions extends RealtimeConnectionLifecycleHooks {
+  /**
+   * Maximum number of topics a single client may subscribe to simultaneously.
+   * Attempts beyond this limit receive an error envelope and are rejected.
+   * Default: 100.
+   */
+  maxSubscriptionsPerClient?: number;
+}

--- a/backend/src/modules/websocket/websocket.server.ts
+++ b/backend/src/modules/websocket/websocket.server.ts
@@ -19,8 +19,10 @@ export class EventWebSocketServer {
   private clients: Map<WebSocket, ClientSubscription> = new Map();
   /** room → set of WebSocket connections */
   private rooms: Map<string, Set<WebSocket>> = new Map();
+  private readonly maxSubscriptionsPerClient: number;
 
-  constructor(server: Server) {
+  constructor(server: Server, maxSubscriptionsPerClient = 100) {
+    this.maxSubscriptionsPerClient = maxSubscriptionsPerClient;
     this.wss = new WebSocketServer({ server });
     this.init();
   }
@@ -222,11 +224,15 @@ export class EventWebSocketServer {
         norm = `notification:events:${t.toUpperCase()}`;
       }
 
-      if (sub.subscriptions.size >= 20) {
+      if (sub.subscriptions.size >= this.maxSubscriptionsPerClient) {
+        const remaining = 0;
         ws.send(
           JSON.stringify({
             type: "error",
-            message: "Maximum 20 topic subscriptions per connection",
+            code: "SUBSCRIPTION_LIMIT_REACHED",
+            message: `Maximum ${this.maxSubscriptionsPerClient} topic subscriptions per connection`,
+            limit: this.maxSubscriptionsPerClient,
+            remaining,
           }),
         );
         break;

--- a/backend/src/modules/websocket/websocket.subscription-limit.test.ts
+++ b/backend/src/modules/websocket/websocket.subscription-limit.test.ts
@@ -1,0 +1,405 @@
+/**
+ * Tests for WebSocket subscription rate limiting per client (#1372).
+ *
+ * Covers both WebSocket implementations:
+ *  - EventWebSocketServer (legacy event-broadcasting server)
+ *  - RealtimeServer (new topic-based realtime server)
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { WebSocket } from "ws";
+import { startServer } from "../../server.js";
+import { RealtimeServer } from "../realtime/realtime-server.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function waitForMessage(
+  ws: WebSocket,
+  predicate: (msg: any) => boolean,
+  timeoutMs = 3000,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("timed out waiting for message")),
+      timeoutMs,
+    );
+    const handler = (data: Buffer) => {
+      const msg = JSON.parse(data.toString());
+      if (predicate(msg)) {
+        clearTimeout(timeout);
+        ws.off("message", handler);
+        resolve(msg);
+      }
+    };
+    ws.on("message", handler);
+  });
+}
+
+/** Collect all messages received within a short window. */
+function collectMessages(ws: WebSocket, durationMs = 200): Promise<any[]> {
+  return new Promise((resolve) => {
+    const msgs: any[] = [];
+    const handler = (data: Buffer) => msgs.push(JSON.parse(data.toString()));
+    ws.on("message", handler);
+    setTimeout(() => {
+      ws.off("message", handler);
+      resolve(msgs);
+    }, durationMs);
+  });
+}
+
+/** Register a mock connection directly into a RealtimeServer (mirrors realtime-streaming.test.ts). */
+function registerMockConnection(
+  server: RealtimeServer,
+  id: string,
+  recv: any[],
+): void {
+  const conn = {
+    id,
+    ws: {
+      readyState: 1 /* OPEN */,
+      ping: () => {},
+      terminate: () => {},
+      close: () => {},
+    },
+    lastPong: Date.now(),
+    send: (msg: any) => recv.push(msg),
+    close: () => {},
+  };
+  (server as any).connections.set(id, conn);
+  (server as any).hooks.onConnected?.(id);
+  conn.send({
+    type: "hello",
+    ts: new Date().toISOString(),
+    payload: { connectionId: id, status: "connected" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// RealtimeServer — unit tests (no live HTTP server needed)
+// ---------------------------------------------------------------------------
+
+test("RealtimeServer subscription limits", async (t) => {
+  await t.test("subscribe succeeds up to the configured limit", () => {
+    const server = new RealtimeServer({ maxSubscriptionsPerClient: 3 });
+    const recv: any[] = [];
+    registerMockConnection(server, "c1", recv);
+
+    for (let i = 1; i <= 3; i++) {
+      const result = server.subscribe("c1", server.createTopic("proposal", String(i)));
+      assert.equal(result, true, `subscribe #${i} should succeed`);
+    }
+
+    assert.equal(server.getSubscriptions("c1").size, 3);
+  });
+
+  await t.test("subscribe returns false and sends error envelope when limit is exceeded", () => {
+    const server = new RealtimeServer({ maxSubscriptionsPerClient: 2 });
+    const recv: any[] = [];
+    registerMockConnection(server, "c2", recv);
+
+    server.subscribe("c2", server.createTopic("proposal", "a"));
+    server.subscribe("c2", server.createTopic("proposal", "b"));
+
+    // Third subscribe should be rejected
+    const result = server.subscribe("c2", server.createTopic("proposal", "c"));
+    assert.equal(result, false, "subscribe beyond limit should return false");
+
+    // Should not be added
+    assert.equal(server.getSubscriptions("c2").size, 2);
+
+    // An error envelope should have been delivered
+    const errors = recv.filter((m) => m.type === "error");
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].payload.code, "SUBSCRIPTION_LIMIT_REACHED");
+    assert.equal(errors[0].payload.limit, 2);
+    assert.equal(errors[0].payload.remaining, 0);
+  });
+
+  await t.test("error envelope includes the rejected topic", () => {
+    const server = new RealtimeServer({ maxSubscriptionsPerClient: 1 });
+    const recv: any[] = [];
+    registerMockConnection(server, "c3", recv);
+
+    server.subscribe("c3", server.createTopic("proposal", "first"));
+    const rejectedTopic = server.createTopic("proposal", "second");
+    server.subscribe("c3", rejectedTopic);
+
+    const errors = recv.filter((m) => m.type === "error");
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].topic, rejectedTopic);
+  });
+
+  await t.test("subscribe succeeds again after unsubscribing below the limit", () => {
+    const server = new RealtimeServer({ maxSubscriptionsPerClient: 2 });
+    const recv: any[] = [];
+    registerMockConnection(server, "c4", recv);
+
+    const t1 = server.createTopic("proposal", "1");
+    const t2 = server.createTopic("proposal", "2");
+    const t3 = server.createTopic("proposal", "3");
+
+    server.subscribe("c4", t1);
+    server.subscribe("c4", t2);
+
+    // At limit — t3 rejected
+    assert.equal(server.subscribe("c4", t3), false);
+
+    // Free up a slot
+    server.unsubscribe("c4", t1);
+    assert.equal(server.getSubscriptions("c4").size, 1);
+
+    // Now t3 should succeed
+    assert.equal(server.subscribe("c4", t3), true);
+    assert.equal(server.getSubscriptions("c4").size, 2);
+  });
+
+  await t.test("each client enforces its own independent limit", () => {
+    const server = new RealtimeServer({ maxSubscriptionsPerClient: 2 });
+    const recvA: any[] = [];
+    const recvB: any[] = [];
+    registerMockConnection(server, "cA", recvA);
+    registerMockConnection(server, "cB", recvB);
+
+    server.subscribe("cA", server.createTopic("proposal", "1"));
+    server.subscribe("cA", server.createTopic("proposal", "2"));
+
+    // cA is at limit — cB should still be able to subscribe freely
+    assert.equal(server.subscribe("cB", server.createTopic("proposal", "3")), true);
+    assert.equal(server.subscribe("cB", server.createTopic("proposal", "4")), true);
+
+    // cA third sub is rejected
+    assert.equal(
+      server.subscribe("cA", server.createTopic("proposal", "5")),
+      false,
+    );
+    // cB third sub is rejected
+    assert.equal(
+      server.subscribe("cB", server.createTopic("proposal", "6")),
+      false,
+    );
+
+    assert.equal(recvA.filter((m) => m.type === "error").length, 1);
+    assert.equal(recvB.filter((m) => m.type === "error").length, 1);
+  });
+
+  await t.test("default limit is 100", () => {
+    const server = new RealtimeServer(); // no maxSubscriptionsPerClient
+    const recv: any[] = [];
+    registerMockConnection(server, "default-limit", recv);
+
+    // Subscribe 100 topics — all should succeed
+    for (let i = 0; i < 100; i++) {
+      const ok = server.subscribe(
+        "default-limit",
+        server.createTopic("custom", `topic-${i}`),
+      );
+      assert.equal(ok, true, `topic ${i} should succeed`);
+    }
+
+    // 101st should be rejected
+    const rejected = server.subscribe(
+      "default-limit",
+      server.createTopic("custom", "over-limit"),
+    );
+    assert.equal(rejected, false);
+    assert.equal(server.getSubscriptions("default-limit").size, 100);
+
+    const errors = recv.filter((m) => m.type === "error");
+    assert.equal(errors.length, 1);
+    assert.equal(errors[0].payload.limit, 100);
+    assert.equal(errors[0].payload.remaining, 0);
+  });
+
+  await t.test("limit of 0 rejects every subscription", () => {
+    const server = new RealtimeServer({ maxSubscriptionsPerClient: 0 });
+    const recv: any[] = [];
+    registerMockConnection(server, "zero", recv);
+
+    const result = server.subscribe("zero", server.createTopic("proposal", "x"));
+    assert.equal(result, false);
+    assert.equal(server.getSubscriptions("zero").size, 0);
+    assert.equal(recv.filter((m) => m.type === "error").length, 1);
+  });
+
+  await t.test("subscription count resets to zero after unregisterConnection", () => {
+    const server = new RealtimeServer({ maxSubscriptionsPerClient: 3 });
+    const recv: any[] = [];
+    registerMockConnection(server, "cleanup", recv);
+
+    server.subscribe("cleanup", server.createTopic("proposal", "1"));
+    server.subscribe("cleanup", server.createTopic("proposal", "2"));
+    assert.equal(server.getSubscriptions("cleanup").size, 2);
+
+    server.unregisterConnection("cleanup");
+    assert.equal(server.getSubscriptions("cleanup").size, 0);
+    assert.equal(server.getConnectionCount(), 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EventWebSocketServer — integration tests via live HTTP server
+// ---------------------------------------------------------------------------
+
+test("EventWebSocketServer subscription limits", async (t) => {
+  // Use maxSubscriptionsPerClient: 3 via env override so tests run quickly
+  const mockEnv = {
+    port: 0,
+    host: "127.0.0.1",
+    nodeEnv: "test",
+    stellarNetwork: "testnet",
+    sorobanRpcUrl: "https://soroban-testnet.stellar.org",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    contractId: "CDTEST",
+    websocketUrl: "ws://localhost:8080",
+    eventPollingIntervalMs: 100,
+    eventPollingEnabled: false,
+    wsMaxSubscriptionsPerClient: 3,
+  };
+
+  const { server, runtime } = await startServer(mockEnv as any);
+
+  if (!server.listening) {
+    await new Promise((resolve) => server.once("listening", resolve));
+  }
+
+  const address: any = server.address();
+  const wsUrl = `ws://127.0.0.1:${address.port}`;
+
+  await t.test(
+    "subscribing exactly at the limit succeeds without error",
+    async () => {
+      const ws = new WebSocket(wsUrl);
+      await new Promise((resolve) => ws.on("open", resolve));
+
+      ws.send(
+        JSON.stringify({
+          type: "subscribe",
+          topics: ["proposal_created", "proposal_approved", "proposal_executed"],
+        }),
+      );
+
+      const confirmation = await waitForMessage(ws, (m) => m.type === "subscribed");
+      assert.ok(
+        Array.isArray(confirmation.topics),
+        "confirmation should have topics array",
+      );
+      assert.equal(confirmation.topics.length, 3);
+
+      ws.close();
+    },
+  );
+
+  await t.test(
+    "subscribing beyond the limit returns an error with code SUBSCRIPTION_LIMIT_REACHED",
+    async () => {
+      const ws = new WebSocket(wsUrl);
+      await new Promise((resolve) => ws.on("open", resolve));
+
+      // Subscribe up to the limit
+      ws.send(
+        JSON.stringify({
+          type: "subscribe",
+          topics: ["proposal_created", "proposal_approved", "proposal_executed"],
+        }),
+      );
+      await waitForMessage(ws, (m) => m.type === "subscribed");
+
+      // Start collecting messages, then try to add a 4th subscription
+      const future = collectMessages(ws, 400);
+      ws.send(
+        JSON.stringify({ type: "subscribe", topics: ["insurance_locked"] }),
+      );
+      const msgs = await future;
+
+      const errors = msgs.filter((m) => m.type === "error");
+      assert.equal(errors.length, 1, "should receive exactly one error");
+      assert.equal(errors[0].code, "SUBSCRIPTION_LIMIT_REACHED");
+      assert.equal(errors[0].limit, 3);
+      assert.equal(errors[0].remaining, 0);
+
+      ws.close();
+    },
+  );
+
+  await t.test(
+    "error message mentions the configured limit",
+    async () => {
+      const ws = new WebSocket(wsUrl);
+      await new Promise((resolve) => ws.on("open", resolve));
+
+      ws.send(
+        JSON.stringify({
+          type: "subscribe",
+          topics: ["proposal_created", "proposal_approved", "proposal_executed"],
+        }),
+      );
+      await waitForMessage(ws, (m) => m.type === "subscribed");
+
+      const future = collectMessages(ws, 400);
+      ws.send(JSON.stringify({ type: "subscribe", topics: ["proposal_vetoed"] }));
+      const msgs = await future;
+
+      const err = msgs.find((m) => m.type === "error");
+      assert.ok(err, "error message should be present");
+      assert.ok(
+        typeof err.message === "string" && err.message.includes("3"),
+        `error message should mention limit 3, got: ${err.message}`,
+      );
+
+      ws.close();
+    },
+  );
+
+  await t.test(
+    "clients do not affect each other's subscription quota",
+    async () => {
+      const wsA = new WebSocket(wsUrl);
+      const wsB = new WebSocket(wsUrl);
+
+      await Promise.all([
+        new Promise((resolve) => wsA.on("open", resolve)),
+        new Promise((resolve) => wsB.on("open", resolve)),
+      ]);
+
+      // Fill client A's quota
+      wsA.send(
+        JSON.stringify({
+          type: "subscribe",
+          topics: ["proposal_created", "proposal_approved", "proposal_executed"],
+        }),
+      );
+      await waitForMessage(wsA, (m) => m.type === "subscribed");
+
+      // Client B should still be able to subscribe up to its own limit
+      wsB.send(
+        JSON.stringify({
+          type: "subscribe",
+          topics: ["proposal_created", "proposal_approved", "proposal_executed"],
+        }),
+      );
+      const confirmB = await waitForMessage(wsB, (m) => m.type === "subscribed");
+      assert.equal(
+        confirmB.topics.length,
+        3,
+        "client B should receive 3 confirmed topics",
+      );
+
+      wsA.close();
+      wsB.close();
+    },
+  );
+
+  // Teardown
+  runtime.wsServer?.stop();
+  await runtime.jobManager.stopAll();
+  if (typeof (server as any).closeAllConnections === "function") {
+    (server as any).closeAllConnections();
+  }
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -246,7 +246,7 @@ export async function startServer(
     runtime.lifecycleManager = lifecycleManager;
   }
 
-  const wsServer = new EventWebSocketServer(server);
+  const wsServer = new EventWebSocketServer(server, env.wsMaxSubscriptionsPerClient);
   runtime.wsServer = wsServer;
 
   // Determine cursor storage and run one-time file→database migration if needed


### PR DESCRIPTION
- Add WS_MAX_SUBSCRIPTIONS_PER_CLIENT config (default 100) to BackendEnv, loadEnv(), createTestEnv(), and .env.example
- EventWebSocketServer: accept maxSubscriptionsPerClient in constructor, replace hardcoded limit of 20; reject with SUBSCRIPTION_LIMIT_REACHED error including limit and remaining quota
- RealtimeServer: add RealtimeServerOptions (extends lifecycle hooks with maxSubscriptionsPerClient); enforce limit in subscribe(), deliver error envelope with code, limit, and remaining fields
- Wire env.wsMaxSubscriptionsPerClient through server.ts and index.ts
- Add 14 tests covering both server implementations: limit enforcement, error payload shape, per-client isolation, quota recovery after unsubscribe, default/edge-case limits

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests  closes #1372 

## Related issues

Closes #

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
