### PR TITLE
feat(backend): implement cursor-based pagination for list endpoints

### DIFF
--- a/backend/src/modules/audit/audit.controller.test.ts
+++ b/backend/src/modules/audit/audit.controller.test.ts
@@ -100,3 +100,135 @@ test("getAuditController: returns 502 when AuditRpcError is thrown", async () =>
   assert.strictEqual(body.success, false);
   assert.ok(body.error.message.includes("503"));
 });
+
+// ============================================================================
+// Cursor Pagination Tests – audit controller
+// ============================================================================
+
+import { encodeCursor } from "../../shared/http/validateQuery.js";
+
+function makeAuditPage(overrides?: Partial<import("./audit.types.js").AuditPage>) {
+  return {
+    data: [
+      {
+        id: "entry-1",
+        action: AuditAction.ProposalCreated,
+        actor: "GABC",
+        target: "proposal:1",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        prev_hash: "0",
+        hash: "aaa",
+        ledger: 42,
+      },
+    ],
+    total: 5,
+    offset: 0,
+    limit: 1,
+    nextCursor: null,
+    ...overrides,
+  };
+}
+
+test("getAuditController cursor mode: first page returns nextCursor when more items exist", async () => {
+  const nextCursor = encodeCursor({ lastId: "entry-1", offset: 1 });
+  const service = makeService({
+    getAuditTrail: async () => makeAuditPage({ total: 5, nextCursor }),
+  });
+  const handler = getAuditController(service);
+  const { res, state } = makeRes();
+
+  await handler(
+    { query: { contractId: "CABC", limit: "1" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  assert.strictEqual(state.statusCode, 200);
+  const body = state.body as any;
+  assert.strictEqual(body.success, true);
+  assert.ok(body.data.nextCursor, "nextCursor should be present on first page");
+  assert.strictEqual(typeof body.data.nextCursor, "string");
+});
+
+test("getAuditController cursor mode: last page returns nextCursor = null", async () => {
+  const service = makeService({
+    getAuditTrail: async () => makeAuditPage({ total: 1, nextCursor: null }),
+  });
+  const handler = getAuditController(service);
+  const { res, state } = makeRes();
+
+  await handler(
+    { query: { contractId: "CABC", limit: "10" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.strictEqual(state.statusCode, 200);
+  assert.strictEqual(body.data.nextCursor, null);
+});
+
+test("getAuditController cursor mode: passes cursor to service (cursor in query)", async () => {
+  const inputCursor = encodeCursor({ lastId: "entry-3", offset: 3 });
+  let capturedArgs: unknown[] = [];
+  const service = makeService({
+    getAuditTrail: async (...args: unknown[]) => {
+      capturedArgs = args;
+      return makeAuditPage({ offset: 3, nextCursor: null });
+    },
+  });
+  const handler = getAuditController(service);
+  const { res, state } = makeRes();
+
+  await handler(
+    { query: { contractId: "CABC", cursor: inputCursor } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  assert.strictEqual(state.statusCode, 200);
+  // 5th arg (index 4) should be the cursor string
+  assert.strictEqual(capturedArgs[4], inputCursor);
+});
+
+test("getAuditController cursor mode: invalid cursor is passed through (service handles fallback)", async () => {
+  let capturedCursor: unknown;
+  const service = makeService({
+    getAuditTrail: async (_contractId, _offset, _limit, _verify, cursor) => {
+      capturedCursor = cursor;
+      return makeAuditPage({ nextCursor: null });
+    },
+  });
+  const handler = getAuditController(service);
+  const { res, state } = makeRes();
+
+  await handler(
+    { query: { contractId: "CABC", cursor: "garbage-cursor" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  assert.strictEqual(state.statusCode, 200);
+  assert.strictEqual(capturedCursor, "garbage-cursor");
+});
+
+test("getAuditController offset mode: backward-compatible when offset param present", async () => {
+  let capturedOffset: number | undefined;
+  const service = makeService({
+    getAuditTrail: async (_contractId, offset) => {
+      capturedOffset = offset;
+      return makeAuditPage({ offset, nextCursor: null });
+    },
+  });
+  const handler = getAuditController(service);
+  const { res, state } = makeRes();
+
+  await handler(
+    { query: { contractId: "CABC", offset: "10", limit: "5" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  assert.strictEqual(state.statusCode, 200);
+  assert.strictEqual(capturedOffset, 10);
+});

--- a/backend/src/modules/audit/audit.controller.ts
+++ b/backend/src/modules/audit/audit.controller.ts
@@ -1,7 +1,10 @@
 import type { RequestHandler } from "express";
 import { success, error } from "../../shared/http/response.js";
 import { ErrorCode } from "../../shared/http/errorCodes.js";
-import { validatePagination } from "../../shared/http/validateQuery.js";
+import {
+  validatePagination,
+  validateCursorPagination,
+} from "../../shared/http/validateQuery.js";
 import type { AuditService } from "./audit.service.js";
 import { AuditRpcError, verifyAuditChain, streamAuditCsv } from "./audit.service.js";
 
@@ -34,11 +37,48 @@ export function getAuditController(service: AuditService): RequestHandler {
       return;
     }
 
-    const pagination = validatePagination(request, response);
-    if (!pagination) return;
-
     const verify =
       getSingleQueryString(request.query as Record<string, unknown>, "verify") === "true";
+
+    // Use cursor pagination when `cursor` param is present or `offset` is absent
+    const isCursorMode =
+      typeof request.query.cursor === "string" ||
+      request.query.offset === undefined;
+
+    if (isCursorMode) {
+      const cursorQuery = validateCursorPagination(request, response);
+      if (!cursorQuery) return;
+
+      try {
+        const page = await service.getAuditTrail(
+          contractId,
+          cursorQuery.cursor?.offset ?? 0,
+          cursorQuery.limit,
+          verify,
+          typeof request.query.cursor === "string" ? request.query.cursor : null,
+        );
+        success(response, page);
+      } catch (err) {
+        if (err instanceof AuditRpcError) {
+          error(response, {
+            message: err.message,
+            status: 502,
+            code: ErrorCode.INTERNAL_ERROR,
+          });
+          return;
+        }
+        error(response, {
+          message: "Failed to fetch audit trail",
+          status: 500,
+          code: ErrorCode.INTERNAL_ERROR,
+        });
+      }
+      return;
+    }
+
+    // Legacy offset pagination path
+    const pagination = validatePagination(request, response);
+    if (!pagination) return;
 
     try {
       const page = await service.getAuditTrail(

--- a/backend/src/modules/audit/audit.service.ts
+++ b/backend/src/modules/audit/audit.service.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Response as ExpressResponse } from "express";
+import { encodeCursor, decodeCursor } from "../../shared/http/validateQuery.js";
 import type {
   AuditEntry,
   AuditPage,
@@ -227,7 +228,18 @@ export class AuditService {
     offset: number,
     limit: number,
     verify = false,
+    cursor?: string | null,
   ): Promise<AuditPage> {
+    // If a cursor is provided, decode it and use its offset as the starting
+    // point. Invalid cursors silently fall back to the supplied offset.
+    let resolvedOffset = offset;
+    if (cursor) {
+      const decoded = decodeCursor(cursor);
+      if (decoded !== null) {
+        resolvedOffset = decoded.offset;
+      }
+    }
+
     let response: globalThis.Response;
     try {
       response = await this.fetchFn(this.rpcUrl, {
@@ -238,7 +250,7 @@ export class AuditService {
           id: 1,
           method: "simulateTransaction",
           params: {
-            transaction: this.buildInvocationXdr(contractId, offset, limit),
+            transaction: this.buildInvocationXdr(contractId, resolvedOffset, limit),
           },
         }),
       });
@@ -268,10 +280,19 @@ export class AuditService {
 
     const { entries, total } = json.result;
 
-    const page: AuditPage = { data: entries, total, offset, limit };
+    const page: AuditPage = { data: entries, total, offset: resolvedOffset, limit };
 
     if (verify) {
       page.verification = verifyAuditChain(entries);
+    }
+
+    // Build next_cursor when more pages remain
+    const nextOffset = resolvedOffset + entries.length;
+    if (entries.length > 0 && nextOffset < total) {
+      const lastEntry = entries[entries.length - 1]!;
+      page.nextCursor = encodeCursor({ lastId: lastEntry.id, offset: nextOffset });
+    } else {
+      page.nextCursor = null;
     }
 
     return page;

--- a/backend/src/modules/audit/audit.types.ts
+++ b/backend/src/modules/audit/audit.types.ts
@@ -51,6 +51,8 @@ export interface AuditPage {
   offset: number;
   limit: number;
   verification?: AuditVerificationResult;
+  /** Opaque base64 cursor pointing to the next page. Null when no further pages. */
+  nextCursor?: string | null;
 }
 
 export interface MerkleProof {

--- a/backend/src/modules/proposals/proposals.controller.test.ts
+++ b/backend/src/modules/proposals/proposals.controller.test.ts
@@ -175,3 +175,131 @@ test("getProposalActivityController returns full event history for a proposal", 
   assert.equal(body.data.total, 2);
   assert.equal(body.data.data.length, 2);
 });
+
+// ============================================================================
+// Cursor Pagination Tests – proposals
+// ============================================================================
+
+test("getAllProposalsController cursor mode: returns first page with nextCursor when records > limit", async () => {
+  const records = Array.from({ length: 5 }, (_, i) =>
+    makeRecord(i, "contract-1", `proposal-${i}`),
+  );
+  const persistence = createPersistence(records);
+  const handler = getAllProposalsController(persistence);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { contractId: "contract-1", limit: "2" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(state.statusCode, 200);
+  assert.equal(body.success, true);
+  assert.equal(body.data.data.length, 2);
+  assert.equal(body.data.total, 5);
+  assert.ok(body.data.nextCursor !== null, "nextCursor should be present");
+  assert.equal(typeof body.data.nextCursor, "string");
+  // No offset field in cursor mode
+  assert.equal(body.data.offset, undefined);
+});
+
+test("getAllProposalsController cursor mode: second page uses nextCursor and returns correct items", async () => {
+  const records = Array.from({ length: 5 }, (_, i) =>
+    makeRecord(i, "contract-1", `proposal-${i}`),
+  );
+  const persistence = createPersistence(records);
+  const handler = getAllProposalsController(persistence);
+
+  // First page
+  const { res: res1, state: state1 } = createMockResponse();
+  await handler(
+    { query: { contractId: "contract-1", limit: "2" } } as any,
+    res1 as any,
+    (() => {}) as any,
+  );
+  const body1 = (state1.body as any).data;
+  const cursor = body1.nextCursor as string;
+  assert.ok(cursor);
+
+  // Second page using cursor
+  const { res: res2, state: state2 } = createMockResponse();
+  await handler(
+    { query: { contractId: "contract-1", limit: "2", cursor } } as any,
+    res2 as any,
+    (() => {}) as any,
+  );
+  const body2 = (state2.body as any).data;
+  assert.equal(state2.statusCode, 200);
+  assert.equal(body2.data.length, 2);
+  // Items on the second page should be different from the first
+  const firstPageIds = body1.data.map((r: any) => r.activityId);
+  const secondPageIds = body2.data.map((r: any) => r.activityId);
+  assert.ok(
+    !firstPageIds.some((id: string) => secondPageIds.includes(id)),
+    "pages should not overlap",
+  );
+});
+
+test("getAllProposalsController cursor mode: last page returns nextCursor = null", async () => {
+  const records = Array.from({ length: 3 }, (_, i) =>
+    makeRecord(i, "contract-1", `proposal-${i}`),
+  );
+  const persistence = createPersistence(records);
+  const handler = getAllProposalsController(persistence);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { contractId: "contract-1", limit: "10" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(body.data.data.length, 3);
+  assert.equal(body.data.nextCursor, null);
+});
+
+test("getAllProposalsController cursor mode: invalid cursor falls back to offset 0", async () => {
+  const records = Array.from({ length: 3 }, (_, i) =>
+    makeRecord(i, "contract-1", `proposal-${i}`),
+  );
+  const persistence = createPersistence(records);
+  const handler = getAllProposalsController(persistence);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { contractId: "contract-1", limit: "2", cursor: "totally-invalid-cursor" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(state.statusCode, 200);
+  // Should return data from the start (offset 0 fallback)
+  assert.equal(body.data.data.length, 2);
+});
+
+test("getAllProposalsController offset mode: backward-compatible with offset+limit params", async () => {
+  const records = Array.from({ length: 10 }, (_, i) =>
+    makeRecord(i, "contract-1", `proposal-${i}`),
+  );
+  const persistence = createPersistence(records);
+  const handler = getAllProposalsController(persistence);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { contractId: "contract-1", offset: "5", limit: "3" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(state.statusCode, 200);
+  assert.equal(body.data.data.length, 3);
+  assert.equal(body.data.offset, 5);
+  assert.equal(body.data.total, 10);
+  // Offset mode should NOT have nextCursor
+  assert.equal(body.data.nextCursor, undefined);
+});

--- a/backend/src/modules/proposals/proposals.controller.ts
+++ b/backend/src/modules/proposals/proposals.controller.ts
@@ -4,9 +4,12 @@ import { ErrorCode } from "../../shared/http/errorCodes.js";
 import {
   validatePagination,
   validateRequiredString,
+  validateCursorPagination,
+  encodeCursor,
 } from "../../shared/http/validateQuery.js";
 import type { ProposalActivityAggregator } from "./aggregator.js";
 import type { ProposalActivityPersistence } from "./types.js";
+import type { ProposalActivityRecord } from "./types.js";
 import type { CacheAdapter } from "../../shared/cache/cache.adapter.js";
 
 /** TTL for proposal list cache: 30 seconds */
@@ -20,6 +23,74 @@ export function getAllProposalsController(
     const contractId = validateRequiredString(req, res, "contractId");
     if (!contractId) return;
 
+    // Support cursor-based pagination when `cursor` param is present (or `limit`
+    // alone is provided without `offset`), and fall back to offset pagination.
+    const isCursorMode =
+      typeof req.query.cursor === "string" || req.query.offset === undefined;
+
+    if (isCursorMode) {
+      const cursorQuery = validateCursorPagination(req, res);
+      if (!cursorQuery) return;
+
+      const cacheKey = `proposals:cursor:${contractId}:${req.query.cursor ?? ""}:${cursorQuery.limit}`;
+
+      try {
+        if (cache) {
+          const cached = cache.get(cacheKey);
+          if (cached !== null) {
+            res.json(cached);
+            return;
+          }
+        }
+
+        const all = await persistence.getByContractId(contractId);
+        const total = all.length;
+
+        let startIndex = 0;
+        if (cursorQuery.cursor) {
+          const { lastId, offset: fallbackOffset } = cursorQuery.cursor;
+          // Seek by lastId first; fall back to offset if not found
+          const foundIdx = all.findIndex(
+            (r: ProposalActivityRecord) => r.activityId === lastId,
+          );
+          startIndex = foundIdx !== -1 ? foundIdx + 1 : fallbackOffset;
+        }
+
+        const endIndex = Math.min(startIndex + cursorQuery.limit, total);
+        const data = all.slice(startIndex, endIndex);
+
+        // Build next_cursor if there are more items after this page
+        let nextCursor: string | null = null;
+        if (endIndex < total) {
+          const lastItem = data[data.length - 1];
+          if (lastItem) {
+            nextCursor = encodeCursor({ lastId: lastItem.activityId, offset: endIndex });
+          }
+        }
+
+        const payload = {
+          data,
+          total,
+          limit: cursorQuery.limit,
+          nextCursor,
+        };
+
+        if (cache) {
+          cache.set(cacheKey, { ok: true, data: payload }, PROPOSALS_CACHE_TTL_MS);
+        }
+
+        success(res, payload);
+      } catch (err) {
+        error(res, {
+          message: "Failed to fetch proposals",
+          status: 500,
+          code: ErrorCode.INTERNAL_ERROR,
+        });
+      }
+      return;
+    }
+
+    // Legacy offset pagination path (backward compatible)
     const pagination = validatePagination(req, res);
     if (!pagination) return;
 

--- a/backend/src/modules/recurring/recurring.controller.ts
+++ b/backend/src/modules/recurring/recurring.controller.ts
@@ -6,6 +6,8 @@ import {
   validatePagination,
   validateOptionalString,
   validateOptionalInteger,
+  validateCursorPagination,
+  encodeCursor,
 } from "../../shared/http/validateQuery.js";
 import type { RecurringIndexerService } from "./recurring.service.js";
 import { RecurringStatus } from "./types.js";
@@ -20,9 +22,6 @@ export function getAllRecurringController(
   cache?: CacheAdapter<unknown>,
 ): RequestHandler {
   return async (request, response) => {
-    const pagination = validatePagination(request, response);
-    if (!pagination) return;
-
     const status = validateEnum(
       request,
       response,
@@ -35,8 +34,83 @@ export function getAllRecurringController(
     const proposer = validateOptionalString(request, "proposer");
     const recipient = validateOptionalString(request, "recipient");
 
-    // Create cache key
-    const cacheKey = `recurring:${contractId || 'all'}:${status || 'all'}:${pagination.offset}:${pagination.limit}`;
+    // Cursor mode when `cursor` param is present or `offset` is absent
+    const isCursorMode =
+      typeof request.query.cursor === "string" ||
+      request.query.offset === undefined;
+
+    if (isCursorMode) {
+      const cursorQuery = validateCursorPagination(request, response);
+      if (!cursorQuery) return;
+
+      const cursorRaw =
+        typeof request.query.cursor === "string" ? request.query.cursor : null;
+      const cacheKey = `recurring:cursor:${contractId ?? "all"}:${status ?? "all"}:${cursorRaw ?? ""}:${cursorQuery.limit}`;
+
+      try {
+        if (cache) {
+          const cached = cache.get(cacheKey);
+          if (cached !== null) {
+            success(response, cached);
+            return;
+          }
+        }
+
+        // Fetch all filtered items — pass a high limit so we can cursor-slice ourselves.
+        // MAX_PAGINATION_LIMIT is for per-request pages; internally we want the full set.
+        const result = await service.getPayments(
+          { contractId, status: status as RecurringStatus | undefined, proposer, recipient },
+          { offset: 0, limit: Number.MAX_SAFE_INTEGER },
+        );
+        const all = result.items;
+        const total = result.total;
+
+        let startIndex = 0;
+        if (cursorQuery.cursor) {
+          const { lastId, offset: fallbackOffset } = cursorQuery.cursor;
+          const foundIdx = all.findIndex((p) => p.paymentId === lastId);
+          startIndex = foundIdx !== -1 ? foundIdx + 1 : fallbackOffset;
+        }
+
+        const endIndex = Math.min(startIndex + cursorQuery.limit, total);
+        const data = all.slice(startIndex, endIndex);
+
+        let nextCursor: string | null = null;
+        if (endIndex < total) {
+          const lastItem = data[data.length - 1];
+          if (lastItem) {
+            nextCursor = encodeCursor({ lastId: lastItem.paymentId, offset: endIndex });
+          }
+        }
+
+        const payload = {
+          data,
+          total,
+          limit: cursorQuery.limit,
+          nextCursor,
+        };
+
+        if (cache) {
+          cache.set(cacheKey, payload, 30_000);
+        }
+
+        success(response, payload);
+      } catch (err) {
+        error(response, {
+          message: "Failed to fetch recurring payments",
+          status: 500,
+          code: ErrorCode.INTERNAL_ERROR,
+          details: err instanceof Error ? err.message : undefined,
+        });
+      }
+      return;
+    }
+
+    // Legacy offset pagination path (backward compatible)
+    const pagination = validatePagination(request, response);
+    if (!pagination) return;
+
+    const cacheKey = `recurring:${contractId ?? "all"}:${status ?? "all"}:${pagination.offset}:${pagination.limit}`;
 
     try {
       if (cache) {
@@ -65,7 +139,7 @@ export function getAllRecurringController(
       };
 
       if (cache) {
-        cache.set(cacheKey, payload, 30_000); // 30 seconds TTL
+        cache.set(cacheKey, payload, 30_000);
       }
 
       success(response, payload);

--- a/backend/src/modules/recurring/recurring.cursor.test.ts
+++ b/backend/src/modules/recurring/recurring.cursor.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Cursor pagination tests for the recurring payments controller.
+ *
+ * Tests cover:
+ *  - First page returns nextCursor when items remain
+ *  - Second page fetched via nextCursor returns the correct slice
+ *  - Last page returns nextCursor = null
+ *  - Invalid cursor falls back to offset 0
+ *  - Backward-compatible offset mode still works
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getAllRecurringController } from "./recurring.controller.js";
+import {
+  MemoryRecurringStorageAdapter,
+  RecurringIndexerService,
+  transformRawRecurringPayment,
+} from "./recurring.service.js";
+import { createTestEnv } from "../../config/env.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePayment(id: string, contractId = "C1") {
+  return transformRawRecurringPayment(
+    {
+      id,
+      proposer: "alice",
+      recipient: "bob",
+      token: "XLM",
+      amount: "100",
+      memo: "",
+      interval: "1000",
+      next_payment_ledger: "9999",
+      payment_count: "0",
+      is_active: true,
+    },
+    contractId,
+    100,
+  );
+}
+
+function createServiceWithPayments(
+  ids: string[],
+  contractId = "C1",
+): RecurringIndexerService {
+  const storage = new MemoryRecurringStorageAdapter();
+  const env = createTestEnv();
+  const service = new RecurringIndexerService(env, storage);
+  // Pre-populate the storage
+  for (const id of ids) {
+    storage.save(makePayment(id, contractId));
+  }
+  return service;
+}
+
+function createMockResponse() {
+  const state: { statusCode: number; body: unknown; headers: Record<string, string> } = {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+  };
+  const res = {
+    status(code: number) {
+      state.statusCode = code;
+      return this;
+    },
+    set(key: string, value: string) {
+      state.headers[key] = value;
+      return this;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return this;
+    },
+  };
+  return { res, state };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("getAllRecurringController cursor mode: first page returns nextCursor when records > limit", async () => {
+  const service = createServiceWithPayments(["p1", "p2", "p3", "p4", "p5"]);
+  const handler = getAllRecurringController(service);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { limit: "2" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(state.statusCode, 200);
+  assert.equal(body.success, true);
+  assert.equal(body.data.data.length, 2);
+  assert.equal(body.data.total, 5);
+  assert.ok(body.data.nextCursor !== null, "nextCursor should be present");
+  assert.equal(typeof body.data.nextCursor, "string");
+  // Cursor mode: no `offset` field
+  assert.equal(body.data.offset, undefined);
+});
+
+test("getAllRecurringController cursor mode: second page uses nextCursor and contains next items", async () => {
+  const service = createServiceWithPayments(["p1", "p2", "p3", "p4", "p5"]);
+  const handler = getAllRecurringController(service);
+
+  // First page
+  const { res: res1, state: state1 } = createMockResponse();
+  await handler(
+    { query: { limit: "2" } } as any,
+    res1 as any,
+    (() => {}) as any,
+  );
+  const page1 = (state1.body as any).data;
+  const cursor = page1.nextCursor as string;
+  assert.ok(cursor, "first page should have a cursor");
+
+  // Second page
+  const { res: res2, state: state2 } = createMockResponse();
+  await handler(
+    { query: { limit: "2", cursor } } as any,
+    res2 as any,
+    (() => {}) as any,
+  );
+  const page2 = (state2.body as any).data;
+  assert.equal(state2.statusCode, 200);
+  assert.equal(page2.data.length, 2);
+
+  // No overlap between pages
+  const ids1 = page1.data.map((p: any) => p.paymentId);
+  const ids2 = page2.data.map((p: any) => p.paymentId);
+  assert.ok(
+    !ids1.some((id: string) => ids2.includes(id)),
+    "pages must not overlap",
+  );
+});
+
+test("getAllRecurringController cursor mode: last page returns nextCursor = null", async () => {
+  const service = createServiceWithPayments(["p1", "p2", "p3"]);
+  const handler = getAllRecurringController(service);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { limit: "10" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(body.data.data.length, 3);
+  assert.equal(body.data.nextCursor, null);
+});
+
+test("getAllRecurringController cursor mode: invalid cursor falls back to offset 0", async () => {
+  const service = createServiceWithPayments(["p1", "p2", "p3"]);
+  const handler = getAllRecurringController(service);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { limit: "2", cursor: "not-a-real-cursor" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(state.statusCode, 200);
+  // Should have returned items starting from index 0
+  assert.equal(body.data.data.length, 2);
+});
+
+test("getAllRecurringController offset mode: backward-compatible with offset+limit", async () => {
+  const service = createServiceWithPayments(["p1", "p2", "p3", "p4", "p5"]);
+  const handler = getAllRecurringController(service);
+  const { res, state } = createMockResponse();
+
+  await handler(
+    { query: { offset: "2", limit: "2" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  const body = state.body as any;
+  assert.equal(state.statusCode, 200);
+  assert.equal(body.data.data.length, 2);
+  assert.equal(body.data.offset, 2);
+  assert.equal(body.data.total, 5);
+  // Offset mode: no nextCursor
+  assert.equal(body.data.nextCursor, undefined);
+});

--- a/backend/src/shared/http/validateQuery.test.ts
+++ b/backend/src/shared/http/validateQuery.test.ts
@@ -357,3 +357,139 @@ test("validateLedgerRange rejects negative to", () => {
   assert.equal(v, null);
   assert.equal(getStatus(), 400);
 });
+
+// ============================================================================
+// Cursor Pagination Tests
+// ============================================================================
+
+import {
+  encodeCursor,
+  decodeCursor,
+  parseCursorPagination,
+  validateCursorPagination,
+  type CursorPayload,
+} from "./validateQuery.js";
+
+test("encodeCursor / decodeCursor round-trips correctly", () => {
+  const payload: CursorPayload = { lastId: "activity-42", offset: 20 };
+  const encoded = encodeCursor(payload);
+  assert.ok(typeof encoded === "string" && encoded.length > 0, "should produce a non-empty string");
+  const decoded = decodeCursor(encoded);
+  assert.deepEqual(decoded, payload);
+});
+
+test("decodeCursor returns null for undefined input", () => {
+  assert.equal(decodeCursor(undefined), null);
+});
+
+test("decodeCursor returns null for empty string", () => {
+  assert.equal(decodeCursor(""), null);
+});
+
+test("decodeCursor returns null for whitespace-only string", () => {
+  assert.equal(decodeCursor("   "), null);
+});
+
+test("decodeCursor returns null for invalid base64", () => {
+  assert.equal(decodeCursor("!!!notbase64!!!"), null);
+});
+
+test("decodeCursor returns null for valid base64 that isn't a cursor object", () => {
+  const bogus = Buffer.from(JSON.stringify({ foo: "bar" })).toString("base64");
+  assert.equal(decodeCursor(bogus), null);
+});
+
+test("decodeCursor returns null when offset is not a number", () => {
+  const bogus = Buffer.from(JSON.stringify({ lastId: "x", offset: "nope" })).toString("base64");
+  assert.equal(decodeCursor(bogus), null);
+});
+
+test("decodeCursor returns null when offset is negative", () => {
+  const bogus = Buffer.from(JSON.stringify({ lastId: "x", offset: -1 })).toString("base64");
+  assert.equal(decodeCursor(bogus), null);
+});
+
+test("parseCursorPagination returns null cursor and default limit when no params", () => {
+  const r = parseCursorPagination({});
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.value.cursor, null);
+    assert.equal(r.value.limit, DEFAULT_PAGINATION_LIMIT);
+  }
+});
+
+test("parseCursorPagination parses a valid cursor param", () => {
+  const payload: CursorPayload = { lastId: "entry-5", offset: 10 };
+  const encoded = encodeCursor(payload);
+  const r = parseCursorPagination({ cursor: encoded });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.deepEqual(r.value.cursor, payload);
+    assert.equal(r.value.limit, DEFAULT_PAGINATION_LIMIT);
+  }
+});
+
+test("parseCursorPagination treats invalid cursor as null (graceful fallback)", () => {
+  const r = parseCursorPagination({ cursor: "this-is-garbage" });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.value.cursor, null);
+  }
+});
+
+test("parseCursorPagination caps limit at MAX_PAGINATION_LIMIT", () => {
+  const r = parseCursorPagination({ limit: "999" });
+  assert.equal(r.ok, true);
+  if (r.ok) {
+    assert.equal(r.value.limit, MAX_PAGINATION_LIMIT);
+  }
+});
+
+test("parseCursorPagination rejects non-integer limit", () => {
+  const r = parseCursorPagination({ limit: "abc" });
+  assert.equal(r.ok, false);
+});
+
+test("parseCursorPagination rejects limit < 1", () => {
+  const r = parseCursorPagination({ limit: "0" });
+  assert.equal(r.ok, false);
+});
+
+test("validateCursorPagination sends 400 on invalid limit", () => {
+  const { res, getStatus, getBody } = mockResponse();
+  const req = { query: { limit: "bad" } } as unknown as Request;
+  const out = validateCursorPagination(req, res);
+  assert.equal(out, null);
+  assert.equal(getStatus(), 400);
+  const body = getBody() as { success: boolean; error: { message: string; code: string } };
+  assert.equal(body.success, false);
+  assert.match(body.error.message, /limit/i);
+  assert.equal(body.error.code, ErrorCode.BAD_REQUEST);
+});
+
+test("validateCursorPagination returns cursor null and default limit for empty query", () => {
+  const { res } = mockResponse();
+  const req = { query: {} } as unknown as Request;
+  const out = validateCursorPagination(req, res);
+  assert.ok(out !== null);
+  assert.equal(out!.cursor, null);
+  assert.equal(out!.limit, DEFAULT_PAGINATION_LIMIT);
+});
+
+test("encodeCursor produces URL-safe base64 (no +, /, =)", () => {
+  // Test with a payload that would normally trigger + or / in standard base64
+  for (let i = 0; i < 50; i++) {
+    const encoded = encodeCursor({ lastId: `id-${i}-some-longer-string`, offset: i * 17 });
+    assert.ok(!/[+/=]/.test(encoded), `cursor should be URL-safe, got: ${encoded}`);
+  }
+});
+
+test("cursor pagination across page boundaries: second page uses nextCursor from first", () => {
+  // Encode a cursor that points to after item at index 2
+  const firstPageCursor: CursorPayload = { lastId: "item-2", offset: 3 };
+  const encoded = encodeCursor(firstPageCursor);
+  const decoded = decodeCursor(encoded);
+  assert.deepEqual(decoded, firstPageCursor);
+  // Simulated second page: startIndex should be 3 (offset from cursor)
+  assert.equal(decoded!.offset, 3);
+});

--- a/backend/src/shared/http/validateQuery.ts
+++ b/backend/src/shared/http/validateQuery.ts
@@ -14,6 +14,122 @@ export interface PaginationQuery {
   limit: number;
 }
 
+// ============================================================================
+// Cursor Pagination
+// ============================================================================
+
+/**
+ * The decoded payload stored inside a base64 cursor token.
+ * `lastId`  – opaque string ID of the last item on the previous page.
+ * `offset`  – the absolute offset that produced `lastId` (used as fallback
+ *             when the ID can no longer be found in the dataset).
+ */
+export interface CursorPayload {
+  lastId: string;
+  offset: number;
+}
+
+/**
+ * Parsed result of a cursor-paginated request.
+ * When `cursor` is present the caller should seek by `lastId` first;
+ * `offset` is the fallback when the ID lookup fails.
+ */
+export interface CursorPaginationQuery {
+  cursor: CursorPayload | null;
+  limit: number;
+}
+
+/**
+ * Encodes a {@link CursorPayload} to a URL-safe base64 string.
+ */
+export function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+/**
+ * Decodes a base64 cursor string.
+ * Returns `null` when the token is missing, empty, or malformed – callers
+ * should fall back to offset-0 pagination in that case.
+ */
+export function decodeCursor(raw: string | undefined): CursorPayload | null {
+  if (!raw || raw.trim() === "") return null;
+  try {
+    // Accept both base64url and standard base64
+    const json = Buffer.from(raw, "base64").toString("utf8");
+    const parsed = JSON.parse(json) as unknown;
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "lastId" in parsed &&
+      "offset" in parsed &&
+      typeof (parsed as CursorPayload).lastId === "string" &&
+      typeof (parsed as CursorPayload).offset === "number" &&
+      Number.isFinite((parsed as CursorPayload).offset) &&
+      (parsed as CursorPayload).offset >= 0
+    ) {
+      return parsed as CursorPayload;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parses `cursor` and `limit` from `req.query`.
+ * - `cursor` is optional; invalid cursors are silently treated as absent
+ *   (graceful degradation to offset-0).
+ * - `limit` follows the same rules as {@link parsePaginationParams}.
+ */
+export function parseCursorPagination(
+  query: Request["query"],
+): { ok: true; value: CursorPaginationQuery } | { ok: false; message: string } {
+  const limitRaw = getFirstQueryString(query, "limit");
+  const cursorRaw = getFirstQueryString(query, "cursor");
+
+  let limit: number;
+  if (limitRaw === undefined || limitRaw === "") {
+    limit = DEFAULT_PAGINATION_LIMIT;
+  } else {
+    const n = Number(limitRaw);
+    if (!Number.isFinite(n) || !Number.isInteger(n)) {
+      return {
+        ok: false,
+        message: `Invalid limit: expected a positive integer, received "${limitRaw}"`,
+      };
+    }
+    if (n < 1) {
+      return {
+        ok: false,
+        message: "Invalid limit: must be at least 1",
+      };
+    }
+    limit = Math.min(n, MAX_PAGINATION_LIMIT);
+  }
+
+  // Invalid cursors degrade gracefully to null (offset 0)
+  const cursor = decodeCursor(cursorRaw);
+
+  return { ok: true, value: { cursor, limit } };
+}
+
+/**
+ * Validates cursor pagination query params and responds with **400** on failure.
+ * An invalid or missing cursor is NOT an error – it returns `cursor: null`.
+ * @returns `{ cursor, limit }` or `null` if a 400 was already sent.
+ */
+export function validateCursorPagination(
+  req: Request,
+  res: Response,
+): CursorPaginationQuery | null {
+  const parsed = parseCursorPagination(req.query);
+  if (!parsed.ok) {
+    error(res, { message: parsed.message, status: 400, code: ErrorCode.BAD_REQUEST });
+    return null;
+  }
+  return parsed.value;
+}
+
 function getFirstQueryString(
   query: Request["query"],
   key: string


### PR DESCRIPTION
## Summary

Implements cursor-based pagination for the backend list endpoints as described in #1384. The cursor is a base64url-encoded JSON token containing the last item's ID and an offset fallback.

## Changes

**New utilities** (`shared/http/validateQuery.ts`)
- `encodeCursor` / `decodeCursor` — base64url JSON `{ lastId, offset }`; invalid cursors return `null` gracefully
- `parseCursorPagination` / `validateCursorPagination` — parse `cursor` + `limit` from query params

**Updated endpoints** (all backward-compatible)
- `GET /api/v1/proposals` — cursor mode when `cursor` param present or `offset` absent
- `GET /api/v1/audit` — same; `AuditPage` now includes `nextCursor`
- `GET /api/v1/recurring` — same

All endpoints return `nextCursor: string | null` in the response. When `offset` is passed explicitly, the legacy offset/limit path is used unchanged.

**Fallback behaviour**: an invalid or missing cursor silently degrades to offset 0, so existing clients are unaffected.

## Tests

33 new tests across 4 files:
- `validateQuery.test.ts` — encode/decode round-trips, edge cases, URL-safety, cross-boundary
- `proposals.controller.test.ts` — first page, second page via cursor, last page, invalid cursor fallback, offset compat
- `audit.controller.test.ts` — same coverage
- `recurring.cursor.test.ts` — same coverage

```
tests 708 | pass 707 | fail 0 | skipped 1
```

Closes #1384