### PR TITLE
Add proposal execution cost estimation oracle integration (#1367)

### DIFF
--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -358,6 +358,11 @@ pub enum VaultError {
     MaxDeadlineExtensionsReached = 47,
     OracleNotConfigured = 721,
     OraclePriceStale = 722,
+    // =========================================================
+    // Issue #1367: Gas-Price Oracle
+    // =========================================================
+    /// Gas-price oracle contract returned a zero or negative price
+    GasPriceOracleInvalidPrice = 723,
 }
 
 // Compatibility markers for CI source checks:

--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -238,6 +238,30 @@ pub fn emit_oracle_price_stale(env: &Env, asset: &Address, price_ledger: u64, cu
     );
 }
 
+// ============================================================================
+// Gas-Price Oracle Fee Estimation Events (Issue #1367)
+// ============================================================================
+
+/// Emit when a proposal fee estimate is finalized, recording which price source
+/// was used (oracle live price vs. local CostModel fallback) and the price value.
+///
+/// Topics: `("oracle_gas_price_used", proposal_id)`
+/// Data:   `(price_used, source_is_oracle: bool)`
+///
+/// `source_is_oracle = true`  → live oracle price was used.
+/// `source_is_oracle = false` → local CostModel fallback was used (oracle unavailable/stale/invalid).
+pub fn emit_oracle_gas_price_used(
+    env: &Env,
+    proposal_id: u64,
+    price_used: i128,
+    source_is_oracle: bool,
+) {
+    env.events().publish(
+        (Symbol::new(env, "oracle_gas_price_used"), proposal_id),
+        (price_used, source_is_oracle),
+    );
+}
+
 /// Emit when quorum configuration is updated by admin
 pub fn emit_quorum_updated(env: &Env, admin: &Address, old_quorum: u32, new_quorum: u32) {
     env.events().publish(

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -33,13 +33,13 @@ use types::{
     CrossVaultStatus, DeadLetterRecord, Delegation, DelegationHistory, DexConfig, Dispute,
     DisputeResolution, DisputeStatus, Escrow, EscrowStatus, ExecutionFeeEstimate, FundingMilestone,
     FundingMilestoneStatus, FundingRound, FundingRoundConfig, FundingRoundStatus, GasConfig,
-    GovernanceProposal, HolidayBehavior, HolidayCalendar, ImpactScore, InitConfig, InsuranceClaim,
-    InsuranceClaimStatus, InsuranceConfig, ListMode, Milestone, MultiPhaseProposal,
-    NotificationPreferences, NotificationPrefs, OptionalProposalOperation,
-    OptionalVaultOracleConfig, PauseState, Priority, Proposal, ProposalAmendment,
-    ProposalOperation, ProposalPhase, ProposalPhaseStatus, ProposalStatus, ProposalTemplate,
-    RecoveryConfig, RecoveryProposal, RecoveryStatus, RecurringPayment, RecurringStatus,
-    Reputation, ReputationConfig, RetryConfig, RetryState, Role, RoleAssignment,
+    GasPriceOracleConfig, GasPriceSource, GovernanceProposal, HolidayBehavior, HolidayCalendar,
+    ImpactScore, InitConfig, InsuranceClaim, InsuranceClaimStatus, InsuranceConfig, ListMode,
+    Milestone, MultiPhaseProposal, NotificationPreferences, NotificationPrefs,
+    OptionalProposalOperation, OptionalVaultOracleConfig, PauseState, Priority, Proposal,
+    ProposalAmendment, ProposalOperation, ProposalPhase, ProposalPhaseStatus, ProposalStatus,
+    ProposalTemplate, RecoveryConfig, RecoveryProposal, RecoveryStatus, RecurringPayment,
+    RecurringStatus, Reputation, ReputationConfig, RetryConfig, RetryState, Role, RoleAssignment,
     ScheduledTransferConfig, ScopedDelegation, SignerTier, StakingConfig, StreamRateWindow,
     StreamStatus, StreamingPayment, Subscription, SubscriptionStatus, SubscriptionTier,
     SwapProposal, SwapResult, TemplateOverrides, ThresholdStrategy, TokenSpendingConfig,
@@ -245,6 +245,8 @@ mod test_cross_vault;
 mod test_disputes;
 #[cfg(test)]
 mod test_fees;
+#[cfg(test)]
+mod test_gas_price_oracle;
 #[cfg(test)]
 mod test_hooks;
 #[cfg(test)]
@@ -7183,7 +7185,26 @@ impl VaultDAO {
     /// Estimate the compute cost of executing a proposal.
     ///
     /// Walks the proposal's operations and conditions, aggregates costs from the
-    /// on-chain CostModel, and applies a 10% buffer.  Read-only (advisory).
+    /// on-chain CostModel, and applies a 10% buffer.
+    ///
+    /// # Oracle integration (Issue #1367)
+    ///
+    /// When a gas-price oracle is configured via `set_gas_price_oracle`, this
+    /// function queries it for a live `stroops_per_10k_compute_units` price.
+    /// The oracle must expose the same `lastprice(asset: Address) -> Option<VaultPriceData>`
+    /// interface already used by `get_asset_price` / condition evaluation.
+    ///
+    /// Fallback rules — the local `CostModel.stroops_per_10k_compute_units` is
+    /// used (and the reason is recorded in `price_source`) if:
+    ///   - no oracle is configured,
+    ///   - the oracle cross-contract call panics,
+    ///   - the oracle returns `None`,
+    ///   - the returned price is stale (older than `max_staleness` ledgers),
+    ///   - the returned price is ≤ 0.
+    ///
+    /// The function **never** returns an error for oracle failures — fallback is
+    /// silent except for the `oracle_gas_price_used` event that records the
+    /// source and price actually used.
     pub fn estimate_proposal_cost(
         env: Env,
         proposal_id: u64,
@@ -7191,6 +7212,7 @@ impl VaultDAO {
         let proposal = storage::get_proposal(&env, proposal_id)?;
         let model = storage::get_cost_model(&env);
 
+        // --- compute unit aggregation (unchanged from Issue #1085) ---
         let mut compute_units: u64 = model.base_compute_units;
         let mut ledger_reads: u32 = model.base_ledger_reads;
         let mut ledger_writes: u32 = model.base_ledger_writes;
@@ -7224,15 +7246,148 @@ impl VaultDAO {
         // Apply 10% conservative buffer
         compute_units = compute_units.saturating_add(compute_units / 10);
 
-        let fee_estimate_xlm =
-            (compute_units as i128 / 10_000).saturating_mul(model.stroops_per_10k_compute_units);
+        // --- oracle price resolution (Issue #1367) ---
+        let (price_used, price_source) = Self::resolve_gas_price(&env, &model, proposal_id);
+
+        let fee_estimate_xlm = (compute_units as i128 / 10_000).saturating_mul(price_used);
 
         Ok(types::CostEstimate {
             compute_units,
             ledger_reads,
             ledger_writes,
             fee_estimate_xlm,
+            price_used,
+            price_source,
         })
+    }
+
+    // ========================================================================
+    // Issue #1367: Gas-Price Oracle Configuration
+    // ========================================================================
+
+    /// Configure the oracle contract used to fetch live gas prices for fee
+    /// estimation.  Admin-only.
+    ///
+    /// Pass the address of any contract that implements the `lastprice` interface
+    /// (same interface already used by `Condition::PriceAbove/Below`):
+    /// ```text
+    /// lastprice(asset: Address) -> Option<VaultPriceData>
+    /// ```
+    /// The `asset` argument passed to `lastprice` is the vault's **own contract
+    /// address**, which acts as a stable identifier for the "gas price" feed.
+    ///
+    /// Set `max_staleness = 0` is rejected; use `clear_gas_price_oracle` to
+    /// remove the oracle and revert to local-only estimation.
+    pub fn set_gas_price_oracle(
+        env: Env,
+        admin: Address,
+        oracle_address: Address,
+        max_staleness: u32,
+    ) -> Result<(), VaultError> {
+        admin.require_auth();
+
+        if !Role::role_satisfies(Role::Admin, storage::get_role(&env, &admin)) {
+            return Err(VaultError::Unauthorized);
+        }
+        if max_staleness == 0 {
+            return Err(VaultError::InvalidAmount);
+        }
+
+        let config = GasPriceOracleConfig {
+            address: oracle_address.clone(),
+            max_staleness,
+        };
+        storage::set_gas_price_oracle_config(&env, &config);
+        storage::extend_instance_ttl(&env);
+
+        // Reuse the existing oracle-config-updated event; the admin and oracle
+        // address are the relevant attributes.
+        events::emit_oracle_config_updated(&env, &admin, &oracle_address);
+
+        Ok(())
+    }
+
+    /// Remove the gas-price oracle configuration.  Subsequent calls to
+    /// `estimate_proposal_cost` will use the local CostModel price only.
+    pub fn clear_gas_price_oracle(env: Env, admin: Address) -> Result<(), VaultError> {
+        admin.require_auth();
+
+        if !Role::role_satisfies(Role::Admin, storage::get_role(&env, &admin)) {
+            return Err(VaultError::Unauthorized);
+        }
+
+        storage::clear_gas_price_oracle_config(&env);
+        storage::extend_instance_ttl(&env);
+        Ok(())
+    }
+
+    /// Return the currently configured gas-price oracle, if any.
+    pub fn get_gas_price_oracle(env: Env) -> Option<GasPriceOracleConfig> {
+        storage::get_gas_price_oracle_config(&env)
+    }
+
+    /// Resolve the stroops-per-10k-compute-units price for fee estimation.
+    ///
+    /// Attempts a live oracle query; silently falls back to the CostModel
+    /// constant on any failure.  Emits `oracle_gas_price_used` in all cases.
+    ///
+    /// Returns `(price, source)`.
+    fn resolve_gas_price(
+        env: &Env,
+        model: &types::CostModel,
+        proposal_id: u64,
+    ) -> (i128, GasPriceSource) {
+        let fallback_price = model.stroops_per_10k_compute_units;
+
+        // No oracle configured → use local price immediately.
+        let oracle_cfg = match storage::get_gas_price_oracle_config(env) {
+            Some(cfg) => cfg,
+            None => {
+                events::emit_oracle_gas_price_used(env, proposal_id, fallback_price, false);
+                return (fallback_price, GasPriceSource::LocalFallback);
+            }
+        };
+
+        // Query oracle.  Use try_invoke_contract so a panicking oracle never
+        // blocks proposal execution; treat all errors as a fallback trigger.
+        let vault_addr = env.current_contract_address();
+        let raw_result = env.try_invoke_contract::<Option<VaultPriceData>, soroban_sdk::Error>(
+            &oracle_cfg.address,
+            &Symbol::new(env, "lastprice"),
+            Vec::from_array(env, [vault_addr.into_val(env)]),
+        );
+
+        let price_data = match raw_result {
+            Ok(Ok(Some(data))) => data,
+            // Oracle returned None, a contract error, or a host error → fallback.
+            _ => {
+                events::emit_oracle_gas_price_used(env, proposal_id, fallback_price, false);
+                return (fallback_price, GasPriceSource::LocalFallback);
+            }
+        };
+
+        // Staleness check.
+        let current_ledger = env.ledger().sequence() as u64;
+        if current_ledger.saturating_sub(price_data.timestamp) > oracle_cfg.max_staleness as u64 {
+            events::emit_oracle_price_stale(
+                env,
+                &oracle_cfg.address,
+                price_data.timestamp,
+                current_ledger,
+            );
+            events::emit_oracle_gas_price_used(env, proposal_id, fallback_price, false);
+            return (fallback_price, GasPriceSource::LocalFallback);
+        }
+
+        // Validity check: price must be positive.
+        if price_data.price <= 0 {
+            events::emit_oracle_gas_price_used(env, proposal_id, fallback_price, false);
+            return (fallback_price, GasPriceSource::LocalFallback);
+        }
+
+        // All checks passed — use the live oracle price.
+        events::emit_oracle_gas_price_used(env, proposal_id, price_data.price, true);
+        (price_data.price, GasPriceSource::Oracle)
     }
 
     // ========================================================================

--- a/contracts/vault/src/storage.rs
+++ b/contracts/vault/src/storage.rs
@@ -27,13 +27,14 @@ use crate::types::{
     ColdSignerConfig, Comment, Config, CostModel, CrossChainProposal, DeadLetterRecord,
     DelegatedPermission, Delegation, DelegationHistory, DexConfig, Escrow, ExecutionFeeEstimate,
     ExecutionSnapshot, FeeStructure, FundingRound, FundingRoundConfig, GasConfig,
-    GovernanceProposal, HolidayCalendar, InsuranceClaim, InsuranceConfig, ListMode, MergeRecord,
-    MultiPhaseProposal, NotificationPreferences, NotificationPrefs, PauseState, PermissionGrant,
-    Proposal, ProposalAmendment, ProposalStatus, ProposalTemplate, RecoveryProposal, Reputation,
-    ReputationConfig, RetryState, Role, RoleAssignment, ScopedDelegation, SignerTier, StakeRecord,
-    StakingConfig, StreamRateWindow, Subscription, SwapProposal, SwapResult, Tag, TemplateVarRef,
-    TimeWeightedConfig, TokenLock, TokenSpendingConfig, VarTemplate, VaultMetrics, VelocityConfig,
-    VestingSchedule, VotingStrategy, WhitelistEntry,
+    GasPriceOracleConfig, GovernanceProposal, HolidayCalendar, InsuranceClaim, InsuranceConfig,
+    ListMode, MergeRecord, MultiPhaseProposal, NotificationPreferences, NotificationPrefs,
+    PauseState, PermissionGrant, Proposal, ProposalAmendment, ProposalStatus, ProposalTemplate,
+    RecoveryProposal, Reputation, ReputationConfig, RetryState, Role, RoleAssignment,
+    ScopedDelegation, SignerTier, StakeRecord, StakingConfig, StreamRateWindow, Subscription,
+    SwapProposal, SwapResult, Tag, TemplateVarRef, TimeWeightedConfig, TokenLock,
+    TokenSpendingConfig, VarTemplate, VaultMetrics, VelocityConfig, VestingSchedule,
+    VotingStrategy, WhitelistEntry,
 };
 use crate::types_balance_snapshot::BalanceSnapshot;
 
@@ -343,6 +344,9 @@ pub enum FeatureKey {
     // ---- Issue #1085: Gas Cost Estimation Oracle ----
     /// Per-operation cost model -> CostModel
     CostModel,
+    // ---- Issue #1367: Gas-Price Oracle for fee estimation ----
+    /// Live gas-price oracle configuration -> GasPriceOracleConfig
+    GasPriceOracle,
     // ---- Issue #1086: Cold Storage Config ----
     /// Cold signer configuration -> ColdSignerConfig
     ColdSignerConfig,
@@ -3574,6 +3578,27 @@ pub fn get_cost_model(env: &Env) -> CostModel {
 
 pub fn set_cost_model(env: &Env, model: &CostModel) {
     env.storage().instance().set(&FeatureKey::CostModel, model);
+}
+
+// ============================================================================
+// Issue #1367: Gas-Price Oracle Storage
+// ============================================================================
+
+/// Retrieve the gas-price oracle configuration, if one has been set by an admin.
+pub fn get_gas_price_oracle_config(env: &Env) -> Option<GasPriceOracleConfig> {
+    env.storage().instance().get(&FeatureKey::GasPriceOracle)
+}
+
+/// Persist the gas-price oracle configuration.
+pub fn set_gas_price_oracle_config(env: &Env, config: &GasPriceOracleConfig) {
+    env.storage()
+        .instance()
+        .set(&FeatureKey::GasPriceOracle, config);
+}
+
+/// Remove the gas-price oracle configuration (reverts to local-only estimation).
+pub fn clear_gas_price_oracle_config(env: &Env) {
+    env.storage().instance().remove(&FeatureKey::GasPriceOracle);
 }
 
 // ============================================================================

--- a/contracts/vault/src/test_gas_price_oracle.rs
+++ b/contracts/vault/src/test_gas_price_oracle.rs
@@ -1,0 +1,415 @@
+//! Tests for Issue #1367 — Proposal Execution Cost Estimation Oracle Integration.
+//!
+//! Covered scenarios:
+//!  1. No oracle configured → local CostModel price used, event emitted with source=false
+//!  2. Oracle configured, healthy price → oracle price used in fee calculation
+//!  3. Oracle configured, healthy price → event emitted with source=true and correct price
+//!  4. Oracle returns stale price → fallback to local, event source=false
+//!  5. Oracle contract panics / bad address → fallback to local, no propagated panic
+//!  6. Oracle returns None → fallback to local
+//!  7. Oracle returns zero price → fallback to local
+//!  8. Oracle returns negative price → fallback to local
+//!  9. Oracle price used: fee_estimate_xlm matches expected formula
+//! 10. Local fallback fee_estimate_xlm matches original formula
+//! 11. set_gas_price_oracle non-admin is rejected
+//! 12. set_gas_price_oracle with max_staleness=0 is rejected
+//! 13. clear_gas_price_oracle reverts to local fallback
+//! 14. get_gas_price_oracle returns None before set, Some after set
+//! 15. clear_gas_price_oracle non-admin is rejected
+
+use super::*;
+use crate::types::{
+    ConditionLogic, CostModel, GasPriceOracleConfig, GasPriceSource, Priority, RetryConfig,
+    ThresholdStrategy, VaultPriceData, VelocityConfig,
+};
+use crate::{InitConfig, VaultDAO, VaultDAOClient};
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::{Address as _, Events, Ledger},
+    token::StellarAssetClient,
+    Address, Env, Symbol, Vec,
+};
+
+// ============================================================================
+// Mock gas-price oracle
+// ============================================================================
+//
+// Exposes the same `lastprice(asset: Address) -> Option<VaultPriceData>`
+// interface used by the vault's existing oracle integration.
+
+#[contracttype]
+#[derive(Clone)]
+enum GpoKey {
+    Price,
+    ReturnNone,
+}
+
+#[contract]
+pub struct MockGasPriceOracle;
+
+#[contractimpl]
+impl MockGasPriceOracle {
+    pub fn set_price(env: Env, price: i128, timestamp: u64) {
+        env.storage()
+            .instance()
+            .set(&GpoKey::Price, &VaultPriceData { price, timestamp });
+        env.storage().instance().set(&GpoKey::ReturnNone, &false);
+    }
+
+    pub fn set_return_none(env: Env) {
+        env.storage().instance().set(&GpoKey::ReturnNone, &true);
+    }
+
+    pub fn lastprice(env: Env, _asset: Address) -> Option<VaultPriceData> {
+        let return_none: bool = env
+            .storage()
+            .instance()
+            .get(&GpoKey::ReturnNone)
+            .unwrap_or(false);
+        if return_none {
+            return None;
+        }
+        env.storage().instance().get(&GpoKey::Price)
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn default_init(env: &Env, admin: &Address) -> InitConfig {
+    let mut signers = Vec::new(env);
+    signers.push_back(admin.clone());
+    InitConfig {
+        signers,
+        threshold: 1,
+        quorum: 0,
+        quorum_percentage: 0,
+        spending_limit: 10_000_000,
+        daily_limit: 50_000_000,
+        weekly_limit: 100_000_000,
+        timelock_threshold: 9_999_999,
+        timelock_delay: 0,
+        velocity_limit: VelocityConfig {
+            limit: 100_000_000,
+            window: 3_600,
+            per_token_limit: 0,
+        },
+        threshold_strategy: ThresholdStrategy::Fixed,
+        default_voting_deadline: 0,
+        veto_addresses: Vec::new(env),
+        veto_window_ledgers: 0,
+        retry_config: RetryConfig {
+            enabled: false,
+            max_retries: 0,
+            initial_backoff_ledgers: 0,
+            max_retry_delay: 0,
+        },
+        recovery_config: crate::types::RecoveryConfig::default(env),
+        staking_config: crate::types::StakingConfig::default(),
+        pre_execution_hooks: Vec::new(env),
+        post_execution_hooks: Vec::new(env),
+        proposal_id_prefix: 0,
+        whitelist_mode: false,
+        grace_period_ledgers: 100,
+        vote_weight: crate::types::VoteWeight::Flat,
+        high_impact_threshold: 70,
+        admin_rotation_delay: 1_440,
+    }
+}
+
+/// Returns (env, client, admin, token, oracle_address, proposal_id).
+fn setup() -> (Env, VaultDAOClient<'static>, Address, Address, Address, u64) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let vault_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &vault_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &default_init(&env, &admin));
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    StellarAssetClient::new(&env, &token).mint(&vault_id, &1_000_000i128);
+
+    let oracle_id = env.register(MockGasPriceOracle, ());
+
+    // Create a basic proposal so we have a valid proposal_id.
+    let recipient = Address::generate(&env);
+    let pid = client.propose_transfer(
+        &admin,
+        &recipient,
+        &token,
+        &100i128,
+        &Symbol::new(&env, "test"),
+        &Priority::Normal,
+        &Vec::new(&env),
+        &ConditionLogic::And,
+        &0i128,
+    );
+
+    (env, client, admin, token, oracle_id, pid)
+}
+
+fn oracle_client(env: &Env, oracle: &Address) -> MockGasPriceOracleClient {
+    MockGasPriceOracleClient::new(env, oracle)
+}
+
+// ============================================================================
+// 1. No oracle → local price used, event source=false
+// ============================================================================
+#[test]
+fn test_no_oracle_uses_local_price() {
+    let (env, client, _, _, _, pid) = setup();
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(estimate.price_source, GasPriceSource::LocalFallback);
+    assert_eq!(
+        estimate.price_used,
+        CostModel::default().stroops_per_10k_compute_units
+    );
+}
+
+// ============================================================================
+// 2. Oracle configured, healthy → oracle price used
+// ============================================================================
+#[test]
+fn test_oracle_price_used_when_healthy() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    let current = env.ledger().sequence() as u64;
+    oracle_client(&env, &oracle).set_price(&500i128, &current);
+
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(estimate.price_source, GasPriceSource::Oracle);
+    assert_eq!(estimate.price_used, 500);
+}
+
+// ============================================================================
+// 3. Oracle configured, healthy → event emitted with source=true
+// ============================================================================
+#[test]
+fn test_oracle_price_event_emitted_source_true() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    let current = env.ledger().sequence() as u64;
+    oracle_client(&env, &oracle).set_price(&300i128, &current);
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    env.events().all(); // flush
+    client.estimate_proposal_cost(&pid).unwrap();
+
+    let all_events = env.events().all();
+    // Find the oracle_gas_price_used event
+    let found = all_events.iter().any(|(topics, data)| {
+        if let Ok(topic_sym) = topics.get::<Symbol>(0) {
+            if topic_sym == Symbol::new(&env, "oracle_gas_price_used") {
+                // data is (price_used: i128, source_is_oracle: bool)
+                let price: i128 =
+                    soroban_sdk::Val::try_from_val(&env, &data.get::<soroban_sdk::Val>(0).unwrap())
+                        .unwrap();
+                let is_oracle: bool =
+                    soroban_sdk::Val::try_from_val(&env, &data.get::<soroban_sdk::Val>(1).unwrap())
+                        .unwrap();
+                return price == 300 && is_oracle;
+            }
+        }
+        false
+    });
+    assert!(
+        found,
+        "expected oracle_gas_price_used event with source=true"
+    );
+}
+
+// ============================================================================
+// 4. Stale price → fallback to local
+// ============================================================================
+#[test]
+fn test_stale_oracle_price_falls_back_to_local() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    // Price timestamp = 0; advance 200 ledgers past the 100-ledger window.
+    oracle_client(&env, &oracle).set_price(&999i128, &0u64);
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+    env.ledger().with_mut(|li| li.sequence_number += 200);
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(estimate.price_source, GasPriceSource::LocalFallback);
+    assert_eq!(
+        estimate.price_used,
+        CostModel::default().stroops_per_10k_compute_units
+    );
+}
+
+// ============================================================================
+// 5. Bad oracle address → fallback, no panic
+// ============================================================================
+#[test]
+fn test_bad_oracle_address_falls_back_without_panic() {
+    let (env, client, admin, _, _, pid) = setup();
+    let bad_oracle = Address::generate(&env);
+    // This will set the oracle but calling it will panic inside try_invoke_contract.
+    client.set_gas_price_oracle(&admin, &bad_oracle, &100u32);
+
+    // Must not panic — fallback must be used silently.
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(estimate.price_source, GasPriceSource::LocalFallback);
+}
+
+// ============================================================================
+// 6. Oracle returns None → fallback
+// ============================================================================
+#[test]
+fn test_oracle_returns_none_falls_back() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    oracle_client(&env, &oracle).set_return_none();
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(estimate.price_source, GasPriceSource::LocalFallback);
+}
+
+// ============================================================================
+// 7. Oracle returns zero price → fallback
+// ============================================================================
+#[test]
+fn test_oracle_zero_price_falls_back() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    let current = env.ledger().sequence() as u64;
+    oracle_client(&env, &oracle).set_price(&0i128, &current);
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(estimate.price_source, GasPriceSource::LocalFallback);
+    assert!(estimate.price_used > 0, "fallback price must be positive");
+}
+
+// ============================================================================
+// 8. Oracle returns negative price → fallback
+// ============================================================================
+#[test]
+fn test_oracle_negative_price_falls_back() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    let current = env.ledger().sequence() as u64;
+    oracle_client(&env, &oracle).set_price(&-100i128, &current);
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(estimate.price_source, GasPriceSource::LocalFallback);
+}
+
+// ============================================================================
+// 9. Oracle path: fee_estimate_xlm uses oracle price in formula
+// ============================================================================
+#[test]
+fn test_fee_estimate_uses_oracle_price_in_formula() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    let current = env.ledger().sequence() as u64;
+    let oracle_price: i128 = 250;
+    oracle_client(&env, &oracle).set_price(&oracle_price, &current);
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+
+    // Reproduce the formula: fee = (compute_units / 10_000) * price_used
+    let expected_fee = (estimate.compute_units as i128 / 10_000).saturating_mul(oracle_price);
+    assert_eq!(estimate.fee_estimate_xlm, expected_fee);
+}
+
+// ============================================================================
+// 10. Local fallback path: fee_estimate_xlm matches original formula
+// ============================================================================
+#[test]
+fn test_fee_estimate_local_fallback_matches_original_formula() {
+    let (env, client, _, _, _, pid) = setup();
+    // No oracle configured.
+    let model = CostModel::default();
+
+    let estimate = client.estimate_proposal_cost(&pid).unwrap();
+
+    let expected_fee = (estimate.compute_units as i128 / 10_000)
+        .saturating_mul(model.stroops_per_10k_compute_units);
+    assert_eq!(estimate.fee_estimate_xlm, expected_fee);
+    assert_eq!(estimate.price_used, model.stroops_per_10k_compute_units);
+}
+
+// ============================================================================
+// 11. Non-admin cannot set oracle
+// ============================================================================
+#[test]
+fn test_set_gas_price_oracle_non_admin_rejected() {
+    let (env, client, _, _, oracle, _) = setup();
+    let stranger = Address::generate(&env);
+
+    let result = client.try_set_gas_price_oracle(&stranger, &oracle, &100u32);
+    assert_eq!(result, Err(Ok(VaultError::Unauthorized)));
+}
+
+// ============================================================================
+// 12. max_staleness = 0 rejected
+// ============================================================================
+#[test]
+fn test_set_gas_price_oracle_zero_staleness_rejected() {
+    let (env, client, admin, _, oracle, _) = setup();
+
+    let result = client.try_set_gas_price_oracle(&admin, &oracle, &0u32);
+    assert_eq!(result, Err(Ok(VaultError::InvalidAmount)));
+}
+
+// ============================================================================
+// 13. clear_gas_price_oracle reverts to local fallback
+// ============================================================================
+#[test]
+fn test_clear_oracle_reverts_to_local() {
+    let (env, client, admin, _, oracle, pid) = setup();
+    let current = env.ledger().sequence() as u64;
+    oracle_client(&env, &oracle).set_price(&888i128, &current);
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    // Oracle path active.
+    let with_oracle = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(with_oracle.price_source, GasPriceSource::Oracle);
+
+    // Clear it.
+    client.clear_gas_price_oracle(&admin);
+
+    let after_clear = client.estimate_proposal_cost(&pid).unwrap();
+    assert_eq!(after_clear.price_source, GasPriceSource::LocalFallback);
+    assert_eq!(
+        after_clear.price_used,
+        CostModel::default().stroops_per_10k_compute_units
+    );
+}
+
+// ============================================================================
+// 14. get_gas_price_oracle reflects config state
+// ============================================================================
+#[test]
+fn test_get_gas_price_oracle_lifecycle() {
+    let (env, client, admin, _, oracle, _) = setup();
+
+    assert!(client.get_gas_price_oracle().is_none());
+
+    client.set_gas_price_oracle(&admin, &oracle, &50u32);
+    let cfg = client.get_gas_price_oracle().unwrap();
+    assert_eq!(cfg.address, oracle);
+    assert_eq!(cfg.max_staleness, 50);
+
+    client.clear_gas_price_oracle(&admin);
+    assert!(client.get_gas_price_oracle().is_none());
+}
+
+// ============================================================================
+// 15. Non-admin cannot clear oracle
+// ============================================================================
+#[test]
+fn test_clear_gas_price_oracle_non_admin_rejected() {
+    let (env, client, admin, _, oracle, _) = setup();
+    client.set_gas_price_oracle(&admin, &oracle, &100u32);
+
+    let stranger = Address::generate(&env);
+    let result = client.try_clear_gas_price_oracle(&stranger);
+    assert_eq!(result, Err(Ok(VaultError::Unauthorized)));
+}

--- a/contracts/vault/src/types.rs
+++ b/contracts/vault/src/types.rs
@@ -2289,6 +2289,34 @@ pub struct Tag {
 // Issue #1085: Gas Cost Estimation Oracle
 // ============================================================================
 
+/// Which price source was used when producing a fee estimate.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GasPriceSource {
+    /// Live price fetched from the configured gas-price oracle.
+    Oracle,
+    /// Static `stroops_per_10k_compute_units` value from the local CostModel
+    /// (used when no oracle is configured, or on oracle failure).
+    LocalFallback,
+}
+
+/// Configuration for the gas-price oracle integration (Issue #1367).
+///
+/// Stored in instance storage and set by an admin via `set_gas_price_oracle`.
+/// When present, `estimate_proposal_cost` queries this oracle for a live
+/// stroops-per-10k-compute-units price instead of relying solely on the
+/// static `CostModel.stroops_per_10k_compute_units` constant.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GasPriceOracleConfig {
+    /// Address of the gas-price oracle contract.
+    /// The oracle must expose `lastprice(asset: Address) -> Option<VaultPriceData>`.
+    pub address: Address,
+    /// Maximum number of ledgers since the oracle's recorded timestamp before
+    /// the price is treated as stale and the local fallback is used.
+    pub max_staleness: u32,
+}
+
 /// Estimated compute cost breakdown for a proposal's execution.
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -2301,6 +2329,10 @@ pub struct CostEstimate {
     pub ledger_writes: u32,
     /// Fee estimate in stroops (XLM * 10^7)
     pub fee_estimate_xlm: i128,
+    /// Stroops-per-10k-compute-units price actually used for the estimate.
+    pub price_used: i128,
+    /// Whether the price came from the oracle or the local CostModel fallback.
+    pub price_source: GasPriceSource,
 }
 
 /// Per-operation cost weights stored on-chain and updatable by admin.


### PR DESCRIPTION
Closes #1367

---

- Add gas-price oracle configuration (set/clear/get_gas_price_oracle)
- Query oracle for live gas price in estimate_proposal_cost
- Fall back to local CostModel price on oracle failure, staleness, or invalid price
- Emit oracle_gas_price_used event recording price and source
- Add tests covering oracle success, fallback paths, and admin config lifecycle

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
