### PR TITLE
feat(#1364): add recurring payment jitter for load distribution

### DIFF
--- a/backend/docs/ROADMAP.md
+++ b/backend/docs/ROADMAP.md
@@ -91,3 +91,25 @@ git push origin feature/your-task
 ```
 
 **Updated: YYYY-MM-DD** | **Next Sprint Focus**: Foundation → Indexing
+
+---
+
+## ⏱️ Recurring Payment Jitter — Audit Trail Note (issue #1364)
+
+Recurring payments support an **optional jitter window** (`jitter_window > 0`) for load distribution.
+When enabled, each payment cycle's `next_payment_ledger` is shifted forward by a fixed, deterministic
+offset (`jitter_offset`, in `[0, jitter_window)` ledgers) computed at creation time from
+`sha256(payment_id || creation_ledger) % jitter_window`.
+
+**What this means for payment history audits:**
+- The **first** payment in every series has **no jitter** — it executes at exactly `creation_ledger + interval`.
+- From the **second cycle onward**, `next_payment_ledger = nominal_schedule + jitter_offset`.
+- Consecutive execution timestamps that appear `interval + jitter_offset` ledgers apart
+  (instead of exactly `interval`) are **expected and intentional**.
+- The on-chain event `recurring_pay_jittered` (topics: `["recurring_pay_jittered", payment_id]`,
+  data: `(nominal_next_ledger, jittered_next_ledger, jitter_offset)`) is emitted whenever jitter
+  is applied — use it to confirm the variance is deliberate.
+- The `jitter_offset` field on the `RecurringPayment` struct is fixed for the payment's lifetime.
+- **Do not treat jitter-induced timing variance as a missed or delayed payment.**
+- When `jitter_window == 0` (the default), behavior is byte-for-byte identical to the
+  pre-jitter fixed-interval scheduling — zero overhead.

--- a/backend/src/modules/events/types.ts
+++ b/backend/src/modules/events/types.ts
@@ -76,6 +76,11 @@ export enum EventType {
   SUBSCRIPTION_CANCELLED = "SUBSCRIPTION_CANCELLED",
   SUBSCRIPTION_UPGRADED = "SUBSCRIPTION_UPGRADED",
   SUBSCRIPTION_EXPIRED = "SUBSCRIPTION_EXPIRED",
+  /** Emitted when jitter shifts a recurring payment's next execution ledger.
+   *  Present only when jitter_window > 0 and the payment is past its first cycle.
+   *  Auditors: timing variance equal to the jitter_offset is expected behavior. */
+  RECURRING_PAYMENT_EXECUTED = "RECURRING_PAYMENT_EXECUTED",
+  RECURRING_PAYMENT_JITTERED = "RECURRING_PAYMENT_JITTERED",
 
   // ── Recovery ──────────────────────────────────────────────────────────────
   RECOVERY_PROPOSED = "RECOVERY_PROPOSED",
@@ -441,6 +446,38 @@ export interface SubscriptionExpiredData {
   readonly subscriptionId: string;
 }
 
+// ── Recurring payment data interfaces ────────────────────────────────────────
+
+export interface RecurringPaymentExecutedData {
+  readonly paymentId: string;
+  /** The ledger at which this individual payment transfer executed. */
+  readonly paymentLedger: number;
+  readonly amount: string;
+}
+
+/**
+ * Data carried by RECURRING_PAYMENT_JITTERED events.
+ *
+ * When jitter is enabled on a recurring payment (`jitter_window > 0`) and the
+ * payment is past its first cycle, the next execution ledger is shifted forward
+ * by `jitterOffset` ledgers.  This event captures both the unshifted
+ * (`nominalNextLedger`) and the actual stored (`jitteredNextLedger`) values so
+ * that auditors can verify the timing variance is deliberate.
+ *
+ * **Audit trail note**: A difference of `jitterOffset` ledgers between
+ * consecutive execution timestamps is expected and intentional.  Do not treat
+ * it as a missed or delayed payment.
+ */
+export interface RecurringPaymentJitteredData {
+  readonly paymentId: string;
+  /** Next execution ledger without jitter: prevNextLedger + n * interval */
+  readonly nominalNextLedger: number;
+  /** Actual stored next execution ledger: nominalNextLedger + jitterOffset */
+  readonly jitteredNextLedger: number;
+  /** Ledger offset applied, in [0, jitter_window) */
+  readonly jitterOffset: number;
+}
+
 // ── Recovery data interfaces ──────────────────────────────────────────────────
 
 export interface RecoveryProposedData {
@@ -638,6 +675,8 @@ export const CONTRACT_EVENT_MAP: Record<string, EventType> = {
   subscription_cancelled: EventType.SUBSCRIPTION_CANCELLED,
   subscription_upgraded: EventType.SUBSCRIPTION_UPGRADED,
   subscription_expired: EventType.SUBSCRIPTION_EXPIRED,
+  recurring_payment_executed: EventType.RECURRING_PAYMENT_EXECUTED,
+  recurring_pay_jittered: EventType.RECURRING_PAYMENT_JITTERED,
 
   // Recovery
   recovery_proposed: EventType.RECOVERY_PROPOSED,

--- a/backend/src/modules/recurring/recurring.service.test.ts
+++ b/backend/src/modules/recurring/recurring.service.test.ts
@@ -138,6 +138,8 @@ test("MemoryRecurringStorageAdapter filter by status/proposer/recipient/token/le
     computedStatus: "active" as const,
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   };
 
   await adapter.save(item);
@@ -213,6 +215,8 @@ test("getPayments supports combined filters and returns pagination metadata", as
     computedStatus: "active",
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   });
   await storage.save({
     paymentId: "p-2",
@@ -236,6 +240,8 @@ test("getPayments supports combined filters and returns pagination metadata", as
     computedStatus: "active",
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   });
   await storage.save({
     paymentId: "p-3",
@@ -259,6 +265,8 @@ test("getPayments supports combined filters and returns pagination metadata", as
     computedStatus: "active",
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   });
 
   const filtered = await service.getPayments(
@@ -304,6 +312,8 @@ test("getDuePaymentsAtLedger returns only payments ready for execution", async (
     computedStatus: "active",
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   });
   await storage.save({
     paymentId: "due-status",
@@ -327,6 +337,8 @@ test("getDuePaymentsAtLedger returns only payments ready for execution", async (
     computedStatus: "active",
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   });
   await storage.save({
     paymentId: "not-due",
@@ -350,6 +362,8 @@ test("getDuePaymentsAtLedger returns only payments ready for execution", async (
     computedStatus: "active",
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   });
   await storage.save({
     paymentId: "cancelled",
@@ -373,9 +387,170 @@ test("getDuePaymentsAtLedger returns only payments ready for execution", async (
     computedStatus: "stopped",
     ledgersUntilDue: 0,
     missedPayments: 0,
+    jitterWindow: 0,
+    jitterOffset: 0,
   });
 
   const due = await service.getDuePaymentsAtLedger(12);
   const ids = due.map((payment) => payment.paymentId).sort();
   assert.deepEqual(ids, ["due-now", "due-status"]);
+});
+
+// ============================================================================
+// Issue #1364: Recurring Payment Jitter — Backend Service Tests
+//
+// The on-chain jitter source is Soroban's sha256 — deterministic, not random.
+// The backend service reflects the contract's fields directly; there is no
+// separate RNG to inject.  Instead we use known raw values to assert exact
+// outputs from transformRawRecurringPayment.
+// ============================================================================
+
+// ── Jitter T1: jitter disabled (window == 0) — transform output is unchanged ──
+
+test("jitter disabled: transformRawRecurringPayment sets jitterWindow=0 and jitterOffset=0", () => {
+  const raw = { ...baseRaw, jitter_window: "0", jitter_offset: "0" };
+  const normalized = transformRawRecurringPayment(raw, "C1", 5);
+
+  assert.equal(normalized.jitterWindow, 0, "jitterWindow must be 0 when disabled");
+  assert.equal(normalized.jitterOffset, 0, "jitterOffset must be 0 when disabled");
+});
+
+test("jitter disabled: omitted jitter fields default to 0 (backward compat)", () => {
+  // Legacy raw payments (before jitter support) have no jitter_window/jitter_offset
+  const normalized = transformRawRecurringPayment(baseRaw, "C1", 5);
+
+  assert.equal(normalized.jitterWindow, 0, "missing jitter_window defaults to 0");
+  assert.equal(normalized.jitterOffset, 0, "missing jitter_offset defaults to 0");
+});
+
+// ── Jitter T2: jitter enabled — exact known offset is propagated correctly ───
+
+test("jitter enabled: transformRawRecurringPayment propagates exact jitterWindow and jitterOffset", () => {
+  const raw = {
+    ...baseRaw,
+    jitter_window: "100",   // window set to 100 ledgers
+    jitter_offset: "42",    // deterministic offset from sha256 — 42 < 100 ✓
+  };
+  const normalized = transformRawRecurringPayment(raw, "C1", 5);
+
+  assert.equal(normalized.jitterWindow, 100, "jitterWindow must match raw value");
+  assert.equal(normalized.jitterOffset, 42, "jitterOffset must match raw value exactly");
+});
+
+test("jitter enabled: existing payment preserves jitterOffset across re-transforms", () => {
+  const raw = { ...baseRaw, jitter_window: "50", jitter_offset: "17" };
+  const first = transformRawRecurringPayment(raw, "C1", 3);
+
+  // Re-transform (simulates a sync cycle receiving updated data)
+  const updated_raw = { ...raw, next_payment_ledger: "20", payment_count: "1" };
+  const second = transformRawRecurringPayment(updated_raw, "C1", 5, first);
+
+  assert.equal(second.jitterWindow, 50, "jitterWindow must be stable across re-transforms");
+  assert.equal(second.jitterOffset, 17, "jitterOffset must be stable across re-transforms");
+});
+
+// ── Jitter T3: statistical range check ───────────────────────────────────────
+
+test("jitter enabled: offset is always within [0, jitterWindow) — range check", () => {
+  // Simulate N distinct raw payments with varying offsets; all must be valid
+  const window = 200;
+  const testCases = [
+    { id: "r-0",  jitter_offset: "0"   },
+    { id: "r-1",  jitter_offset: "1"   },
+    { id: "r-99", jitter_offset: "99"  },
+    { id: "r-199",jitter_offset: "199" },
+  ];
+
+  for (const tc of testCases) {
+    const raw = { ...baseRaw, id: tc.id, jitter_window: String(window), jitter_offset: tc.jitter_offset };
+    const normalized = transformRawRecurringPayment(raw, "C1", 5);
+
+    assert.ok(
+      normalized.jitterOffset >= 0 && normalized.jitterOffset < window,
+      `paymentId=${tc.id}: jitterOffset ${normalized.jitterOffset} must be in [0, ${window})`,
+    );
+  }
+});
+
+// ── Jitter T4: JITTERED event appended when payment_count > 1 and window > 0 ─
+
+test("jitter enabled: JITTERED event added when payment_count > 1 and jitter_window > 0", () => {
+  const firstRaw = { ...baseRaw, jitter_window: "100", jitter_offset: "30" };
+  const existing = transformRawRecurringPayment(firstRaw, "C1", 5);
+
+  // Simulate second execution: payment_count increases from 0 to 2
+  const updatedRaw = { ...firstRaw, payment_count: "2", next_payment_ledger: "2030" };
+  const updated = transformRawRecurringPayment(updatedRaw, "C1", 10, existing);
+
+  assert.ok(
+    updated.events.includes(RecurringEvent.EXECUTED),
+    "EXECUTED event must be present",
+  );
+  assert.ok(
+    updated.events.includes(RecurringEvent.JITTERED),
+    "JITTERED event must be present after second cycle with jitter enabled",
+  );
+});
+
+test("jitter enabled: JITTERED event NOT added when jitter_window == 0", () => {
+  const firstRaw = { ...baseRaw, jitter_window: "0", jitter_offset: "0" };
+  const existing = transformRawRecurringPayment(firstRaw, "C1", 5);
+
+  const updatedRaw = { ...firstRaw, payment_count: "2", next_payment_ledger: "2000" };
+  const updated = transformRawRecurringPayment(updatedRaw, "C1", 10, existing);
+
+  assert.ok(
+    updated.events.includes(RecurringEvent.EXECUTED),
+    "EXECUTED event must be present",
+  );
+  assert.ok(
+    !updated.events.includes(RecurringEvent.JITTERED),
+    "JITTERED event must NOT be present when jitter_window == 0",
+  );
+});
+
+test("jitter enabled: JITTERED event NOT added on first cycle (payment_count == 1)", () => {
+  // First execution: payment_count goes from 0 to 1 — jitter not applied to first cycle
+  const firstRaw = { ...baseRaw, jitter_window: "100", jitter_offset: "30" };
+  const existing = transformRawRecurringPayment(firstRaw, "C1", 5);
+
+  const updatedRaw = { ...firstRaw, payment_count: "1", next_payment_ledger: "1030" };
+  const updated = transformRawRecurringPayment(updatedRaw, "C1", 10, existing);
+
+  assert.ok(
+    !updated.events.includes(RecurringEvent.JITTERED),
+    "JITTERED event must NOT be present on the first cycle (payment_count == 1)",
+  );
+});
+
+// ── Jitter T5: edge case — jitter_window = 0 is identical to no jitter ───────
+
+test("jitter edge case: jitter_window=0 and jitter_window absent produce identical output", () => {
+  const withExplicitZero = { ...baseRaw, jitter_window: "0", jitter_offset: "0" };
+  const withoutFields = { ...baseRaw };
+
+  const n1 = transformRawRecurringPayment(withExplicitZero, "C1", 5);
+  const n2 = transformRawRecurringPayment(withoutFields, "C1", 5);
+
+  assert.equal(n1.jitterWindow, n2.jitterWindow, "jitterWindow must be 0 in both cases");
+  assert.equal(n1.jitterOffset, n2.jitterOffset, "jitterOffset must be 0 in both cases");
+  assert.equal(n1.nextPaymentLedger, n2.nextPaymentLedger, "nextPaymentLedger must be identical");
+  assert.equal(n1.status, n2.status, "status must be identical");
+});
+
+// ── Jitter T6: CONTRACT_RECURRING_EVENT_MAP is correctly wired ───────────────
+
+test("CONTRACT_RECURRING_EVENT_MAP maps recurring_payment_executed and recurring_pay_jittered", async () => {
+  const { CONTRACT_RECURRING_EVENT_MAP, RecurringEvent: RE } = await import("./types.js");
+
+  assert.equal(
+    CONTRACT_RECURRING_EVENT_MAP["recurring_payment_executed"],
+    RE.EXECUTED,
+    "recurring_payment_executed must map to EXECUTED",
+  );
+  assert.equal(
+    CONTRACT_RECURRING_EVENT_MAP["recurring_pay_jittered"],
+    RE.JITTERED,
+    "recurring_pay_jittered must map to JITTERED",
+  );
 });

--- a/backend/src/modules/recurring/recurring.service.ts
+++ b/backend/src/modules/recurring/recurring.service.ts
@@ -148,6 +148,14 @@ export function transformRawRecurringPayment(
     Number(raw.payment_count) > existingPayment.paymentCount
   ) {
     events.push(RecurringEvent.EXECUTED);
+    // If jitter is configured and this payment is past its first cycle, the
+    // contract will have emitted a recurring_pay_jittered event on-chain.
+    // Mirror that in the local event log for audit-trail completeness.
+    if (Number(raw.jitter_window ?? "0") > 0 && Number(raw.payment_count) > 1) {
+      if (!events.includes(RecurringEvent.JITTERED)) {
+        events.push(RecurringEvent.JITTERED);
+      }
+    }
   }
 
   // Calculate computed fields
@@ -195,6 +203,10 @@ export function transformRawRecurringPayment(
     computedStatus,
     ledgersUntilDue,
     missedPayments,
+    // Jitter fields — default to 0 for payments created before jitter support
+    // or when not returned by the RPC (optional in RawRecurringPayment).
+    jitterWindow: Number(raw.jitter_window ?? "0"),
+    jitterOffset: Number(raw.jitter_offset ?? "0"),
   };
 }
 

--- a/backend/src/modules/recurring/types.ts
+++ b/backend/src/modules/recurring/types.ts
@@ -27,6 +27,12 @@ export enum RecurringEvent {
   CANCELLED = "CANCELLED",
   /** Payment became due (ledger threshold reached) */
   BECAME_DUE = "BECAME_DUE",
+  /**
+   * Jitter was applied to the next execution ledger.
+   * The next_payment_ledger on this payment is offset by jitter_offset ledgers
+   * beyond the nominal schedule.  This is expected behavior, not an anomaly.
+   */
+  JITTERED = "JITTERED",
 }
 
 /**
@@ -68,6 +74,21 @@ export interface NormalizedRecurringPayment {
   readonly ledgersUntilDue: number;
   /** Number of missed payments when overdue */
   readonly missedPayments: number;
+  /**
+   * Maximum ledger spread applied after the first cycle for load distribution.
+   * 0 means jitter is disabled for this payment.
+   * When non-zero, each cycle's `nextPaymentLedger` is shifted forward by
+   * `jitterOffset` ledgers.  Auditors: this variance is intentional — see
+   * RECURRING_PAYMENT_JITTERED events for per-cycle details.
+   */
+  readonly jitterWindow: number;
+  /**
+   * Deterministic offset (in ledgers) added to `nextPaymentLedger` each cycle
+   * when `jitterWindow > 0`.  Computed on-chain as
+   * `sha256(id || creation_ledger) % jitter_window`.  Fixed for the lifetime
+   * of the payment.
+   */
+  readonly jitterOffset: number;
 }
 
 /**
@@ -85,6 +106,16 @@ export interface RawRecurringPayment {
   readonly next_payment_ledger: string;
   readonly payment_count: string;
   readonly is_active: boolean;
+  /**
+   * Maximum jitter window in ledgers (0 = disabled).
+   * Capped on-chain at 10% of the payment interval.
+   */
+  readonly jitter_window?: string;
+  /**
+   * Deterministic jitter offset in ledgers applied from the second cycle
+   * onward.  sha256(id || creation_ledger) % jitter_window.
+   */
+  readonly jitter_offset?: string;
 }
 
 /**
@@ -129,10 +160,8 @@ export interface RecurringFilter {
 
 /**
  * Map of contract event topics to internal RecurringEvent types.
- * TODO: Add recurring event topics once contract emits them
  */
 export const CONTRACT_RECURRING_EVENT_MAP: Record<string, RecurringEvent> = {
-  // recurring_created: RecurringEvent.CREATED,
-  // recurring_executed: RecurringEvent.EXECUTED,
-  // recurring_cancelled: RecurringEvent.CANCELLED,
+  recurring_payment_executed: RecurringEvent.EXECUTED,
+  recurring_pay_jittered: RecurringEvent.JITTERED,
 };

--- a/contracts/vault/Cargo.lock
+++ b/contracts/vault/Cargo.lock
@@ -544,9 +544,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -1545,3 +1545,42 @@ pub fn emit_gov_proposal_executed(env: &Env, id: u64, param: u32, new_value: i12
     env.events()
         .publish((Symbol::new(env, "gov_executed"), id), (param, new_value));
 }
+
+// ============================================================================
+// Recurring Payment Jitter Events (issue #1364)
+// ============================================================================
+
+/// Emit when jitter is applied to a recurring payment's next execution ledger.
+///
+/// This event fires once per execution cycle (not per missed-payment catch-up
+/// transfer) whenever `jitter_window > 0` AND the payment is past its first
+/// cycle (jitter is skipped for the very first payment so it executes promptly).
+///
+/// **Audit note**: When this event is present for a payment ID, the
+/// `next_payment_ledger` stored on-chain will differ from the naive
+/// `prev_next_payment_ledger + interval` by exactly `jitter_offset` ledgers.
+/// Auditors should treat this timing variance as expected behavior, not a bug.
+///
+/// Topics: `("recurring_pay_jittered", payment_id)`
+/// Data:   `(nominal_next_ledger, jittered_next_ledger, jitter_offset)`
+///
+/// # Arguments
+/// * `payment_id`           - ID of the recurring payment.
+/// * `nominal_next_ledger`  - What `next_payment_ledger` would be without jitter
+///                            (i.e. `prev_next_payment_ledger + n * interval`).
+/// * `jittered_next_ledger` - The actual stored `next_payment_ledger` after
+///                            adding `jitter_offset`.
+/// * `jitter_offset`        - The ledger offset added (`jitter_offset` field on
+///                            the payment, in `[0, jitter_window)`).
+pub fn emit_recurring_payment_jittered(
+    env: &Env,
+    payment_id: u64,
+    nominal_next_ledger: u64,
+    jittered_next_ledger: u64,
+    jitter_offset: u32,
+) {
+    env.events().publish(
+        (Symbol::new(env, "recurring_pay_jittered"), payment_id),
+        (nominal_next_ledger, jittered_next_ledger, jitter_offset),
+    );
+}

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -4838,11 +4838,22 @@ impl VaultDAO {
         // Update payment schedule.
         // After the first payment (payment_count was 0), apply jitter to all subsequent cycles.
         let was_first_payment = payment.payment_count == 0;
-        payment.next_payment_ledger += total_payments * payment.interval;
+        let nominal_next_ledger = payment.next_payment_ledger + total_payments * payment.interval;
+        payment.next_payment_ledger = nominal_next_ledger;
         if !was_first_payment && payment.jitter_window > 0 {
             payment.next_payment_ledger = payment
                 .next_payment_ledger
                 .saturating_add(payment.jitter_offset as u64);
+
+            // Emit a jitter event so auditors can distinguish timing variance
+            // from scheduling bugs.  See events.rs for full field documentation.
+            crate::events::emit_recurring_payment_jittered(
+                &env,
+                payment_id,
+                nominal_next_ledger,
+                payment.next_payment_ledger,
+                payment.jitter_offset,
+            );
         }
         payment.payment_count += total_payments as u32;
         storage::set_recurring_payment(&env, &payment);

--- a/contracts/vault/src/test_recurring.rs
+++ b/contracts/vault/src/test_recurring.rs
@@ -715,3 +715,388 @@ fn test_two_payments_same_interval_different_jitter() {
     assert!(p1.jitter_offset < jitter_window);
     assert!(p2.jitter_offset < jitter_window);
 }
+
+// ============================================================================
+// Issue #1364: Recurring Payment Jitter — Load Distribution Tests
+//
+// Design notes
+// ─────────────
+// • Jitter window: [0, jitter_window).  Forward-only (non-symmetric).
+//   Consistent with the existing on-chain formula: sha256(id||ledger) % window.
+// • Randomness source: Soroban's env.crypto().sha256() — fully deterministic
+//   given the same (id, creation_ledger) pair.  No external RNG to mock;
+//   determinism is guaranteed by the ledger environment.
+// • First payment has NO jitter (always executes at creation_ledger + interval)
+//   so organisations aren't surprised by a delayed first disbursement.
+// • Jitter is applied from the second cycle onward by adding jitter_offset to
+//   the advanced next_payment_ledger.
+// • jitter_offset is fixed at creation — identical for every subsequent cycle
+//   of the same payment.
+// • When jitter_window == 0, behavior is byte-for-byte identical to the
+//   pre-jitter scheduling logic.
+// ============================================================================
+
+// ── Helper: advance to next_payment_ledger and execute, returning the payment ──
+
+fn execute_at_due(
+    env: &Env,
+    client: &crate::VaultDAOClient<'_>,
+    payment_id: u64,
+) -> crate::RecurringPayment {
+    let p = client.get_recurring_payment(&payment_id);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = p.next_payment_ledger as u32);
+    client.execute_recurring_payment(&payment_id);
+    client.get_recurring_payment(&payment_id)
+}
+
+// ── T1: Regression — jitter disabled (window == 0) is identical to pre-jitter
+//        scheduling for both the first and second cycles. ────────────────────
+
+#[test]
+fn test_jitter_disabled_regression_first_and_second_cycle() {
+    let env = Env::default();
+    let (client, admin, token, recipient) = setup(&env);
+
+    let interval = 1440u64;
+    let creation_ledger = env.ledger().sequence() as u64;
+
+    let payment_id = client.schedule_payment(
+        &admin,
+        &recipient,
+        &token,
+        &50i128,
+        &Symbol::new(&env, "salary"),
+        &interval,
+        &0u32, // max_missed_payments
+        &0u32, // jitter_window = 0 → no jitter
+    );
+
+    // ── First cycle ──────────────────────────────────────────────────────────
+    let p = client.get_recurring_payment(&payment_id);
+    assert_eq!(p.jitter_window, 0, "jitter_window must be 0");
+    assert_eq!(p.jitter_offset, 0, "jitter_offset must be 0");
+    assert_eq!(
+        p.next_payment_ledger,
+        creation_ledger + interval,
+        "first next_payment_ledger must equal creation_ledger + interval exactly"
+    );
+
+    // Execute first cycle
+    env.ledger()
+        .with_mut(|l| l.sequence_number = p.next_payment_ledger as u32);
+    client.execute_recurring_payment(&payment_id);
+
+    // ── Second cycle ─────────────────────────────────────────────────────────
+    let after_first = client.get_recurring_payment(&payment_id);
+    assert_eq!(
+        after_first.next_payment_ledger,
+        creation_ledger + 2 * interval,
+        "second next_payment_ledger must equal creation_ledger + 2*interval with no jitter"
+    );
+}
+
+// ── T2: Deterministic enabled — jitter_offset is a fixed, known value
+//        derived from sha256(id || creation_ledger) % jitter_window.
+//        We verify the exact offset is applied starting from the second cycle. ─
+
+#[test]
+fn test_jitter_enabled_deterministic_exact_offset_applied_second_cycle() {
+    let env = Env::default();
+    let (client, admin, token, recipient) = setup(&env);
+
+    let interval = 2000u64;
+    let jitter_window = 200u32; // 10% of interval
+    let creation_ledger = env.ledger().sequence() as u64;
+
+    let payment_id = client.schedule_payment(
+        &admin,
+        &recipient,
+        &token,
+        &100i128,
+        &Symbol::new(&env, "grant"),
+        &interval,
+        &0u32,
+        &jitter_window,
+    );
+
+    let p = client.get_recurring_payment(&payment_id);
+    // Capture the exact deterministic offset at creation time
+    let fixed_offset = p.jitter_offset;
+
+    // Preconditions
+    assert!(
+        fixed_offset < jitter_window,
+        "jitter_offset must be in [0, jitter_window)"
+    );
+    assert_eq!(
+        p.next_payment_ledger,
+        creation_ledger + interval,
+        "first payment must not be jittered"
+    );
+
+    // Execute first cycle (no jitter applied to this cycle's *advancement*)
+    env.ledger()
+        .with_mut(|l| l.sequence_number = p.next_payment_ledger as u32);
+    client.execute_recurring_payment(&payment_id);
+
+    let after_first = client.get_recurring_payment(&payment_id);
+    // After first payment: next_payment_ledger = creation + 2*interval + fixed_offset
+    let expected_second = creation_ledger + 2 * interval + fixed_offset as u64;
+    assert_eq!(
+        after_first.next_payment_ledger, expected_second,
+        "second cycle next_payment_ledger must be nominal + fixed_offset exactly"
+    );
+
+    // Execute second cycle to confirm jitter is also applied to the third cycle
+    env.ledger()
+        .with_mut(|l| l.sequence_number = after_first.next_payment_ledger as u32);
+    client.execute_recurring_payment(&payment_id);
+
+    let after_second = client.get_recurring_payment(&payment_id);
+    let expected_third = creation_ledger + 3 * interval + 2 * fixed_offset as u64;
+    assert_eq!(
+        after_second.next_payment_ledger, expected_third,
+        "third cycle next_payment_ledger must be nominal + 2*fixed_offset exactly"
+    );
+}
+
+// ── T3: Statistical range check — across N payments with different IDs, every
+//        jitter_offset falls strictly within [0, jitter_window). ─────────────
+
+#[test]
+fn test_jitter_offsets_always_within_window_statistical() {
+    let env = Env::default();
+    let (client, admin, token, _) = setup(&env);
+
+    let interval = 3000u64;
+    let jitter_window = 300u32; // 10% of interval
+
+    for i in 0u64..20 {
+        let recipient = soroban_sdk::Address::generate(&env);
+        let payment_id = client.schedule_payment(
+            &admin,
+            &recipient,
+            &token,
+            &(10 + i as i128),
+            &Symbol::new(&env, "dist"),
+            &interval,
+            &0u32,
+            &jitter_window,
+        );
+        // Advance ledger so each payment gets a unique creation_ledger hash
+        env.ledger().with_mut(|l| l.sequence_number += 3);
+
+        let p = client.get_recurring_payment(&payment_id);
+        assert!(
+            p.jitter_offset < jitter_window,
+            "payment {i}: jitter_offset {} must be < jitter_window {}",
+            p.jitter_offset,
+            jitter_window
+        );
+    }
+}
+
+// ── T4: Event emission — recurring_pay_jittered is emitted on second cycle
+//        with correct (nominal, jittered, offset) values, and is NOT emitted
+//        on the first cycle or when jitter_window == 0. ────────────────────
+
+#[test]
+fn test_jitter_event_emitted_on_second_cycle_not_on_first() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, recipient) = setup(&env);
+
+    let interval = 1440u64;
+    let jitter_window = 144u32; // 10%
+    let creation_ledger = env.ledger().sequence() as u64;
+
+    let payment_id = client.schedule_payment(
+        &admin,
+        &recipient,
+        &token,
+        &75i128,
+        &Symbol::new(&env, "payroll"),
+        &interval,
+        &0u32,
+        &jitter_window,
+    );
+
+    let p = client.get_recurring_payment(&payment_id);
+    let fixed_offset = p.jitter_offset;
+
+    // ── First execution: no jitter event expected ─────────────────────────
+    env.ledger()
+        .with_mut(|l| l.sequence_number = p.next_payment_ledger as u32);
+
+    let events_before_first_exec = env.events().all();
+    client.execute_recurring_payment(&payment_id);
+    let events_after_first_exec = env.events().all();
+
+    // Count recurring_pay_jittered events emitted during first execution
+    let jitter_events_first: Vec<_> = events_after_first_exec
+        .iter()
+        .skip(events_before_first_exec.len())
+        .filter(|e| {
+            e.0.get(0)
+                .map(|t| t == soroban_sdk::Val::from(soroban_sdk::Symbol::new(&env, "recurring_pay_jittered")))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        jitter_events_first.len(),
+        0,
+        "recurring_pay_jittered must NOT be emitted on the first cycle"
+    );
+
+    // ── Second execution: jitter event IS expected ────────────────────────
+    let after_first = client.get_recurring_payment(&payment_id);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = after_first.next_payment_ledger as u32);
+
+    let events_before_second_exec = env.events().all();
+    client.execute_recurring_payment(&payment_id);
+    let events_after_second_exec = env.events().all();
+
+    let jitter_events_second: Vec<_> = events_after_second_exec
+        .iter()
+        .skip(events_before_second_exec.len())
+        .filter(|e| {
+            e.0.get(0)
+                .map(|t| t == soroban_sdk::Val::from(soroban_sdk::Symbol::new(&env, "recurring_pay_jittered")))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        jitter_events_second.len(),
+        1,
+        "recurring_pay_jittered must be emitted exactly once on the second cycle"
+    );
+
+    // Verify event data: (nominal_next_ledger, jittered_next_ledger, jitter_offset)
+    let event_data = &jitter_events_second[0].1;
+    // nominal = creation_ledger + 2*interval (before jitter)
+    let expected_nominal = creation_ledger + 2 * interval;
+    let expected_jittered = expected_nominal + fixed_offset as u64;
+
+    let data_vec = soroban_sdk::Vec::<soroban_sdk::Val>::try_from(event_data.clone())
+        .expect("event data should be a vec");
+
+    let nominal_val = u64::try_from(data_vec.get(0).unwrap()).expect("nominal should be u64");
+    let jittered_val = u64::try_from(data_vec.get(1).unwrap()).expect("jittered should be u64");
+    let offset_val = u32::try_from(data_vec.get(2).unwrap()).expect("offset should be u32");
+
+    assert_eq!(nominal_val, expected_nominal, "event nominal_next_ledger mismatch");
+    assert_eq!(jittered_val, expected_jittered, "event jittered_next_ledger mismatch");
+    assert_eq!(offset_val, fixed_offset, "event jitter_offset mismatch");
+}
+
+#[test]
+fn test_jitter_event_not_emitted_when_window_is_zero() {
+    let env = Env::default();
+    let (client, admin, token, recipient) = setup(&env);
+
+    let interval = 1000u64;
+
+    let payment_id = client.schedule_payment(
+        &admin,
+        &recipient,
+        &token,
+        &100i128,
+        &Symbol::new(&env, "nowjitter"),
+        &interval,
+        &0u32,
+        &0u32, // jitter_window = 0
+    );
+
+    // Execute first cycle
+    let p = client.get_recurring_payment(&payment_id);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = p.next_payment_ledger as u32);
+    client.execute_recurring_payment(&payment_id);
+
+    // Execute second cycle
+    let p2 = client.get_recurring_payment(&payment_id);
+    env.ledger()
+        .with_mut(|l| l.sequence_number = p2.next_payment_ledger as u32);
+
+    let events_before = env.events().all();
+    client.execute_recurring_payment(&payment_id);
+    let events_after = env.events().all();
+
+    let jitter_events: Vec<_> = events_after
+        .iter()
+        .skip(events_before.len())
+        .filter(|e| {
+            e.0.get(0)
+                .map(|t| t == soroban_sdk::Val::from(soroban_sdk::Symbol::new(&env, "recurring_pay_jittered")))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert_eq!(
+        jitter_events.len(),
+        0,
+        "recurring_pay_jittered must NOT be emitted when jitter_window == 0"
+    );
+}
+
+// ── T5: Edge case — jitter window of zero is behaviorally identical to no
+//        jitter at all, even across many cycles. ───────────────────────────
+
+#[test]
+fn test_jitter_window_zero_identical_to_no_jitter_multi_cycle() {
+    let env = Env::default();
+    let (client, admin, token, recipient) = setup(&env);
+    let recipient2 = soroban_sdk::Address::generate(&env);
+
+    let interval = 1440u64;
+    let creation_ledger = env.ledger().sequence() as u64;
+
+    // Payment A: jitter_window explicitly 0
+    let id_a = client.schedule_payment(
+        &admin,
+        &recipient,
+        &token,
+        &100i128,
+        &Symbol::new(&env, "paymenta"),
+        &interval,
+        &0u32,
+        &0u32, // window = 0
+    );
+
+    // Both created at same ledger so their schedules must stay in lock-step
+    let id_b = client.schedule_payment(
+        &admin,
+        &recipient2,
+        &token,
+        &100i128,
+        &Symbol::new(&env, "paymentb"),
+        &interval,
+        &0u32,
+        &0u32, // also window = 0
+    );
+
+    for cycle in 1u64..=4 {
+        let pa = client.get_recurring_payment(&id_a);
+        let pb = client.get_recurring_payment(&id_b);
+
+        // Both must be due at exactly creation_ledger + cycle * interval
+        let expected = creation_ledger + cycle * interval;
+        assert_eq!(
+            pa.next_payment_ledger, expected,
+            "cycle {cycle}: payment A next_payment_ledger mismatch"
+        );
+        assert_eq!(
+            pb.next_payment_ledger, expected,
+            "cycle {cycle}: payment B next_payment_ledger mismatch"
+        );
+
+        env.ledger()
+            .with_mut(|l| l.sequence_number = expected as u32);
+        client.execute_recurring_payment(&id_a);
+        client.execute_recurring_payment(&id_b);
+    }
+}

--- a/contracts/vault/src/types.rs
+++ b/contracts/vault/src/types.rs
@@ -679,6 +679,13 @@ pub struct RecurringPayment {
     pub jitter_window: u32,
     /// Deterministic jitter offset computed as sha256(id || creation_ledger) % jitter_window.
     /// Added to the base schedule ledger. Zero for the first payment.
+    ///
+    /// **Audit trail note**: When `jitter_window > 0`, the `next_payment_ledger` stored
+    /// after each execution (starting from the second cycle) will differ from the nominal
+    /// schedule by exactly `jitter_offset` ledgers.  Consecutive execution timestamps that
+    /// appear `interval + jitter_offset` ledgers apart (rather than exactly `interval`) are
+    /// expected and intentional — check for a `recurring_pay_jittered` on-chain event to
+    /// confirm.  Do not treat this timing variance as a missed or delayed payment.
     pub jitter_offset: u32,
 }
 


### PR DESCRIPTION
Closes #1364

---

- Add jitter_window and jitter_offset fields to RecurringPayment (contract)
- Deterministic offset: sha256(id || creation_ledger) % jitter_window — no external RNG needed on-chain, fully reproducible given the same inputs
- Jitter applied from second payment cycle onward (first payment never jittered)
- Emit recurring_pay_jittered event with nominal/jittered ledger and offset on each jittered execution
- Mirror jitter fields and JITTERED event in backend recurring.service.ts for audit-log completeness
- Document audit-trail timing impact directly on the jitter_offset struct field
- Tests: disabled regression (multi-cycle), deterministic exact-offset compounding across cycles, statistical range check across 20 payments, event emission presence/absence, zero-window edge case

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
