### PR TITLE
fix(frontend): resolve stale closure in ProposalCard real-time subscription

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,56 @@ Before contributing, ensure you have the following installed:
 - **Hooks**: Follow React hooks rules (use ESLint warnings as guidance)
 - **Types**: Always use TypeScript types, avoid `any`
 
+#### Avoiding Stale Closures in Real-Time Subscriptions
+
+A **stale closure** happens when a callback (e.g. a WebSocket handler) captures
+a variable at the time it is created and never sees later updates.  This is a
+common bug in components that subscribe to live data.
+
+**The problem:**
+
+```tsx
+// ❌ BAD — the callback closes over `proposal` from the first render.
+//    When a WS update arrives, it merges into the *original* object,
+//    not the latest state.
+useEffect(() => {
+  const unsub = subscribe('proposal_updated', (update) => {
+    render({ ...proposal, ...update }); // `proposal` is always stale
+  });
+  return unsub;
+}, []); // empty deps → callback never re-created
+```
+
+**The fix — separate state + functional updater:**
+
+```tsx
+// ✅ GOOD — live data lives in its own state bucket.
+//    The functional updater receives `prev` (always the latest value),
+//    so the callback never needs to close over any external variable.
+const [liveProposal, setLiveProposal] = useState(initialProposal);
+
+const handleUpdate = useCallback((data) => {
+  setLiveProposal((prev) => ({ ...prev, ...data })); // `prev` is always fresh
+}, [/* no deps that could go stale */]);
+
+useEffect(() => {
+  const unsub = subscribe('proposal_updated', handleUpdate);
+  return unsub; // always clean up on unmount
+}, [subscribe, handleUpdate]);
+```
+
+**Rules of thumb for subscription callbacks:**
+
+1. **Never read state or props inside a subscription callback** — pass everything through `setState`'s functional updater instead.
+2. **Store mutable identifiers in a `ref`** (e.g. `proposalIdRef.current`) when you need to filter events without adding the value to `useCallback` deps.
+3. **Always return the unsubscribe function** from `useEffect` so the handler is removed when the component unmounts.
+4. **Keep `useCallback` deps minimal and stable** — prefer context values that are themselves wrapped in `useCallback`/`useMemo`.
+5. **Separate concerns** — put subscription logic in a dedicated hook (e.g. `useProposalRealtime`) and keep display components pure/presentational.
+
+See `src/hooks/useProposalRealtime.ts` for the canonical implementation and
+`src/hooks/__tests__/useProposalRealtime.test.ts` for tests that explicitly
+guard against regressions.
+
 ## 🔄 Contribution Workflow
 
 ### 1. Create a Branch

--- a/frontend/src/components/ProposalCard.tsx
+++ b/frontend/src/components/ProposalCard.tsx
@@ -11,6 +11,28 @@ interface ProposalCardProps {
   onToggleSelect?: (id: number) => void;
   /** Whether the checkbox should be disabled (max reached and not selected) */
   selectDisabled?: boolean;
+  /**
+   * Live-updated proposal data from `useProposalRealtime`.
+   *
+   * When provided, this prop takes precedence over `proposal` for rendering so
+   * the card always shows the freshest state without the parent needing to
+   * manage subscription logic.  Pass `undefined` to keep purely server-driven
+   * rendering (default).
+   *
+   * ## Why a separate prop instead of subscribing here?
+   *
+   * Keeping the subscription in `useProposalRealtime` and passing the result
+   * down prevents stale closures: the hook owns its own state bucket and uses
+   * functional `setState` updaters, so no callback inside the hook ever closes
+   * over a stale value.  `ProposalCard` itself stays a pure presentational
+   * component that is easy to test in isolation.
+   */
+  liveProposal?: Proposal;
+  /**
+   * When `true`, a small pulsing indicator is shown to signal that this card
+   * is receiving live updates.  Driven by `useProposalRealtime.hasLiveUpdate`.
+   */
+  hasLiveUpdate?: boolean;
 }
 
 const ProposalCard: React.FC<ProposalCardProps> = ({
@@ -18,66 +40,81 @@ const ProposalCard: React.FC<ProposalCardProps> = ({
   selected = false,
   onToggleSelect,
   selectDisabled = false,
+  liveProposal,
+  hasLiveUpdate = false,
 }) => {
+  // Prefer live data when available; fall back to the server-fetched proposal.
+  const displayed = liveProposal ?? proposal;
   const showCheckbox = onToggleSelect !== undefined;
 
   return (
     <article
       tabIndex={0}
-      aria-label={`Proposal #${proposal.id}, status: ${proposal.status}`}
+      aria-label={`Proposal #${displayed.id}, status: ${displayed.status}`}
       className={`relative rounded-xl border bg-white dark:bg-gray-800/80 p-4 transition-colors hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500/50 ${
         selected
           ? 'border-purple-500 dark:border-purple-500'
           : 'border-gray-200 dark:border-gray-700'
       }`}
     >
+      {/* Live update indicator */}
+      {hasLiveUpdate && (
+        <span
+          aria-label="Live update received"
+          className="absolute top-3 left-3 flex h-2 w-2"
+        >
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+        </span>
+      )}
+
       {/* Multi-select checkbox */}
       {showCheckbox && (
         <div className="absolute top-3 right-3">
           <input
             type="checkbox"
-            id={`select-proposal-${proposal.id}`}
+            id={`select-proposal-${displayed.id}`}
             checked={selected}
             disabled={selectDisabled}
-            onChange={() => onToggleSelect(proposal.id)}
-            aria-label={`Select proposal #${proposal.id} for comparison`}
+            onChange={() => onToggleSelect(displayed.id)}
+            aria-label={`Select proposal #${displayed.id} for comparison`}
             className="h-4 w-4 cursor-pointer rounded border-gray-500 bg-gray-700 text-purple-600 focus:ring-purple-500 disabled:cursor-not-allowed disabled:opacity-40"
           />
         </div>
       )}
 
       <div className="mb-3 flex items-center justify-between pr-6">
-        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Proposal #{proposal.id}</p>
-        <StatusBadge status={proposal.status} />
+        <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">Proposal #{displayed.id}</p>
+        <StatusBadge status={displayed.status} />
       </div>
 
       <dl className="space-y-2 text-sm">
         <div className="flex justify-between gap-3">
           <dt className="text-gray-500 dark:text-gray-400">Proposer</dt>
-          <dd className="font-mono text-gray-700 dark:text-gray-200">{truncateAddress(proposal.proposer)}</dd>
+          <dd className="font-mono text-gray-700 dark:text-gray-200">{truncateAddress(displayed.proposer)}</dd>
         </div>
         <div className="flex justify-between gap-3">
           <dt className="text-gray-500 dark:text-gray-400">Recipient</dt>
-          <dd className="font-mono text-gray-700 dark:text-gray-200">{truncateAddress(proposal.recipient)}</dd>
+          <dd className="font-mono text-gray-700 dark:text-gray-200">{truncateAddress(displayed.recipient)}</dd>
         </div>
         <div className="flex justify-between gap-3">
           <dt className="text-gray-500 dark:text-gray-400">Amount</dt>
-          <dd className="text-gray-900 dark:text-gray-100">{formatTokenAmount(proposal.amount)}</dd>
+          <dd className="text-gray-900 dark:text-gray-100">{formatTokenAmount(displayed.amount)}</dd>
         </div>
         <div className="flex justify-between gap-3">
           <dt className="text-gray-500 dark:text-gray-400">Created</dt>
-          <dd className="text-gray-700 dark:text-gray-200">{formatLedger(proposal.createdAt)}</dd>
+          <dd className="text-gray-700 dark:text-gray-200">{formatLedger(displayed.createdAt)}</dd>
         </div>
-        {proposal.unlockTime ? (
+        {displayed.unlockTime ? (
           <div className="flex justify-between gap-3">
             <dt className="text-gray-500 dark:text-gray-400">Unlock</dt>
-            <dd className="text-gray-700 dark:text-gray-200">{formatLedger(proposal.unlockTime)}</dd>
+            <dd className="text-gray-700 dark:text-gray-200">{formatLedger(displayed.unlockTime)}</dd>
           </div>
         ) : null}
       </dl>
 
-      {proposal.description ? (
-        <p className="mt-3 line-clamp-2 text-xs text-gray-500 dark:text-gray-400">{proposal.description}</p>
+      {displayed.description ? (
+        <p className="mt-3 line-clamp-2 text-xs text-gray-500 dark:text-gray-400">{displayed.description}</p>
       ) : null}
     </article>
   );

--- a/frontend/src/components/__tests__/ProposalCard.test.tsx
+++ b/frontend/src/components/__tests__/ProposalCard.test.tsx
@@ -143,4 +143,86 @@ describe('ProposalCard', () => {
       expect(articles[2]).toHaveAttribute('aria-label', 'Proposal #3, status: Executed');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // liveProposal prop — stale closure regression tests
+  // -------------------------------------------------------------------------
+
+  describe('liveProposal prop', () => {
+    it('renders liveProposal data when provided instead of proposal data', () => {
+      const liveProposal: Proposal = {
+        ...mockProposal,
+        status: 'Approved' as const,
+        description: 'Live description',
+      };
+
+      render(<ProposalCard proposal={mockProposal} liveProposal={liveProposal} />);
+
+      expect(screen.getByText('Approved')).toBeInTheDocument();
+      expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+      expect(screen.getByText('Live description')).toBeInTheDocument();
+    });
+
+    it('falls back to proposal when liveProposal is undefined', () => {
+      render(<ProposalCard proposal={mockProposal} liveProposal={undefined} />);
+
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    it('aria-label reflects the live status, not the stale prop status', () => {
+      const liveProposal: Proposal = { ...mockProposal, status: 'Executed' as const };
+
+      render(<ProposalCard proposal={mockProposal} liveProposal={liveProposal} />);
+
+      const article = screen.getByRole('article');
+      expect(article).toHaveAttribute('aria-label', 'Proposal #123, status: Executed');
+    });
+
+    it('STALE CLOSURE: multiple sequential prop updates render the latest value', () => {
+      const { rerender } = render(
+        <ProposalCard proposal={mockProposal} liveProposal={{ ...mockProposal, status: 'Approved' as const }} />,
+      );
+
+      expect(screen.getByText('Approved')).toBeInTheDocument();
+
+      rerender(
+        <ProposalCard proposal={mockProposal} liveProposal={{ ...mockProposal, status: 'Executed' as const }} />,
+      );
+
+      expect(screen.getByText('Executed')).toBeInTheDocument();
+      expect(screen.queryByText('Approved')).not.toBeInTheDocument();
+      expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // hasLiveUpdate indicator
+  // -------------------------------------------------------------------------
+
+  describe('hasLiveUpdate indicator', () => {
+    it('does not render live indicator when hasLiveUpdate is false', () => {
+      render(<ProposalCard proposal={mockProposal} hasLiveUpdate={false} />);
+
+      expect(screen.queryByLabelText('Live update received')).not.toBeInTheDocument();
+    });
+
+    it('does not render live indicator when hasLiveUpdate is not provided', () => {
+      render(<ProposalCard proposal={mockProposal} />);
+
+      expect(screen.queryByLabelText('Live update received')).not.toBeInTheDocument();
+    });
+
+    it('renders live indicator when hasLiveUpdate is true', () => {
+      render(<ProposalCard proposal={mockProposal} hasLiveUpdate={true} />);
+
+      expect(screen.getByLabelText('Live update received')).toBeInTheDocument();
+    });
+
+    it('live indicator has accessible label', () => {
+      render(<ProposalCard proposal={mockProposal} hasLiveUpdate={true} />);
+
+      const indicator = screen.getByLabelText('Live update received');
+      expect(indicator).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/hooks/__tests__/useProposalRealtime.test.ts
+++ b/frontend/src/hooks/__tests__/useProposalRealtime.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Tests for useProposalRealtime hook.
+ *
+ * Covers:
+ *  - Initial state mirrors the initial proposal
+ *  - proposal_updated events are applied to state
+ *  - Stale closure: late-arriving events see the latest state, not the original
+ *  - Events for other proposal IDs are ignored
+ *  - Unsubscribe / cleanup fires on unmount
+ *  - Duplicate events are deduplicated
+ *  - Status-change events (approved / rejected) are applied
+ *  - hasLiveUpdate flag transitions correctly
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useProposalRealtime } from '../useProposalRealtime';
+import type { Proposal } from '../../components/type';
+
+// ---------------------------------------------------------------------------
+// Realtime context mock
+// ---------------------------------------------------------------------------
+
+/** Captured subscribe handlers keyed by event type. */
+const handlers: Record<string, Array<(data: unknown) => void>> = {};
+const unsubscribers: Array<() => void> = [];
+
+const mockTrackEvent = vi.fn().mockReturnValue(true);
+const mockSubscribe = vi.fn().mockImplementation(
+  (type: string, handler: (data: unknown) => void) => {
+    if (!handlers[type]) handlers[type] = [];
+    handlers[type].push(handler);
+    const unsub = () => {
+      handlers[type] = (handlers[type] ?? []).filter((h) => h !== handler);
+      unsubscribers.push(unsub);
+    };
+    return unsub;
+  },
+);
+
+vi.mock('../../contexts/RealtimeContext', () => ({
+  useRealtime: () => ({
+    isConnected: true,
+    connectionStatus: 'connected',
+    onlineUsers: [],
+    subscribe: mockSubscribe,
+    sendUpdate: vi.fn(),
+    updatePresence: vi.fn(),
+    trackEvent: mockTrackEvent,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function emit(type: string, data: unknown) {
+  (handlers[type] ?? []).forEach((h) => h(data));
+}
+
+const BASE_PROPOSAL: Proposal = {
+  id: 42,
+  proposer: 'GPROPOSER',
+  recipient: 'GRECIPIENT',
+  amount: '100000000',
+  status: 'Pending',
+  createdAt: 1_000_000,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useProposalRealtime', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset captured handlers
+    for (const key of Object.keys(handlers)) delete handlers[key];
+    // vi.clearAllMocks() resets mockImplementation — restore it
+    mockSubscribe.mockImplementation(
+      (type: string, handler: (data: unknown) => void) => {
+        if (!handlers[type]) handlers[type] = [];
+        handlers[type].push(handler);
+        return () => {
+          handlers[type] = (handlers[type] ?? []).filter((h) => h !== handler);
+        };
+      },
+    );
+    mockTrackEvent.mockReturnValue(true);
+  });
+
+  it('returns the initial proposal unchanged on mount', () => {
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+    expect(result.current.liveProposal).toEqual(BASE_PROPOSAL);
+    expect(result.current.hasLiveUpdate).toBe(false);
+  });
+
+  it('subscribes to proposal_updated, proposal_approved, and proposal_rejected', () => {
+    renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+    expect(mockSubscribe).toHaveBeenCalledWith('proposal_updated', expect.any(Function));
+    expect(mockSubscribe).toHaveBeenCalledWith('proposal_approved', expect.any(Function));
+    expect(mockSubscribe).toHaveBeenCalledWith('proposal_rejected', expect.any(Function));
+  });
+
+  it('applies proposal_updated patch to liveProposal', () => {
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+
+    act(() => {
+      emit('proposal_updated', { id: 42, status: 'Approved', votesFor: 3 });
+    });
+
+    expect(result.current.liveProposal.status).toBe('Approved');
+    expect(result.current.liveProposal.votesFor).toBe(3);
+    expect(result.current.hasLiveUpdate).toBe(true);
+  });
+
+  it('ignores events for a different proposal id', () => {
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+
+    act(() => {
+      emit('proposal_updated', { id: 99, status: 'Approved' });
+    });
+
+    expect(result.current.liveProposal.status).toBe('Pending');
+    expect(result.current.hasLiveUpdate).toBe(false);
+  });
+
+  it('STALE CLOSURE: consecutive updates each see the latest state — not the initial value', () => {
+    /**
+     * This is the core stale-closure regression test.
+     *
+     * If the callback closed over the initial proposal, the second update
+     * would be merged onto the *original* object (losing the first update).
+     * The functional setState updater must receive `prev` as the latest state,
+     * so both updates compose correctly.
+     */
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+
+    act(() => {
+      emit('proposal_updated', { id: 42, votesFor: 1 });
+    });
+    expect(result.current.liveProposal.votesFor).toBe(1);
+
+    act(() => {
+      emit('proposal_updated', { id: 42, votesFor: 2 });
+    });
+    // If stale closure: second update merges onto the *original* state (votesFor: undefined)
+    // With functional updater: second update merges onto the state after first update
+    expect(result.current.liveProposal.votesFor).toBe(2);
+    // The original status must still be preserved — not reset to BASE_PROPOSAL
+    expect(result.current.liveProposal.status).toBe('Pending');
+  });
+
+  it('STALE CLOSURE: status update applied after vote update preserves the vote', () => {
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+
+    act(() => {
+      emit('proposal_updated', { id: 42, votesFor: 5 });
+    });
+
+    // Now status changes via approved event
+    act(() => {
+      emit('proposal_approved', { id: 42 });
+    });
+
+    // Both fields must be present — stale closure would wipe out votesFor
+    expect(result.current.liveProposal.status).toBe('Approved');
+    expect(result.current.liveProposal.votesFor).toBe(5);
+  });
+
+  it('applies proposal_approved and sets status to Approved', () => {
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+
+    act(() => {
+      emit('proposal_approved', { id: 42 });
+    });
+
+    expect(result.current.liveProposal.status).toBe('Approved');
+    expect(result.current.hasLiveUpdate).toBe(true);
+  });
+
+  it('applies proposal_rejected and sets status to Rejected', () => {
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+
+    act(() => {
+      emit('proposal_rejected', { id: 42 });
+    });
+
+    expect(result.current.liveProposal.status).toBe('Rejected');
+    expect(result.current.hasLiveUpdate).toBe(true);
+  });
+
+  it('deduplicates identical events (same payload)', () => {
+    // First call returns true (new event), subsequent calls return false
+    let callCount = 0;
+    mockTrackEvent.mockImplementation(() => {
+      callCount++;
+      return callCount === 1; // only first call is new
+    });
+
+    const { result } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+
+    act(() => {
+      emit('proposal_updated', { id: 42, votesFor: 3 });
+      emit('proposal_updated', { id: 42, votesFor: 3 }); // duplicate
+    });
+
+    // Only the first event should have been applied
+    expect(result.current.liveProposal.votesFor).toBe(3);
+    // trackEvent was called twice
+    expect(callCount).toBe(2);
+  });
+
+  it('unsubscribes from all events on unmount', () => {
+    const unsubFns = [vi.fn(), vi.fn(), vi.fn()];
+    let callIndex = 0;
+    mockSubscribe.mockImplementation(() => unsubFns[callIndex++] ?? vi.fn());
+
+    const { unmount } = renderHook(() => useProposalRealtime(BASE_PROPOSAL));
+    unmount();
+
+    // All three unsubscribe functions must have been called
+    unsubFns.forEach((unsub) => expect(unsub).toHaveBeenCalledOnce());
+  });
+
+  it('resets liveProposal when a new initialProposal is passed (refetch)', () => {
+    const { result, rerender } = renderHook(
+      ({ proposal }) => useProposalRealtime(proposal),
+      { initialProps: { proposal: BASE_PROPOSAL } },
+    );
+
+    // Apply a live update
+    act(() => {
+      emit('proposal_updated', { id: 42, votesFor: 7 });
+    });
+    expect(result.current.liveProposal.votesFor).toBe(7);
+
+    // Parent refetches and passes a fresh proposal
+    const refreshed: Proposal = { ...BASE_PROPOSAL, status: 'Approved', votesFor: 7 };
+    rerender({ proposal: refreshed });
+
+    expect(result.current.liveProposal).toEqual(refreshed);
+  });
+});

--- a/frontend/src/hooks/useProposalRealtime.ts
+++ b/frontend/src/hooks/useProposalRealtime.ts
@@ -1,0 +1,153 @@
+/**
+ * useProposalRealtime
+ *
+ * Subscribes to real-time proposal updates from the WebSocket layer and merges
+ * them into a local copy of the proposal.  The hook is the single source of
+ * truth for live data, keeping ProposalCard pure and avoiding stale closures.
+ *
+ * ## Stale-closure problem (and why this hook solves it)
+ *
+ * A stale closure happens when a callback captures a value from an outer scope
+ * at the time it is **created** and never sees later updates:
+ *
+ * ```tsx
+ * // ❌ BAD – subscription callback closes over the initial `proposal` value.
+ * //    Every time an update arrives, it still refers to the original object.
+ * useEffect(() => {
+ *   const unsub = subscribe('proposal_updated', (update) => {
+ *     render({ ...proposal, ...update }); // `proposal` is always the first render's value
+ *   });
+ *   return unsub;
+ * }, []); // empty deps → callback never re-created → stale forever
+ * ```
+ *
+ * The fix is to **not read the parent prop inside the callback**.  Instead we
+ * store live data in a separate `useState` bucket and merge it via the
+ * functional-updater form so the callback never needs to close over any state:
+ *
+ * ```tsx
+ * // ✅ GOOD – functional updater receives the latest state as its argument.
+ * setLiveProposal((prev) => ({ ...prev, ...patch }));
+ * ```
+ *
+ * This pattern is safe regardless of how often the effect re-runs because the
+ * subscription is keyed on `proposalId`, which rarely changes.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useRealtime } from '../contexts/RealtimeContext';
+import type { Proposal } from '../components/type';
+
+/** Partial update payload pushed over the wire for a single proposal. */
+export interface ProposalRealtimeUpdate {
+  id: number;
+  status?: Proposal['status'];
+  votesFor?: number;
+  votesAgainst?: number;
+  description?: string;
+  unlockTime?: number;
+}
+
+export interface UseProposalRealtimeReturn {
+  /** The live proposal state, seeded with `initialProposal` and patched by WS events. */
+  liveProposal: Proposal;
+  /** True when at least one live update has been applied (drives the live indicator). */
+  hasLiveUpdate: boolean;
+}
+
+/**
+ * Subscribes to `proposal_updated` and `proposal_approved` / `proposal_rejected`
+ * events from the realtime context and applies them to a local copy of the
+ * supplied proposal.
+ *
+ * @param initialProposal - The server-fetched baseline proposal.
+ * @returns An object containing the live-merged proposal and a `hasLiveUpdate` flag.
+ */
+export function useProposalRealtime(
+  initialProposal: Proposal,
+): UseProposalRealtimeReturn {
+  // Separate state bucket for the live copy.  Seeded from the prop but never
+  // directly driven by it after mount so the subscription callback has no
+  // reason to reference the prop.
+  const [liveProposal, setLiveProposal] = useState<Proposal>(initialProposal);
+  const [hasLiveUpdate, setHasLiveUpdate] = useState(false);
+
+  // Keep a ref to the proposal id so we can filter events inside the callback
+  // without adding `initialProposal.id` to the useCallback dep array.  The id
+  // never changes for a given card instance, so a ref is sufficient.
+  const proposalIdRef = useRef(initialProposal.id);
+
+  // When the parent passes a genuinely new proposal (e.g. after a refetch),
+  // reset to the fresh baseline but keep the `hasLiveUpdate` flag.
+  useEffect(() => {
+    proposalIdRef.current = initialProposal.id;
+    setLiveProposal(initialProposal);
+  }, [initialProposal]);
+
+  const { subscribe, trackEvent } = useRealtime();
+
+  /**
+   * Handles a proposal update event.
+   *
+   * Uses the **functional updater** form of setState so the callback never
+   * closes over any state value, eliminating the stale-closure risk entirely.
+   */
+  const handleUpdate = useCallback(
+    (data: unknown) => {
+      const update = data as ProposalRealtimeUpdate;
+      if (update.id !== proposalIdRef.current) return;
+
+      // Dedup: skip if we've already applied this exact event.
+      const eventKey = `proposal_updated:${update.id}:${JSON.stringify(update)}`;
+      if (!trackEvent(eventKey)) return;
+
+      // Functional updater – `prev` is always the latest state value.
+      setLiveProposal((prev) => ({ ...prev, ...update }));
+      setHasLiveUpdate(true);
+    },
+    [trackEvent],
+    // ↑ `trackEvent` is stable (wrapped in useCallback inside RealtimeContext)
+    //   so this callback is only recreated if the context instance changes.
+  );
+
+  const handleStatusChange = useCallback(
+    (newStatus: Proposal['status']) =>
+      (data: unknown) => {
+        const update = data as { id: number };
+        if (update.id !== proposalIdRef.current) return;
+
+        const eventKey = `proposal_status:${newStatus}:${update.id}`;
+        if (!trackEvent(eventKey)) return;
+
+        setLiveProposal((prev) => ({ ...prev, status: newStatus }));
+        setHasLiveUpdate(true);
+      },
+    [trackEvent],
+  );
+
+  useEffect(() => {
+    const unsubUpdate = subscribe<ProposalRealtimeUpdate>(
+      'proposal_updated',
+      handleUpdate,
+    );
+    const unsubApproved = subscribe<{ id: number }>(
+      'proposal_approved',
+      handleStatusChange('Approved'),
+    );
+    const unsubRejected = subscribe<{ id: number }>(
+      'proposal_rejected',
+      handleStatusChange('Rejected'),
+    );
+
+    return () => {
+      unsubUpdate();
+      unsubApproved();
+      unsubRejected();
+    };
+  }, [subscribe, handleUpdate, handleStatusChange]);
+  // ↑ All three are stable references — this effect only re-runs when the
+  //   subscribe function itself changes (i.e. on context remount), never on
+  //   ordinary re-renders.
+
+  return { liveProposal, hasLiveUpdate };
+}


### PR DESCRIPTION
## Root cause

Subscription callbacks in the original code closed over the initial `proposal` prop, so every WebSocket update was merged into the **original** object instead of the current state:

```tsx
// ❌ Before — stale closure: proposal never updates inside the callback
useEffect(() => {
  const unsub = subscribe('proposal_updated', (update) => {
    render({ ...proposal, ...update }); // proposal = first render's value, forever
  });
  return unsub;
}, []);
```

## Fix

**`useProposalRealtime` hook** (`src/hooks/useProposalRealtime.ts`)
- Live data lives in its own `useState` bucket, completely separate from the prop
- Callbacks use the **functional updater** form of `setState` so they never close over any external value:
  ```tsx
  setLiveProposal((prev) => ({ ...prev, ...patch })); // prev is always latest
  ```
- `proposalIdRef` captures the ID without putting it in `useCallback` deps
- Three subscriptions (`proposal_updated`, `proposal_approved`, `proposal_rejected`) all cleaned up on unmount
- Deduplication via `RealtimeContext.trackEvent` prevents double-applying events across reconnects

**`ProposalCard`** (`src/components/ProposalCard.tsx`)
- Accepts optional `liveProposal` and `hasLiveUpdate` props
- Prefers `liveProposal` over `proposal` for rendering (pure/presentational, no subscription logic)
- Renders an accessible pulsing green indicator (`aria-label="Live update received"`) when `hasLiveUpdate` is true

**Usage in a parent:**
```tsx
const { liveProposal, hasLiveUpdate } = useProposalRealtime(proposal);
return <ProposalCard proposal={proposal} liveProposal={liveProposal} hasLiveUpdate={hasLiveUpdate} />;
```

## Tests — 20 new tests, all passing

`useProposalRealtime.test.ts` (11 tests):
- Initial state mirrors the prop
- `proposal_updated` patch applied correctly
- **Stale closure regression**: consecutive updates compose on latest state, not the original
- Status-change via approved/rejected events; vote count preserved across status change
- Events for other proposal IDs ignored
- Deduplication
- All 3 unsubscribers called on unmount
- Resets to fresh baseline when parent refetches

`ProposalCard.test.tsx` (9 new tests):
- `liveProposal` data rendered instead of stale prop
- Fallback to prop when `liveProposal` is undefined
- `aria-label` reflects live status
- Sequential rerenders show latest value (stale closure guard)
- Live indicator present/absent based on `hasLiveUpdate`

## Docs
Added **Avoiding Stale Closures in Real-Time Subscriptions** section to `CONTRIBUTING.md` with a bad example, the correct pattern, 5 rules of thumb, and a link to the canonical implementation.

Closes #1387