### PR TITLE
feat(websocket): unsubscribe cleanup verification (#1373)

### DIFF
--- a/backend/src/modules/realtime/realtime-server.ts
+++ b/backend/src/modules/realtime/realtime-server.ts
@@ -209,15 +209,53 @@ export class RealtimeServer {
   }
 
   public unsubscribe(connectionId: string, topic: RealtimeTopic): boolean {
+    // Snapshot state before removal for verification
+    const beforeTopics = this.subscriptions.getTopics(connectionId);
+    const wasPresentBefore = beforeTopics.has(topic);
+
     const removed = this.subscriptions.unsubscribe(connectionId, topic);
-    if (!removed) return false;
+
+    if (!removed) {
+      // Cleanup did not happen — log whether the topic was never subscribed or
+      // the registry refused to remove it
+      if (!wasPresentBefore) {
+        logger.warn("unsubscribe noop: connection was not subscribed to topic", {
+          connectionId,
+          topic,
+        });
+      } else {
+        logger.error("unsubscribe cleanup failed: registry returned false for a known subscription", {
+          connectionId,
+          topic,
+        });
+      }
+      return false;
+    }
+
+    // Verify cleanup: topic must no longer appear in the registry
+    const afterTopics = this.subscriptions.getTopics(connectionId);
+    if (afterTopics.has(topic)) {
+      logger.error("unsubscribe cleanup failed: topic still present in registry after removal", {
+        connectionId,
+        topic,
+        remainingTopics: Array.from(afterTopics),
+      });
+    } else {
+      logger.info("unsubscribe verified: topic removed from registry", {
+        connectionId,
+        topic,
+        remainingTopics: Array.from(afterTopics),
+      });
+    }
 
     this.hooks.onUnsubscribed?.(connectionId, topic);
+
+    // Emit cleanup event with subscriber identity and affected topic
     this.deliver(connectionId, {
       type: "unsubscribed",
       topic,
       ts: new Date().toISOString(),
-      payload: { topic },
+      payload: { subscriber: connectionId, topic },
     });
     return true;
   }

--- a/backend/src/modules/websocket/realtime-streaming.test.ts
+++ b/backend/src/modules/websocket/realtime-streaming.test.ts
@@ -188,6 +188,152 @@ test("RealtimeServer", async (t) => {
     server.unregisterConnection("cnt-1");
     assert.equal(server.getConnectionCount(), 1);
   });
+
+  // ---------------------------------------------------------------------------
+  // Unsubscribe cleanup verification (#1373)
+  // ---------------------------------------------------------------------------
+
+  await t.test(
+    "no events delivered after unsubscribe — subscription fully cleaned up",
+    () => {
+      const server = new RealtimeServer();
+      const recv: any[] = [];
+      registerMockConnection(server, "cleanup-1", recv);
+
+      const topic = server.createTopic("proposal", "cleanup");
+      server.subscribe("cleanup-1", topic);
+
+      // Sanity: broadcast reaches the subscriber before unsubscribe
+      const beforeCount = server.broadcast(topic, { before: true });
+      assert.equal(beforeCount, 1, "should deliver before unsubscribe");
+
+      // Unsubscribe
+      const removed = server.unsubscribe("cleanup-1", topic);
+      assert.equal(removed, true, "unsubscribe should return true");
+
+      // Verify subscription is gone from registry
+      assert.equal(
+        server.getSubscriptions("cleanup-1").has(topic),
+        false,
+        "topic must not remain in subscriptions after unsubscribe",
+      );
+
+      // Clear received messages, then broadcast again
+      recv.length = 0;
+      const afterCount = server.broadcast(topic, { after: true });
+      assert.equal(afterCount, 0, "no events should be delivered after unsubscribe");
+
+      const events = recv.filter((m) => m.type === "event");
+      assert.equal(events.length, 0, "recv buffer must contain no events after unsubscribe");
+    },
+  );
+
+  await t.test(
+    "unsubscribed envelope carries subscriber identity and topic",
+    () => {
+      const server = new RealtimeServer();
+      const recv: any[] = [];
+      registerMockConnection(server, "payload-check", recv);
+
+      const topic = server.createTopic("proposal", "payload-check");
+      server.subscribe("payload-check", topic);
+
+      // Clear hello/subscribed messages
+      recv.length = 0;
+
+      server.unsubscribe("payload-check", topic);
+
+      const envelope = recv.find((m) => m.type === "unsubscribed");
+      assert.ok(envelope, "unsubscribed envelope must be delivered");
+      assert.equal(
+        (envelope.payload as any).subscriber,
+        "payload-check",
+        "envelope payload must include subscriber identity",
+      );
+      assert.equal(
+        (envelope.payload as any).topic,
+        topic,
+        "envelope payload must include the unsubscribed topic",
+      );
+    },
+  );
+
+  await t.test(
+    "unsubscribe returns false and emits no event for unknown topic",
+    () => {
+      const server = new RealtimeServer();
+      const recv: any[] = [];
+      registerMockConnection(server, "noop-check", recv);
+
+      const topic = server.createTopic("proposal", "never-subscribed");
+
+      // Clear hello message
+      recv.length = 0;
+
+      const removed = server.unsubscribe("noop-check", topic);
+      assert.equal(removed, false, "unsubscribe of unknown topic must return false");
+
+      const envelope = recv.find((m) => m.type === "unsubscribed");
+      assert.equal(envelope, undefined, "no unsubscribed envelope when topic was not subscribed");
+    },
+  );
+
+  await t.test(
+    "unsubscribe one topic does not affect other subscriptions",
+    () => {
+      const server = new RealtimeServer();
+      const recv: any[] = [];
+      registerMockConnection(server, "partial-unsub", recv);
+
+      const topicA = server.createTopic("proposal", "keep");
+      const topicB = server.createTopic("proposal", "remove");
+
+      server.subscribe("partial-unsub", topicA);
+      server.subscribe("partial-unsub", topicB);
+
+      server.unsubscribe("partial-unsub", topicB);
+
+      // topicA must still be active
+      assert.equal(
+        server.getSubscriptions("partial-unsub").has(topicA),
+        true,
+        "retained topic must still be in subscriptions",
+      );
+      assert.equal(
+        server.getSubscriptions("partial-unsub").has(topicB),
+        false,
+        "removed topic must not be in subscriptions",
+      );
+
+      // Broadcast to topicA still reaches the client; topicB does not
+      recv.length = 0;
+      assert.equal(server.broadcast(topicA, { t: "A" }), 1);
+      assert.equal(server.broadcast(topicB, { t: "B" }), 0);
+
+      const events = recv.filter((m) => m.type === "event");
+      assert.equal(events.length, 1);
+      assert.equal((events[0].payload as any).t, "A");
+    },
+  );
+
+  await t.test(
+    "onUnsubscribed lifecycle hook fires after successful unsubscribe",
+    () => {
+      const fired: Array<{ id: string; topic: string }> = [];
+      const server = new RealtimeServer({
+        onUnsubscribed: (id, topic) => fired.push({ id, topic }),
+      });
+
+      registerMockConnection(server, "hook-unsub", []);
+      const topic = server.createTopic("activity", "hook-test");
+      server.subscribe("hook-unsub", topic);
+      server.unsubscribe("hook-unsub", topic);
+
+      assert.equal(fired.length, 1);
+      assert.equal(fired[0].id, "hook-unsub");
+      assert.equal(fired[0].topic, topic);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/src/modules/websocket/websocket.server.test.ts
+++ b/backend/src/modules/websocket/websocket.server.test.ts
@@ -219,6 +219,145 @@ test("WebSocket Server", async (t) => {
     assert.doesNotThrow(() => runtime.wsServer?.broadcastEvent(badEvent));
   });
 
+  // ---------------------------------------------------------------------------
+  // Unsubscribe cleanup verification (#1373)
+  // ---------------------------------------------------------------------------
+
+  await t.test("no events received after unsubscribe — subscription fully cleaned up", async () => {
+    const ws = new WebSocket(wsUrl);
+    await new Promise((resolve) => ws.on("open", resolve));
+
+    // Subscribe to a topic
+    ws.send(JSON.stringify({ type: "subscribe", topics: ["proposal_executed"] }));
+    await waitForMessage(ws, (m) => m.type === "subscribed");
+
+    // Now unsubscribe
+    ws.send(JSON.stringify({ type: "unsubscribe", topics: ["proposal_executed"] }));
+    const unsubMsg = await waitForMessage(ws, (m) => m.type === "unsubscribed");
+
+    // Confirm the topic is gone from remainingTopics
+    assert.ok(Array.isArray(unsubMsg.remainingTopics), "remainingTopics must be an array");
+    assert.equal(
+      unsubMsg.remainingTopics.includes("notification:events:PROPOSAL_EXECUTED"),
+      false,
+      "unsubscribed topic must not appear in remainingTopics",
+    );
+
+    // Broadcast the event — client should NOT receive it
+    const receivedEvents: any[] = [];
+    ws.on("message", (data: Buffer) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === "contract_event") receivedEvents.push(msg);
+    });
+
+    const event: ContractEvent = {
+      id: "after-unsub-1",
+      contractId: "CDTEST",
+      topic: ["proposal_executed"],
+      value: {},
+      ledger: 200,
+      ledgerClosedAt: new Date().toISOString(),
+    };
+
+    runtime.wsServer?.broadcastEvent(event);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    assert.equal(receivedEvents.length, 0, "no events should arrive after unsubscribe");
+    ws.close();
+  });
+
+  await t.test("unsubscribed envelope includes subscriber identity and removedTopics", async () => {
+    const ws = new WebSocket(wsUrl);
+    await new Promise((resolve) => ws.on("open", resolve));
+
+    ws.send(JSON.stringify({ type: "subscribe", topics: ["proposal_approved"] }));
+    await waitForMessage(ws, (m) => m.type === "subscribed");
+
+    ws.send(JSON.stringify({ type: "unsubscribe", topics: ["proposal_approved"] }));
+    const msg = await waitForMessage(ws, (m) => m.type === "unsubscribed");
+
+    assert.ok(typeof msg.subscriber === "string" && msg.subscriber.length > 0,
+      "envelope must include a non-empty subscriber field");
+    assert.ok(Array.isArray(msg.removedTopics), "envelope must include removedTopics array");
+    assert.ok(
+      msg.removedTopics.includes("notification:events:PROPOSAL_APPROVED"),
+      "removedTopics must list the normalized topic that was removed",
+    );
+
+    ws.close();
+  });
+
+  await t.test("unsubscribing a topic does not affect other active subscriptions", async () => {
+    const ws = new WebSocket(wsUrl);
+    await new Promise((resolve) => ws.on("open", resolve));
+
+    // Subscribe to two topics
+    ws.send(JSON.stringify({ type: "subscribe", topics: ["proposal_approved", "proposal_executed"] }));
+    await waitForMessage(ws, (m) => m.type === "subscribed");
+
+    // Unsubscribe from one
+    ws.send(JSON.stringify({ type: "unsubscribe", topics: ["proposal_executed"] }));
+    const unsubMsg = await waitForMessage(ws, (m) => m.type === "unsubscribed");
+
+    // The retained topic must still appear in remainingTopics
+    assert.ok(
+      unsubMsg.remainingTopics.includes("notification:events:PROPOSAL_APPROVED"),
+      "retained topic must remain in remainingTopics",
+    );
+    assert.equal(
+      unsubMsg.remainingTopics.includes("notification:events:PROPOSAL_EXECUTED"),
+      false,
+      "removed topic must not appear in remainingTopics",
+    );
+
+    // Broadcast to retained topic — must be delivered
+    const received: any[] = [];
+    ws.on("message", (data: Buffer) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === "contract_event") received.push(msg.payload);
+    });
+
+    runtime.wsServer?.broadcastEvent({
+      id: "retained-evt",
+      contractId: "CDTEST",
+      topic: ["proposal_approved"],
+      value: {},
+      ledger: 300,
+      ledgerClosedAt: new Date().toISOString(),
+    });
+
+    runtime.wsServer?.broadcastEvent({
+      id: "removed-evt",
+      contractId: "CDTEST",
+      topic: ["proposal_executed"],
+      value: {},
+      ledger: 301,
+      ledgerClosedAt: new Date().toISOString(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    assert.equal(received.length, 1, "only the retained topic event should arrive");
+    assert.equal(received[0].id, "retained-evt");
+
+    ws.close();
+  });
+
+  await t.test("unsubscribing a topic not subscribed to is a no-op", async () => {
+    const ws = new WebSocket(wsUrl);
+    await new Promise((resolve) => ws.on("open", resolve));
+
+    // Do NOT subscribe to anything first — then try unsubscribing
+    ws.send(JSON.stringify({ type: "unsubscribe", topics: ["proposal_created"] }));
+    const msg = await waitForMessage(ws, (m) => m.type === "unsubscribed");
+
+    // removedTopics should be empty since there was nothing to remove
+    assert.ok(Array.isArray(msg.removedTopics), "removedTopics must still be an array");
+    assert.equal(msg.removedTopics.length, 0, "removedTopics must be empty for a no-op unsubscribe");
+
+    ws.close();
+  });
+
   // Clean up server
   runtime.wsServer?.stop();
   await runtime.jobManager.stopAll();

--- a/backend/src/modules/websocket/websocket.server.ts
+++ b/backend/src/modules/websocket/websocket.server.ts
@@ -251,7 +251,7 @@ export class EventWebSocketServer {
   private handleUnsubscribe(
     ws: WebSocket,
     message: any,
-    _connectionId: string,
+    connectionId: string,
   ) {
     const topics: string[] | undefined = Array.isArray(message.topics)
       ? message.topics
@@ -264,21 +264,62 @@ export class EventWebSocketServer {
       return;
     }
 
+    // Track state before removal for cleanup verification
+    const before = new Set(sub.subscriptions);
+
+    const removedTopics: string[] = [];
+    const failedTopics: string[] = [];
+
     for (const t of topics) {
       let norm = t;
       if (!t.includes(":")) {
         norm = `notification:events:${t.toUpperCase()}`;
       }
+
+      if (!before.has(norm)) {
+        // Topic was not subscribed — nothing to remove
+        continue;
+      }
+
       sub.subscriptions.delete(norm);
+
+      // Verify cleanup: topic must no longer be present
+      if (sub.subscriptions.has(norm)) {
+        failedTopics.push(norm);
+        logger.warn("unsubscribe cleanup failed: topic still present after removal", {
+          connectionId,
+          topic: norm,
+        });
+      } else {
+        removedTopics.push(norm);
+      }
+    }
+
+    if (failedTopics.length > 0) {
+      logger.error("unsubscribe incomplete: some topics were not cleaned up", {
+        connectionId,
+        failedTopics,
+        remainingSubscriptions: Array.from(sub.subscriptions),
+      });
     }
 
     this.clients.set(ws, sub);
+
+    // Emit cleanup event with subscriber identity and affected topics
     ws.send(
       JSON.stringify({
         type: "unsubscribed",
-        topics: Array.from(sub.subscriptions),
+        subscriber: connectionId,
+        removedTopics,
+        remainingTopics: Array.from(sub.subscriptions),
       }),
     );
+
+    logger.info("client unsubscribed", {
+      connectionId,
+      removedTopics,
+      remainingSubscriptions: sub.subscriptions.size,
+    });
   }
 
   private findWs(connectionId: string): WebSocket | undefined {


### PR DESCRIPTION
- Track subscription state before and after unsubscribe in both EventWebSocketServer and RealtimeServer
- Emit 'unsubscribed' cleanup event with subscriber identity and affected topic(s) in both servers
- Log warn/error when cleanup fails or is a noop
- Add tests verifying no events are delivered after unsubscribe, unsubscribed envelope carries subscriber + topic, partial unsubscribe preserves other subscriptions, and noop unsubscribe is handled cleanly

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #1373 

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
