### PR TITLE
feat(backend): implement graceful shutdown with active request draining

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -38,6 +38,7 @@ import { createErrorMiddleware } from "./shared/errors/handleError.js";
 import { CorsAllowlist } from "./shared/http/corsAllowlist.js";
 import { initFeatureFlags, getFeatureFlags } from "./shared/feature-flags.js";
 import { initRpcPool } from "./shared/rpc-pool.js";
+import { createDrainMiddleware } from "./shared/http/drain.js";
 
 export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
   const app = express();
@@ -58,6 +59,13 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
 
   // Remove X-Powered-By header
   app.disable("x-powered-by");
+
+  // ── Drain middleware (must be first) ────────────────────────────────────────
+  // Increments the in-flight counter for every request and returns 503 once
+  // the server has begun shutting down, allowing active requests to complete.
+  if (runtime.lifecycleManager) {
+    app.use(createDrainMiddleware(runtime.lifecycleManager));
+  }
 
   // Security headers middleware
   app.use((_req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/app/lifecycle/lifecycle-manager.test.ts
+++ b/backend/src/app/lifecycle/lifecycle-manager.test.ts
@@ -243,3 +243,115 @@ test("LifecycleManager: second initialize() call does not duplicate signal handl
     "SIGINT listener count must not increase on second initialize()",
   );
 });
+
+// ============================================================================
+// In-flight request counter tests
+// ============================================================================
+
+test("LifecycleManager: incrementInFlight / decrementInFlight update counter", () => {
+  const manager = new LifecycleManager(null, 30_000);
+
+  assert.equal(manager.getInFlightCount(), 0, "starts at 0");
+
+  manager.incrementInFlight();
+  manager.incrementInFlight();
+  manager.incrementInFlight();
+  assert.equal(manager.getInFlightCount(), 3);
+
+  manager.decrementInFlight();
+  assert.equal(manager.getInFlightCount(), 2);
+
+  manager.decrementInFlight();
+  manager.decrementInFlight();
+  assert.equal(manager.getInFlightCount(), 0, "back to 0 after all decrements");
+});
+
+test("LifecycleManager: decrementInFlight does not go below 0", () => {
+  const manager = new LifecycleManager(null, 30_000);
+
+  manager.decrementInFlight();
+  manager.decrementInFlight();
+
+  assert.equal(manager.getInFlightCount(), 0, "must clamp at 0, never negative");
+});
+
+test("LifecycleManager: isShuttingDown returns false before shutdown", () => {
+  const manager = new LifecycleManager(null, 30_000);
+  assert.equal(manager.isShuttingDown(), false);
+});
+
+test("LifecycleManager: isShuttingDown returns true once shutdown() is called", async () => {
+  const originalExit = process.exit;
+  process.exit = (() => {}) as typeof process.exit;
+
+  try {
+    const manager = new LifecycleManager(null, 30_000);
+    assert.equal(manager.isShuttingDown(), false);
+
+    // Fire shutdown — don't await, just let it proceed in background
+    manager.shutdown().catch(() => {});
+    // Yield one microtask tick so the synchronous part of shutdown() runs
+    await Promise.resolve();
+
+    assert.equal(manager.isShuttingDown(), true, "must be true immediately after shutdown() starts");
+
+    // Let remaining timers clear
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  } finally {
+    process.exit = originalExit;
+  }
+});
+
+test("LifecycleManager: waitForInFlightRequests resolves when counter reaches 0", async () => {
+  const originalExit = process.exit;
+  process.exit = (() => {}) as typeof process.exit;
+
+  try {
+    const manager = new LifecycleManager(null, 5_000);
+
+    // Simulate two in-flight requests
+    manager.incrementInFlight();
+    manager.incrementInFlight();
+
+    // Start shutdown in the background — it will wait for in-flight to drain
+    let shutdownResolved = false;
+    manager.shutdown().then(() => {
+      shutdownResolved = true;
+    }).catch(() => {});
+
+    // Give shutdown a moment to enter the wait loop
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    // Requests haven't finished yet
+    assert.equal(shutdownResolved, false, "shutdown must not complete while requests are in-flight");
+
+    // First request finishes
+    manager.decrementInFlight();
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    assert.equal(shutdownResolved, false, "still one request in-flight");
+
+    // Last request finishes — shutdown should now complete
+    manager.decrementInFlight();
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
+    assert.equal(shutdownResolved, true, "shutdown must complete once all requests drain");
+  } finally {
+    process.exit = originalExit;
+  }
+});
+
+test("LifecycleManager: shutdown does not wait when no requests are in-flight", async () => {
+  const originalExit = process.exit;
+  process.exit = (() => {}) as typeof process.exit;
+
+  try {
+    const manager = new LifecycleManager(null, 5_000);
+
+    const start = Date.now();
+    await manager.shutdown();
+    const elapsed = Date.now() - start;
+
+    assert.ok(elapsed < 500, `shutdown with no in-flight requests took ${elapsed}ms, expected < 500ms`);
+  } finally {
+    process.exit = originalExit;
+  }
+});

--- a/backend/src/shared/http/drain.test.ts
+++ b/backend/src/shared/http/drain.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the request-draining middleware (createDrainMiddleware).
+ *
+ * All tests use a minimal in-process mock — no real HTTP server is started.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { EventEmitter } from "node:events";
+import { createDrainMiddleware, type DrainController } from "./drain.js";
+import type { Request, Response, NextFunction } from "express";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a controllable DrainController stub.
+ */
+function makeController(shuttingDown = false): DrainController & {
+  count: number;
+  setShuttingDown(v: boolean): void;
+} {
+  const ctrl = {
+    count: 0,
+    _shuttingDown: shuttingDown,
+    isShuttingDown() {
+      return this._shuttingDown;
+    },
+    incrementInFlight() {
+      this.count++;
+    },
+    decrementInFlight() {
+      this.count = Math.max(0, this.count - 1);
+    },
+    setShuttingDown(v: boolean) {
+      this._shuttingDown = v;
+    },
+  };
+  return ctrl;
+}
+
+/**
+ * Creates a minimal mock Express Response that emits 'finish' / 'close'
+ * events like a real response, and records status + JSON body.
+ */
+function makeRes(): {
+  res: Response;
+  emitFinish(): void;
+  emitClose(): void;
+  getStatus(): number;
+  getBody(): unknown;
+  getHeader(name: string): string | undefined;
+} {
+  const emitter = new EventEmitter();
+  const state: { status: number; body: unknown; headers: Record<string, string> } = {
+    status: 200,
+    body: undefined,
+    headers: {},
+  };
+
+  const res = Object.assign(emitter, {
+    status(code: number) {
+      state.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return this;
+    },
+    set(key: string, value: string) {
+      state.headers[key.toLowerCase()] = value;
+      return this;
+    },
+    // expose recorded state
+    __state: state,
+  }) as unknown as Response;
+
+  return {
+    res,
+    emitFinish: () => emitter.emit("finish"),
+    emitClose: () => emitter.emit("close"),
+    getStatus: () => state.status,
+    getBody: () => state.body,
+    getHeader: (name: string) => state.headers[name.toLowerCase()],
+  };
+}
+
+const dummyReq = {} as Request;
+
+// ---------------------------------------------------------------------------
+// Tests: Normal (non-shutdown) path
+// ---------------------------------------------------------------------------
+
+test("drainMiddleware: passes request to next() when not shutting down", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+  const { res } = makeRes();
+
+  let nextCalled = false;
+  const next: NextFunction = () => {
+    nextCalled = true;
+  };
+
+  middleware(dummyReq, res, next);
+
+  assert.ok(nextCalled, "next() must be called when not shutting down");
+});
+
+test("drainMiddleware: increments in-flight counter on entry", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+  const { res } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+
+  assert.equal(controller.count, 1, "counter should be 1 after one request enters");
+});
+
+test("drainMiddleware: decrements in-flight counter when response finishes", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+  const { res, emitFinish } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+  assert.equal(controller.count, 1);
+
+  emitFinish();
+  assert.equal(controller.count, 0, "counter should be 0 after response finishes");
+});
+
+test("drainMiddleware: decrements in-flight counter when connection closes before finish", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+  const { res, emitClose } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+  assert.equal(controller.count, 1);
+
+  emitClose();
+  assert.equal(controller.count, 0, "counter should be 0 after close without finish");
+});
+
+test("drainMiddleware: does NOT double-decrement when both finish and close fire", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+  const { res, emitFinish, emitClose } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+  assert.equal(controller.count, 1);
+
+  emitFinish(); // first decrement
+  emitClose();  // should be a no-op (already decremented)
+  assert.equal(controller.count, 0, "counter must not go below 0");
+});
+
+test("drainMiddleware: counter tracks multiple concurrent requests correctly", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+
+  const mock1 = makeRes();
+  const mock2 = makeRes();
+  const mock3 = makeRes();
+
+  middleware(dummyReq, mock1.res, () => {});
+  middleware(dummyReq, mock2.res, () => {});
+  middleware(dummyReq, mock3.res, () => {});
+  assert.equal(controller.count, 3, "three concurrent requests");
+
+  mock2.emitFinish();
+  assert.equal(controller.count, 2);
+
+  mock1.emitFinish();
+  assert.equal(controller.count, 1);
+
+  mock3.emitFinish();
+  assert.equal(controller.count, 0);
+});
+
+test("drainMiddleware: sets Connection: close header on normal requests", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+  const { res, getHeader } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+
+  assert.equal(
+    getHeader("connection"),
+    "close",
+    "Connection: close must be set so load-balancers drain the instance",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Shutdown (draining) path
+// ---------------------------------------------------------------------------
+
+test("drainMiddleware: returns 503 when server is shutting down", () => {
+  const controller = makeController(true); // already shutting down
+  const middleware = createDrainMiddleware(controller);
+  const { res, getStatus } = makeRes();
+
+  let nextCalled = false;
+  middleware(dummyReq, res, () => {
+    nextCalled = true;
+  });
+
+  assert.equal(getStatus(), 503, "status must be 503 during shutdown");
+  assert.ok(!nextCalled, "next() must NOT be called during shutdown");
+});
+
+test("drainMiddleware: 503 response body has correct shape", () => {
+  const controller = makeController(true);
+  const middleware = createDrainMiddleware(controller);
+  const { res, getBody } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+
+  const body = getBody() as any;
+  assert.equal(body.success, false);
+  assert.ok(body.error?.message, "error.message must be present");
+  assert.ok(body.error?.code, "error.code must be present");
+});
+
+test("drainMiddleware: 503 response sets Connection: close", () => {
+  const controller = makeController(true);
+  const middleware = createDrainMiddleware(controller);
+  const { res, getHeader } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+
+  assert.equal(
+    getHeader("connection"),
+    "close",
+    "Connection: close must be set on 503 responses",
+  );
+});
+
+test("drainMiddleware: does NOT increment counter when returning 503", () => {
+  const controller = makeController(true);
+  const middleware = createDrainMiddleware(controller);
+  const { res } = makeRes();
+
+  middleware(dummyReq, res, () => {});
+
+  assert.equal(controller.count, 0, "counter must not increment for rejected requests");
+});
+
+test("drainMiddleware: transitions from accepting to rejecting when shutdown begins mid-stream", () => {
+  const controller = makeController(false);
+  const middleware = createDrainMiddleware(controller);
+
+  // First request arrives before shutdown
+  const mock1 = makeRes();
+  middleware(dummyReq, mock1.res, () => {});
+  assert.equal(controller.count, 1, "first request should be counted");
+
+  // Shutdown begins
+  controller.setShuttingDown(true);
+
+  // Second request arrives after shutdown signal
+  const mock2 = makeRes();
+  let next2Called = false;
+  middleware(dummyReq, mock2.res, () => {
+    next2Called = true;
+  });
+
+  assert.equal(mock2.getStatus(), 503, "second request must be rejected with 503");
+  assert.ok(!next2Called, "next() must not fire for post-shutdown request");
+  assert.equal(controller.count, 1, "only the first request should remain in-flight");
+
+  // First request finishes — counter drains to zero
+  mock1.emitFinish();
+  assert.equal(controller.count, 0, "counter must reach 0 after in-flight request finishes");
+});

--- a/backend/src/shared/http/drain.ts
+++ b/backend/src/shared/http/drain.ts
@@ -1,0 +1,88 @@
+/**
+ * Request-draining middleware for graceful shutdown.
+ *
+ * Behaviour:
+ *  - Every request that passes through increments the in-flight counter on
+ *    the LifecycleManager and decrements it when the response finishes.
+ *  - Once shutdown has been signalled (`isShuttingDown() === true`) all new
+ *    requests receive 503 Service Unavailable immediately so the server can
+ *    drain cleanly.
+ *  - The `Connection: close` header is set on 503 responses and on every
+ *    response during the drain window so load-balancers remove the instance
+ *    from rotation as quickly as possible.
+ */
+
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+
+/**
+ * Minimal interface required from the lifecycle manager so the middleware
+ * can be unit-tested without importing the full LifecycleManager class.
+ */
+export interface DrainController {
+  isShuttingDown(): boolean;
+  incrementInFlight(): void;
+  decrementInFlight(): void;
+}
+
+/**
+ * Creates a request-draining Express middleware bound to the supplied
+ * {@link DrainController}.
+ *
+ * Wire this as the **first** middleware in `createApp` so that every
+ * request is accounted for before any other processing happens.
+ *
+ * @example
+ * ```ts
+ * app.use(createDrainMiddleware(runtime.lifecycleManager));
+ * ```
+ */
+export function createDrainMiddleware(
+  controller: DrainController,
+): RequestHandler {
+  return function drainMiddleware(
+    _req: Request,
+    res: Response,
+    next: NextFunction,
+  ): void {
+    // While draining, reject all new requests immediately with 503.
+    if (controller.isShuttingDown()) {
+      res.set("Connection", "close");
+      res.status(503).json({
+        success: false,
+        error: {
+          message: "Service Unavailable: server is shutting down",
+          code: "SERVICE_UNAVAILABLE",
+        },
+      });
+      return;
+    }
+
+    // Count this request as in-flight.
+    controller.incrementInFlight();
+
+    // Set Connection: close so the client doesn't try to reuse the connection
+    // once the server starts draining.
+    res.set("Connection", "close");
+
+    // Decrement when the response is fully sent.
+    res.on("finish", () => {
+      controller.decrementInFlight();
+    });
+
+    // Also decrement if the connection is closed/aborted before finish fires.
+    res.on("close", () => {
+      // `close` fires after `finish` too, so guard with the flag set below.
+      if (!(res as any).__drainDecremented) {
+        (res as any).__drainDecremented = true;
+        controller.decrementInFlight();
+      }
+    });
+
+    // Mark as decremented once finish fires so the close guard above is a no-op.
+    res.on("finish", () => {
+      (res as any).__drainDecremented = true;
+    });
+
+    next();
+  };
+}


### PR DESCRIPTION
## Summary

Implements graceful shutdown request draining as described in #1385. New requests receive **503** once shutdown begins; in-flight requests run to completion before shutdown hooks execute.

## Changes

**`shared/http/drain.ts`** — new file
- `DrainController` interface (decoupled from `LifecycleManager` for testability)
- `createDrainMiddleware(controller)` — Express middleware that:
  - Calls `incrementInFlight()` on entry, `decrementInFlight()` on `finish`/`close`
  - Double-decrement guard: the `close` handler is a no-op if `finish` already fired
  - Sets `Connection: close` on every response so load-balancers drain the instance
  - Returns `503 Service Unavailable` (without touching the counter) once `isShuttingDown()` is true

**`app.ts`**
- Wires `createDrainMiddleware(runtime.lifecycleManager)` as the **first** middleware (null-guarded for the pre-lifecycle window)

**`LifecycleManager`** (no logic changes)
- `incrementInFlight` / `decrementInFlight` / `getInFlightCount` / `isShuttingDown` were already present
- `shutdown()` already calls `waitForInFlightRequests()` before running hooks — everything works end-to-end with no service changes needed

## Shutdown sequence
```
SIGTERM / SIGINT
  → isShuttingDown = true
  → server.close()          (stop accepting new TCP connections)
  → new requests → 503
  → waitForInFlightRequests() polls until counter = 0 (or timeout)
  → executeShutdownHooks()  (jobs, queues, etc.) — LIFO order
  → process.exit(0)
```

## Tests — 18 new tests

`drain.test.ts` (13 tests):
- next() called / not called depending on shutdown state
- Counter increments on entry, decrements on finish and close
- Double-decrement guard (finish + close both fire)
- Concurrent request counter tracking
- `Connection: close` header set in both normal and shutdown paths
- 503 status and response body shape during drain
- Counter not incremented for rejected requests
- Mid-stream transition: request accepted before shutdown, next rejected with 503

`lifecycle-manager.test.ts` (6 new tests):
- increment/decrement arithmetic
- Clamp at 0 (never negative)
- `isShuttingDown()` false before, true after `shutdown()` starts
- `waitForInFlightRequests()` blocks until counter drains to 0
- Immediate completion when no requests are in-flight

```
tests 726 | pass 725 | fail 0 | skipped 1
```

Closes #1385