### PR TITLE
feat: optimistic UI updates with rollback for proposal approval

### DIFF
--- a/frontend/src/app/dashboard/Proposals.tsx
+++ b/frontend/src/app/dashboard/Proposals.tsx
@@ -11,6 +11,7 @@ import ProposalFilters, { type FilterState } from '../../components/proposals/Pr
 import ProposalComparison from '../../components/ProposalComparison';
 import TransactionSimulatorModal from '../../components/TransactionSimulatorModal';
 import { useToast } from '../../hooks/useToast';
+import { useOptimisticUpdate } from '../../hooks/useOptimisticUpdate';
 import { useVaultContract } from '../../hooks/useVaultContract';
 import { useProposals } from '../../hooks/useProposals';
 import { useWallet } from '../../hooks/useWallet';
@@ -65,7 +66,8 @@ export interface Proposal {
 }
 
 const Proposals: React.FC = () => {
-  const { notify } = useToast();
+  const { notify, showToast } = useToast();
+  const { execute: optimisticExecute } = useOptimisticUpdate<Proposal[]>();
   const { rejectProposal, approveProposal, executeProposal, getUserRole, getTokenBalances, getVaultConfig } = useVaultContract();
   const { address } = useWallet();
   const { isReady, checkReady } = useActionReadiness();
@@ -357,24 +359,30 @@ const Proposals: React.FC = () => {
     const doApprove = async () => {
       setApprovingIds(prev => new Set(prev).add(proposalId));
       try {
-        await approveProposal(Number(proposalId));
-        setLocalProposals(prev => prev.map(p => {
-          if (p.id === proposalId) {
-            const newApprovals = p.approvals + 1;
-            const newApprovedBy = [...p.approvedBy, address!];
-            return {
-              ...p,
-              approvals: newApprovals,
-              approvedBy: newApprovedBy,
-              status: newApprovals >= p.threshold ? 'Approved' : p.status
-            };
-          }
-          return p;
-        }));
-        notify('proposal_approved', `Proposal #${proposalId} approved successfully`, 'success');
-      } catch (err: unknown) {
-        const errorMessage = err instanceof Error ? err.message : 'Failed to approve proposal';
-        notify('proposal_rejected', errorMessage, 'error');
+        await optimisticExecute(setLocalProposals, {
+          metricLabel: 'approve_proposal',
+          applyUpdate: (prev) => prev.map(p => {
+            if (p.id === proposalId) {
+              const newApprovals = p.approvals + 1;
+              const newApprovedBy = [...p.approvedBy, address!];
+              return {
+                ...p,
+                approvals: newApprovals,
+                approvedBy: newApprovedBy,
+                status: newApprovals >= p.threshold ? 'Approved' : p.status,
+              };
+            }
+            return p;
+          }),
+          performAction: () => approveProposal(Number(proposalId)),
+          onSuccess: () => {
+            notify('proposal_approved', `Proposal #${proposalId} approved successfully`, 'success');
+          },
+          onError: (err) => {
+            const errorMessage = err.message || 'Failed to approve proposal';
+            showToast(errorMessage, 'error');
+          },
+        });
       } finally {
         setApprovingIds(prev => {
           const newSet = new Set(prev);
@@ -444,6 +452,51 @@ const Proposals: React.FC = () => {
       onProceed: doExecute,
     });
     setSimulatorOpen(true);
+  };
+
+  /**
+   * Optimistic approve triggered from ProposalDetailModal.
+   * Immediately updates localProposals, then calls the RPC. On failure,
+   * localProposals is rolled back and a toast with the real error is shown.
+   */
+  const handleApproveFromModal = async (proposalId: string): Promise<void> => {
+    const { ready, message } = checkReady();
+    if (!ready) {
+      showToast(message ?? 'Not ready', 'error');
+      return;
+    }
+    setApprovingIds(prev => new Set(prev).add(proposalId));
+    try {
+      await optimisticExecute(setLocalProposals, {
+        metricLabel: 'approve_proposal_modal',
+        applyUpdate: (prev) => prev.map(p => {
+          if (p.id === proposalId) {
+            const newApprovals = p.approvals + 1;
+            const newApprovedBy = [...p.approvedBy, address!];
+            return {
+              ...p,
+              approvals: newApprovals,
+              approvedBy: newApprovedBy,
+              status: newApprovals >= p.threshold ? 'Approved' : p.status,
+            };
+          }
+          return p;
+        }),
+        performAction: () => approveProposal(Number(proposalId)),
+        onSuccess: () => {
+          notify('proposal_approved', `Proposal #${proposalId} approved successfully`, 'success');
+        },
+        onError: (err) => {
+          showToast(err.message || 'Failed to approve proposal', 'error');
+        },
+      });
+    } finally {
+      setApprovingIds(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(proposalId);
+        return newSet;
+      });
+    }
   };
 
   return (
@@ -721,7 +774,7 @@ const Proposals: React.FC = () => {
           onSaveAsTemplate={() => { }}
           onClose={() => setShowNewProposalModal(false)}
         />
-        <ProposalDetailModal isOpen={!!selectedProposal} onClose={() => setSelectedProposal(null)} proposal={selectedProposal} />
+        <ProposalDetailModal isOpen={!!selectedProposal} onClose={() => setSelectedProposal(null)} proposal={selectedProposal} onApprove={handleApproveFromModal} />
         <ConfirmationModal isOpen={showRejectModal} title="Reject Proposal" message="Are you sure you want to reject this?" onConfirm={handleRejectConfirm} onCancel={() => setShowRejectModal(false)} showReasonInput={true} isDestructive={true} />
         {showComparison && (
           <ProposalComparison

--- a/frontend/src/components/modals/ProposalDetailModal.tsx
+++ b/frontend/src/components/modals/ProposalDetailModal.tsx
@@ -6,6 +6,7 @@ import QRSignature from '../QRSignature';
 import ProposalPhaseTimeline, { type ProposalPhase } from '../proposals/ProposalPhaseTimeline';
 import { useVaultContract } from '../../hooks/useVaultContract';
 import { useWallet } from '../../hooks/useWallet';
+import { useToast } from '../../hooks/useToast';
 import VersionHistory from '../collaborative/VersionHistory';
 
 export interface Proposal {
@@ -30,12 +31,20 @@ interface ProposalDetailModalProps {
     isOpen: boolean;
     onClose: () => void;
     proposal: Proposal | null;
+    /**
+     * Optional callback invoked when the user clicks Approve.
+     * When provided, the parent owns the optimistic update; the modal
+     * simply delegates and closes. When absent, the modal calls
+     * `approveProposal` directly and shows inline errors.
+     */
+    onApprove?: (proposalId: string) => Promise<void>;
 }
 
-const ProposalDetailModal: React.FC<ProposalDetailModalProps> = ({ isOpen, onClose, proposal }) => {
+const ProposalDetailModal: React.FC<ProposalDetailModalProps> = ({ isOpen, onClose, proposal, onApprove }) => {
     const [activeTab, setActiveTab] = useState<'details' | 'comments'>('details');
     const { getProposalSignatures, approveProposal, rejectProposal, exportSignatures } = useVaultContract();
     const { address, accountRole } = useWallet();
+    const { showToast } = useToast();
     const [signers, setSigners] = useState<Signer[]>([]);
     const [actionLoading, setActionLoading] = useState<'approve' | 'reject' | null>(null);
     const [actionError, setActionError] = useState<string | null>(null);
@@ -93,10 +102,20 @@ const ProposalDetailModal: React.FC<ProposalDetailModalProps> = ({ isOpen, onClo
         setActionLoading('approve');
         setActionError(null);
         try {
-            await approveProposal(parseInt(proposal.id));
-            onClose();
+            if (onApprove) {
+                // Delegate to parent: the parent owns the optimistic update
+                // and will show any error toasts itself.
+                await onApprove(proposal.id);
+                onClose();
+            } else {
+                // Standalone mode: call RPC directly, show errors inline and via toast.
+                await approveProposal(parseInt(proposal.id));
+                onClose();
+            }
         } catch (e) {
-            setActionError(e instanceof Error ? e.message : 'Failed to approve');
+            const msg = e instanceof Error ? e.message : 'Failed to approve';
+            setActionError(msg);
+            showToast(msg, 'error');
         } finally {
             setActionLoading(null);
         }

--- a/frontend/src/hooks/__tests__/useOptimisticUpdate.test.ts
+++ b/frontend/src/hooks/__tests__/useOptimisticUpdate.test.ts
@@ -1,0 +1,335 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { useState } from 'react';
+import { useOptimisticUpdate } from '../useOptimisticUpdate';
+
+// ---------------------------------------------------------------------------
+// Mock performanceTracker so we can spy on metric emissions without starting
+// the real PerformanceObserver / setInterval machinery.
+// ---------------------------------------------------------------------------
+vi.mock('../../utils/performanceTracking', () => ({
+  performanceTracker: {
+    trackSlowQuery: vi.fn(),
+  },
+}));
+
+// Grab the mock reference after the module is mocked
+import { performanceTracker } from '../../utils/performanceTracking';
+const mockTrackSlowQuery = vi.mocked(performanceTracker.trackSlowQuery);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Renders the hook together with a simple array state so we can inspect
+ *  both the state mutations and the optimistic execute in one place. */
+function renderWithState<T>(initial: T) {
+  const { result } = renderHook(() => {
+    const [state, setState] = useState<T>(initial);
+    const { execute } = useOptimisticUpdate<T>();
+    return { state, setState, execute };
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useOptimisticUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Basic optimistic update (success path)
+  // -------------------------------------------------------------------------
+  describe('success path', () => {
+    it('applies the optimistic update before the async operation resolves', async () => {
+      const result = renderWithState([1, 2, 3]);
+
+      let resolveAction!: () => void;
+      const pendingAction = new Promise<void>((resolve) => {
+        resolveAction = resolve;
+      });
+
+      act(() => {
+        void result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 99],
+          performAction: () => pendingAction,
+        });
+      });
+
+      // Optimistic state should be visible immediately
+      expect(result.current.state).toEqual([1, 2, 3, 99]);
+
+      // Resolve the async operation
+      await act(async () => {
+        resolveAction();
+      });
+
+      // State should remain with the optimistic update applied
+      expect(result.current.state).toEqual([1, 2, 3, 99]);
+    });
+
+    it('calls onSuccess when the operation resolves', async () => {
+      const result = renderWithState<number[]>([]);
+      const onSuccess = vi.fn();
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 1],
+          performAction: () => Promise.resolve(),
+          onSuccess,
+        });
+      });
+
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onError or onRollback when the operation succeeds', async () => {
+      const result = renderWithState<string[]>([]);
+      const onError = vi.fn();
+      const onRollback = vi.fn();
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 'a'],
+          performAction: () => Promise.resolve(),
+          onError,
+          onRollback,
+        });
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onRollback).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Rollback on failure
+  // -------------------------------------------------------------------------
+  describe('failure / rollback path', () => {
+    it('rolls back to the pre-optimistic state when the operation rejects', async () => {
+      const initial = [{ id: '1', status: 'Pending', approvals: 0 }];
+      const result = renderWithState(initial);
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) =>
+            prev.map((p) => (p.id === '1' ? { ...p, status: 'Approved', approvals: 1 } : p)),
+          performAction: () => Promise.reject(new Error('RPC failure')),
+        });
+      });
+
+      // State should be restored to the original value
+      expect(result.current.state).toEqual(initial);
+      expect(result.current.state[0].status).toBe('Pending');
+    });
+
+    it('calls onError with the thrown error', async () => {
+      const result = renderWithState<number[]>([10]);
+      const onError = vi.fn();
+      const rpcError = new Error('network timeout');
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 20],
+          performAction: () => Promise.reject(rpcError),
+          onError,
+        });
+      });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(rpcError);
+    });
+
+    it('wraps non-Error rejections in an Error object before calling onError', async () => {
+      const result = renderWithState<number[]>([]);
+      const onError = vi.fn();
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 1],
+          // eslint-disable-next-line prefer-promise-reject-errors
+          performAction: () => Promise.reject('plain string error'),
+          onError,
+        });
+      });
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      const received = onError.mock.calls[0][0];
+      expect(received).toBeInstanceOf(Error);
+      expect(received.message).toBe('plain string error');
+    });
+
+    it('calls onRollback with the rolled-back state', async () => {
+      const initial = ['a', 'b'];
+      const result = renderWithState(initial);
+      const onRollback = vi.fn();
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 'c'],
+          performAction: () => Promise.reject(new Error('fail')),
+          onRollback,
+        });
+      });
+
+      expect(onRollback).toHaveBeenCalledTimes(1);
+      expect(onRollback).toHaveBeenCalledWith(initial);
+    });
+
+    it('does not call onSuccess when the operation rejects', async () => {
+      const result = renderWithState<number[]>([]);
+      const onSuccess = vi.fn();
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 1],
+          performAction: () => Promise.reject(new Error('oops')),
+          onSuccess,
+        });
+      });
+
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Multiple sequential executions
+  // -------------------------------------------------------------------------
+  describe('sequential executions', () => {
+    it('applies the correct snapshot for each independent execute call', async () => {
+      // Verify that each execute call captures its own pre-call snapshot by
+      // using a standalone useState/dispatch pair rather than renderHook
+      // chained across multiple act() blocks (which can have subtle React 19
+      // batching effects on result.current between acts).
+      const capturedRollbacks: unknown[] = [];
+
+      // First call: success — apply 'x', action succeeds.
+      const result1 = renderWithState<string[]>([]);
+      await act(async () => {
+        await result1.current.execute(result1.current.setState, {
+          applyUpdate: (prev) => [...prev, 'x'],
+          performAction: () => Promise.resolve(),
+        });
+      });
+      expect(result1.current.state).toEqual(['x']);
+
+      // Second call (fresh hook, pre-set to ['x']): failure — optimistic 'y'
+      // should roll back, restoring ['x'].
+      const result2 = renderHook(() => {
+        const [state, setState] = useState<string[]>(['x']);
+        const { execute } = useOptimisticUpdate<string[]>();
+        return { state, setState, execute };
+      });
+      await act(async () => {
+        await result2.result.current.execute(result2.result.current.setState, {
+          applyUpdate: (prev) => [...prev, 'y'],
+          performAction: () => Promise.reject(new Error('rpc fail')),
+          onRollback: (rolled) => capturedRollbacks.push(rolled),
+        });
+      });
+
+      expect(capturedRollbacks).toEqual([['x']]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Metric emissions
+  // -------------------------------------------------------------------------
+  describe('metric tracking', () => {
+    it('emits an optimistic_update metric when the update is applied', async () => {
+      const result = renderWithState<number[]>([]);
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          metricLabel: 'test_action',
+          applyUpdate: (prev) => [...prev, 1],
+          performAction: () => Promise.resolve(),
+        });
+      });
+
+      const updateCall = mockTrackSlowQuery.mock.calls.find(([name]) =>
+        name.startsWith('optimistic_update.')
+      );
+      expect(updateCall).toBeDefined();
+      expect(updateCall![0]).toBe('optimistic_update.test_action');
+    });
+
+    it('emits an optimistic_commit metric on success', async () => {
+      const result = renderWithState<number[]>([]);
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          metricLabel: 'commit_action',
+          applyUpdate: (prev) => [...prev, 1],
+          performAction: () => Promise.resolve(),
+        });
+      });
+
+      const commitCall = mockTrackSlowQuery.mock.calls.find(([name]) =>
+        name.startsWith('optimistic_commit.')
+      );
+      expect(commitCall).toBeDefined();
+      expect(commitCall![0]).toBe('optimistic_commit.commit_action');
+    });
+
+    it('emits an optimistic_rollback metric on failure', async () => {
+      const result = renderWithState<number[]>([]);
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          metricLabel: 'rollback_action',
+          applyUpdate: (prev) => [...prev, 1],
+          performAction: () => Promise.reject(new Error('fail')),
+        });
+      });
+
+      const rollbackCall = mockTrackSlowQuery.mock.calls.find(([name]) =>
+        name.startsWith('optimistic_rollback.')
+      );
+      expect(rollbackCall).toBeDefined();
+      expect(rollbackCall![0]).toBe('optimistic_rollback.rollback_action');
+    });
+
+    it('does NOT emit a rollback metric on success', async () => {
+      const result = renderWithState<number[]>([]);
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          metricLabel: 'no_rollback',
+          applyUpdate: (prev) => [...prev, 1],
+          performAction: () => Promise.resolve(),
+        });
+      });
+
+      const rollbackCall = mockTrackSlowQuery.mock.calls.find(([name]) =>
+        name.startsWith('optimistic_rollback.')
+      );
+      expect(rollbackCall).toBeUndefined();
+    });
+
+    it('uses "unknown" label when metricLabel is not provided', async () => {
+      const result = renderWithState<number[]>([]);
+
+      await act(async () => {
+        await result.current.execute(result.current.setState, {
+          applyUpdate: (prev) => [...prev, 1],
+          performAction: () => Promise.resolve(),
+          // metricLabel intentionally omitted
+        });
+      });
+
+      const updateCall = mockTrackSlowQuery.mock.calls.find(([name]) =>
+        name === 'optimistic_update.unknown'
+      );
+      expect(updateCall).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/hooks/useOptimisticUpdate.ts
+++ b/frontend/src/hooks/useOptimisticUpdate.ts
@@ -1,0 +1,113 @@
+import { useCallback } from 'react';
+import { performanceTracker } from '../utils/performanceTracking';
+
+export interface OptimisticUpdateOptions<T> {
+  /** Apply an optimistic mutation to state before the async operation starts. */
+  applyUpdate: (prev: T) => T;
+  /** The async operation (e.g. RPC call) to perform after the optimistic update. */
+  performAction: () => Promise<void>;
+  /** Called with the current (rolled-back) state when the operation fails. */
+  onRollback?: (rolledBackState: T) => void;
+  /** Called when the operation succeeds. */
+  onSuccess?: () => void;
+  /** Called with the error when the operation fails (after rollback). */
+  onError?: (err: Error) => void;
+  /** Human-readable label used for metric tracking (e.g. "approve_proposal"). */
+  metricLabel?: string;
+}
+
+export interface UseOptimisticUpdateReturn<T> {
+  /**
+   * Execute an optimistic update cycle:
+   * 1. Save current state snapshot.
+   * 2. Apply the optimistic mutation immediately.
+   * 3. Run the async operation.
+   * 4. On failure: rollback state, call onRollback/onError.
+   * 5. On success: call onSuccess.
+   */
+  execute: (
+    setState: React.Dispatch<React.SetStateAction<T>>,
+    options: OptimisticUpdateOptions<T>
+  ) => Promise<void>;
+}
+
+/**
+ * A generic hook that provides a type-safe optimistic update pattern with
+ * automatic rollback on failure.
+ *
+ * Emits performance metrics via `performanceTracker` for:
+ *   - `optimistic_update.<label>` — fired on every optimistic application
+ *   - `optimistic_commit.<label>` — fired when the operation succeeds
+ *   - `optimistic_rollback.<label>` — fired when a rollback is triggered
+ */
+export function useOptimisticUpdate<T>(): UseOptimisticUpdateReturn<T> {
+  const execute = useCallback(
+    async (
+      setState: React.Dispatch<React.SetStateAction<T>>,
+      {
+        applyUpdate,
+        performAction,
+        onRollback,
+        onSuccess,
+        onError,
+        metricLabel = 'unknown',
+      }: OptimisticUpdateOptions<T>
+    ): Promise<void> => {
+      const startTime = performance.now();
+
+      // We capture the snapshot synchronously inside the setState updater so
+      // we have the exact pre-optimistic value to restore on rollback.
+      // Using a plain variable (closed over) rather than a ref ensures the
+      // value is available at the point the rollback setState updater is
+      // called, even after React flushes batched updates.
+      let snapshot: T | undefined;
+
+      // 1. Capture snapshot + apply optimistic update atomically.
+      setState((prev) => {
+        snapshot = prev;
+        return applyUpdate(prev);
+      });
+
+      // Emit metric: optimistic update applied (duration 0 = event marker).
+      performanceTracker.trackSlowQuery(
+        `optimistic_update.${metricLabel}`,
+        0,
+        'computation'
+      );
+
+      try {
+        // 2. Run the real async operation.
+        await performAction();
+
+        const duration = performance.now() - startTime;
+        performanceTracker.trackSlowQuery(
+          `optimistic_commit.${metricLabel}`,
+          duration,
+          'api'
+        );
+
+        onSuccess?.();
+      } catch (rawErr) {
+        const err = rawErr instanceof Error ? rawErr : new Error(String(rawErr));
+
+        // 3. Rollback: restore the pre-optimistic snapshot.
+        // `snapshot` is guaranteed to be set because step 1 ran synchronously.
+        const rolledBack = snapshot as T;
+        setState(() => rolledBack);
+
+        const duration = performance.now() - startTime;
+        performanceTracker.trackSlowQuery(
+          `optimistic_rollback.${metricLabel}`,
+          duration,
+          'api'
+        );
+
+        onRollback?.(rolledBack);
+        onError?.(err);
+      }
+    },
+    []
+  );
+
+  return { execute };
+}


### PR DESCRIPTION
## Summary

Fixes #1388. Proposal approval now updates the UI immediately (optimistic update) and rolls back automatically if the RPC call fails, replacing the previous pattern of waiting for the transaction before showing any change.

## Changes

### New: `src/hooks/useOptimisticUpdate.ts`
Generic, type-safe hook implementing the optimistic update pattern:
1. Captures a state snapshot atomically inside the `setState` updater
2. Applies the optimistic mutation immediately (e.g. `Pending → Approved`)
3. Awaits the async operation (RPC call)
4. **Success**: calls `onSuccess`
5. **Failure**: restores snapshot, calls `onRollback` + `onError`

Emits `performanceTracker` metrics on every update (`optimistic_update.<label>`), commit (`optimistic_commit.<label>`), and rollback (`optimistic_rollback.<label>`).

### Modified: `src/app/dashboard/Proposals.tsx`
- `doApprove` now calls `optimisticExecute` — state updates before the RPC, rolls back on failure
- `handleApproveFromModal` added so `ProposalDetailModal` delegates to the same flow
- Error toasts show the **actual** RPC error, not an optimistic success message

### Modified: `src/components/modals/ProposalDetailModal.tsx`
- Accepts optional `onApprove?: (proposalId: string) => Promise<void>` prop
- When provided, delegates to parent (which owns the optimistic update)
- Standalone mode retains direct RPC call with `showToast` for errors

### New: `src/hooks/__tests__/useOptimisticUpdate.test.ts`
14 unit tests covering:
- Optimistic update applied before async resolution
- State rollback on rejection
- `onSuccess` / `onError` / `onRollback` contract
- Non-`Error` rejection wrapping
- Sequential independent executions
- All three metric labels emitted correctly

## Testing

```
cd frontend && npx vitest run src/hooks/__tests__/useOptimisticUpdate.test.ts
# 14 passed, 0 failed

npx vitest run src/app/dashboard/__tests__/Proposals.test.tsx
# 7 passed, 0 failed
```