### PR TITLE
feature:Implement Configurable Proposal Fingerprint Deduplication Window

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -65,6 +65,18 @@ export interface BackendEnv {
    * Default: 10,000.  Configure via `NORMALIZER_CACHE_MAX_SIZE`.
    */
   readonly normalizerCacheMaxSize: number;
+  /**
+   * Ledger window used by the proposal fingerprint deduplication store.
+   *
+   * A PROPOSAL_CREATED event is considered a duplicate only when an
+   * identical fingerprint was recorded within this many ledgers.
+   * Fingerprints older than the window are allowed through, enabling
+   * legitimate re-submissions after the cooling-off period.
+   *
+   * Default: 120,960 ledgers ≈ 7 days at ~5 s per ledger on Stellar.
+   * Env var: `PROPOSAL_FINGERPRINT_WINDOW_LEDGERS`
+   */
+  readonly proposalFingerprintWindowLedgers: number;
 }
 
 const DEFAULT_CONTRACT_ID =
@@ -277,6 +289,7 @@ export function createTestEnv(overrides: Partial<BackendEnv> = {}): BackendEnv {
     proposalArchivalThresholdDays: 180,
     proposalHotStorageDays: 7,
     normalizerCacheMaxSize: 10_000,
+    proposalFingerprintWindowLedgers: 120_960,
     ...overrides,
   };
 }
@@ -368,9 +381,16 @@ export function loadEnv(): BackendEnv {
   const wsMaxSubscriptionsPerClient = readPort(
     "WS_MAX_SUBSCRIPTIONS_PER_CLIENT",
     100,
+    issues,
+  );
   const normalizerCacheMaxSize = readPort(
     "NORMALIZER_CACHE_MAX_SIZE",
     10_000,
+    issues,
+  );
+  const proposalFingerprintWindowLedgers = readPort(
+    "PROPOSAL_FINGERPRINT_WINDOW_LEDGERS",
+    120_960,
     issues,
   );
 
@@ -482,5 +502,6 @@ export function loadEnv(): BackendEnv {
     proposalArchivalThresholdDays,
     proposalHotStorageDays,
     normalizerCacheMaxSize,
+    proposalFingerprintWindowLedgers,
   };
 }

--- a/backend/src/modules/proposals/consumer.ts
+++ b/backend/src/modules/proposals/consumer.ts
@@ -21,6 +21,10 @@ import {
 import type { MetricsRegistry } from "../health/metrics.registry.js";
 import type { NotificationPublisher } from "../notifications/notification.types.js";
 import { randomUUID } from "node:crypto";
+import {
+  ProposalFingerprintStore,
+  DEFAULT_FINGERPRINT_WINDOW_LEDGERS,
+} from "./proposal-fingerprint.store.js";
 
 /**
  * Default batch size for consumer buffering.
@@ -66,12 +70,20 @@ export class ProposalActivityConsumer {
   private readonly processedEventIds = new Set<string>();
   private readonly maxDedupeSize: number;
 
+  // Fingerprint-based duplicate detection for PROPOSAL_CREATED events
+  private readonly fingerprintStore: ProposalFingerprintStore;
+
   constructor(options?: {
     batchSize?: number;
     flushIntervalMs?: number;
     maxRetries?: number;
     initialBackoffMs?: number;
     maxDedupeSize?: number;
+    /**
+     * Ledger window for fingerprint deduplication on PROPOSAL_CREATED events.
+     * Defaults to DEFAULT_FINGERPRINT_WINDOW_LEDGERS (120,960 ≈ 7 days).
+     */
+    fingerprintWindowLedgers?: number;
     metricsRegistry?: MetricsRegistry;
     notificationQueue?: NotificationPublisher;
     /** Broadcast hook — called synchronously after each record is produced. */
@@ -86,6 +98,9 @@ export class ProposalActivityConsumer {
     this.metrics = options?.metricsRegistry;
     this.notificationQueue = options?.notificationQueue;
     this.onActivity = options?.onActivity;
+    this.fingerprintStore = new ProposalFingerprintStore(
+      options?.fingerprintWindowLedgers ?? DEFAULT_FINGERPRINT_WINDOW_LEDGERS,
+    );
   }
 
   private deriveEventKey(event: NormalizedEvent): string {
@@ -290,6 +305,29 @@ export class ProposalActivityConsumer {
 
     const proposalId = this.extractProposalId(event);
     const data = this.mapActivityData(event, activityType);
+
+    // Fingerprint deduplication: only applied to PROPOSAL_CREATED events.
+    // We compute the fingerprint after mapping activity data so we have
+    // strongly-typed fields. If an identical proposal was already seen
+    // within the configured ledger window we drop it here.
+    if (activityType === ProposalActivityType.CREATED) {
+      const isNew = this.fingerprintStore.checkAndRecord(
+        event.metadata.contractId,
+        proposalId,
+        data as import("./types.js").ProposalCreatedActivityData,
+        event.metadata.ledger,
+      );
+
+      if (!isNew) {
+        this.logger.debug(
+          `dropping duplicate PROPOSAL_CREATED within fingerprint window: proposalId=${proposalId}`,
+        );
+        this.metrics?.incrementCounter(
+          "vaultdao_proposals_fingerprint_duplicates_total",
+        );
+        return null;
+      }
+    }
 
     // Increment proposal metrics
     if (this.metrics) {
@@ -681,6 +719,13 @@ export class ProposalActivityConsumer {
   }
 
   /**
+   * Returns the underlying fingerprint store (for diagnostics / testing).
+   */
+  public getFingerprintStore(): ProposalFingerprintStore {
+    return this.fingerprintStore;
+  }
+
+  /**
    * Returns the current buffer size.
    */
   public getBufferSize(): number {
@@ -725,6 +770,7 @@ export class ProposalActivityConsumer {
 export function createProposalConsumer(options?: {
   batchSize?: number;
   flushIntervalMs?: number;
+  fingerprintWindowLedgers?: number;
   metricsRegistry?: MetricsRegistry;
   notificationQueue?: NotificationPublisher;
   onActivity?: (record: ProposalActivityRecord) => void;

--- a/backend/src/modules/proposals/proposal-fingerprint.store.test.ts
+++ b/backend/src/modules/proposals/proposal-fingerprint.store.test.ts
@@ -1,0 +1,370 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ProposalFingerprintStore,
+  DEFAULT_FINGERPRINT_WINDOW_LEDGERS,
+} from "./proposal-fingerprint.store.js";
+import type { ProposalCreatedActivityData } from "./types.js";
+import { ProposalActivityType } from "./types.js";
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeCreatedData(
+  overrides: Partial<ProposalCreatedActivityData> = {},
+): ProposalCreatedActivityData {
+  return {
+    activityType: ProposalActivityType.CREATED,
+    proposer: "GPROPOSER001",
+    recipient: "GRECIPIENT001",
+    token: "CTOKEN00000000000000000000000000000000000000000000000001",
+    amount: "1000",
+    insuranceAmount: "100",
+    description: "Initial proposal",
+    ...overrides,
+  };
+}
+
+const CONTRACT_ID = "CDCONTRACT0000000000000000000000000000000000000000000001";
+const PROPOSAL_ID = "proposal-001";
+const BASE_LEDGER = 1_000_000;
+
+// ─── Constructor ───────────────────────────────────────────────────────────
+
+test("ProposalFingerprintStore constructor", async (t) => {
+  await t.test("uses DEFAULT_FINGERPRINT_WINDOW_LEDGERS when no arg given", () => {
+    const store = new ProposalFingerprintStore();
+    assert.equal(store.window, DEFAULT_FINGERPRINT_WINDOW_LEDGERS);
+    assert.equal(store.window, 120_960);
+  });
+
+  await t.test("accepts a custom window", () => {
+    const store = new ProposalFingerprintStore(500);
+    assert.equal(store.window, 500);
+  });
+
+  await t.test("throws RangeError for zero window", () => {
+    assert.throws(() => new ProposalFingerprintStore(0), RangeError);
+  });
+
+  await t.test("throws RangeError for negative window", () => {
+    assert.throws(() => new ProposalFingerprintStore(-1), RangeError);
+  });
+
+  await t.test("throws RangeError for non-integer window", () => {
+    assert.throws(() => new ProposalFingerprintStore(1.5), RangeError);
+  });
+});
+
+// ─── Basic allow / reject ──────────────────────────────────────────────────
+
+test("ProposalFingerprintStore - basic behaviour", async (t) => {
+  await t.test("allows first-seen proposal", () => {
+    const store = new ProposalFingerprintStore(100);
+    const data = makeCreatedData();
+    const result = store.checkAndRecord(CONTRACT_ID, PROPOSAL_ID, data, BASE_LEDGER);
+    assert.equal(result, true);
+  });
+
+  await t.test("rejects identical proposal within window", () => {
+    const store = new ProposalFingerprintStore(100);
+    const data = makeCreatedData();
+
+    store.checkAndRecord(CONTRACT_ID, PROPOSAL_ID, data, BASE_LEDGER);
+    const result = store.checkAndRecord(CONTRACT_ID, "proposal-002", data, BASE_LEDGER + 50);
+    assert.equal(result, false);
+  });
+
+  await t.test("rejects at exactly the window boundary (age === window)", () => {
+    const store = new ProposalFingerprintStore(100);
+    const data = makeCreatedData();
+
+    store.checkAndRecord(CONTRACT_ID, PROPOSAL_ID, data, BASE_LEDGER);
+    // age = BASE_LEDGER + 100 - BASE_LEDGER = 100, which equals window → still a duplicate
+    const result = store.checkAndRecord(CONTRACT_ID, "proposal-002", data, BASE_LEDGER + 100);
+    assert.equal(result, false);
+  });
+
+  await t.test("allows identical proposal one ledger after window expires", () => {
+    const store = new ProposalFingerprintStore(100);
+    const data = makeCreatedData();
+
+    store.checkAndRecord(CONTRACT_ID, PROPOSAL_ID, data, BASE_LEDGER);
+    // age = 101 > 100 → outside window
+    const result = store.checkAndRecord(CONTRACT_ID, "proposal-002", data, BASE_LEDGER + 101);
+    assert.equal(result, true);
+  });
+
+  await t.test("allows proposals with different content fields concurrently", () => {
+    const store = new ProposalFingerprintStore(100);
+
+    const dataA = makeCreatedData({ amount: "1000" });
+    const dataB = makeCreatedData({ amount: "2000" }); // different amount → different fingerprint
+
+    const r1 = store.checkAndRecord(CONTRACT_ID, "p-1", dataA, BASE_LEDGER);
+    const r2 = store.checkAndRecord(CONTRACT_ID, "p-2", dataB, BASE_LEDGER);
+
+    assert.equal(r1, true);
+    assert.equal(r2, true);
+  });
+
+  await t.test("different contractId produces a different fingerprint", () => {
+    const store = new ProposalFingerprintStore(100);
+    const data = makeCreatedData();
+
+    store.checkAndRecord("CONTRACT-A", PROPOSAL_ID, data, BASE_LEDGER);
+    // Same data but different contract → should be allowed
+    const result = store.checkAndRecord("CONTRACT-B", "proposal-002", data, BASE_LEDGER + 1);
+    assert.equal(result, true);
+  });
+
+  await t.test("undefined description treated same as empty string (stable fingerprint)", () => {
+    const store = new ProposalFingerprintStore(100);
+
+    const withUndefined = makeCreatedData({ description: undefined });
+    const withEmpty = makeCreatedData({ description: "" });
+
+    // Both should hash to the same fingerprint
+    store.checkAndRecord(CONTRACT_ID, "p-1", withUndefined, BASE_LEDGER);
+    const result = store.checkAndRecord(CONTRACT_ID, "p-2", withEmpty, BASE_LEDGER + 1);
+    assert.equal(result, false, "undefined and empty description must share fingerprint");
+  });
+});
+
+// ─── Window expiry ─────────────────────────────────────────────────────────
+
+test("ProposalFingerprintStore - window expiry", async (t) => {
+  await t.test("refreshes entry after window expires, then blocks again within new window", () => {
+    const WINDOW = 100;
+    const store = new ProposalFingerprintStore(WINDOW);
+    const data = makeCreatedData();
+
+    // First submission at ledger 1000
+    assert.equal(store.checkAndRecord(CONTRACT_ID, "p-1", data, 1000), true);
+
+    // Re-submission at ledger 1102 (age=102, outside window) → allowed, entry refreshed
+    assert.equal(store.checkAndRecord(CONTRACT_ID, "p-2", data, 1102), true);
+
+    // Now within 100 ledgers of the refreshed entry (ledger 1150, age=48) → duplicate
+    assert.equal(store.checkAndRecord(CONTRACT_ID, "p-3", data, 1150), false);
+  });
+
+  await t.test("7-day default window is approximately 120960 ledgers", () => {
+    // 7 days × 24 h × 60 min × 60 s / 5 s per ledger = 120,960
+    const SECONDS_PER_LEDGER = 5;
+    const LEDGERS_PER_DAY = (24 * 60 * 60) / SECONDS_PER_LEDGER;
+    assert.equal(DEFAULT_FINGERPRINT_WINDOW_LEDGERS, Math.round(LEDGERS_PER_DAY * 7));
+  });
+});
+
+// ─── Old fingerprint re-use ────────────────────────────────────────────────
+
+test("ProposalFingerprintStore - old fingerprint re-use", async (t) => {
+  await t.test("identical proposal submitted 6 months ago is allowed today", () => {
+    // 6 months ≈ 180 days ≈ 3,110,400 ledgers — well outside the 7-day window
+    const WINDOW = DEFAULT_FINGERPRINT_WINDOW_LEDGERS; // 120,960
+    const store = new ProposalFingerprintStore(WINDOW);
+    const data = makeCreatedData();
+
+    const SIX_MONTHS_LEDGERS = 3_110_400;
+    const originalLedger = 500_000;
+    const currentLedger = originalLedger + SIX_MONTHS_LEDGERS;
+
+    // Record the old proposal
+    store.checkAndRecord(CONTRACT_ID, "old-proposal", data, originalLedger);
+
+    // Same proposal submitted today — must be allowed
+    const result = store.checkAndRecord(CONTRACT_ID, "new-proposal", data, currentLedger);
+    assert.equal(result, true, "identical proposal after 6 months must be allowed");
+  });
+
+  await t.test("identical proposal submitted 6 days ago is still blocked", () => {
+    const WINDOW = DEFAULT_FINGERPRINT_WINDOW_LEDGERS; // 120,960
+    const store = new ProposalFingerprintStore(WINDOW);
+    const data = makeCreatedData();
+
+    const SIX_DAYS_LEDGERS = 103_680; // 6 × 24 × 60 × 60 / 5
+    const originalLedger = 500_000;
+    const currentLedger = originalLedger + SIX_DAYS_LEDGERS;
+
+    store.checkAndRecord(CONTRACT_ID, "p-1", data, originalLedger);
+    const result = store.checkAndRecord(CONTRACT_ID, "p-2", data, currentLedger);
+    assert.equal(result, false, "identical proposal within 7-day window must be blocked");
+  });
+});
+
+// ─── pruneExpired ──────────────────────────────────────────────────────────
+
+test("ProposalFingerprintStore - pruneExpired", async (t) => {
+  await t.test("removes entries outside the window", () => {
+    const WINDOW = 100;
+    const store = new ProposalFingerprintStore(WINDOW);
+
+    // Record at ledger 1000
+    store.checkAndRecord(CONTRACT_ID, "p-old", makeCreatedData({ amount: "1" }), 1000);
+    assert.equal(store.size, 1);
+
+    // Prune at ledger 1200: entry at ledger 1000, cutoff = 1200 - 100 = 1100 > 1000 → pruned
+    const pruned = store.pruneExpired(1200);
+    assert.equal(pruned, 1);
+    assert.equal(store.size, 0);
+  });
+
+  await t.test("keeps entries within the window", () => {
+    const WINDOW = 100;
+    const store = new ProposalFingerprintStore(WINDOW);
+
+    store.checkAndRecord(CONTRACT_ID, "p-recent", makeCreatedData({ amount: "2" }), 1050);
+    store.checkAndRecord(CONTRACT_ID, "p-old", makeCreatedData({ amount: "1" }), 900);
+
+    // At ledger 1000, cutoff = 900; entry at 900 is NOT < 900 → kept
+    const pruned = store.pruneExpired(1000);
+    // cutoff = 1000 - 100 = 900, so entry.ledger < 900 required to prune
+    // entry at 900: 900 < 900 is false → not pruned
+    assert.equal(pruned, 0);
+    assert.equal(store.size, 2);
+  });
+
+  await t.test("only prunes strictly-expired entries", () => {
+    const WINDOW = 100;
+    const store = new ProposalFingerprintStore(WINDOW);
+
+    store.checkAndRecord(CONTRACT_ID, "p-1", makeCreatedData({ amount: "1" }), 900);
+    store.checkAndRecord(CONTRACT_ID, "p-2", makeCreatedData({ amount: "2" }), 950);
+    store.checkAndRecord(CONTRACT_ID, "p-3", makeCreatedData({ amount: "3" }), 1050);
+
+    // At ledger 1100: cutoff = 1000; entries < 1000 are pruned → 900 is pruned
+    const pruned = store.pruneExpired(1100);
+    assert.equal(pruned, 1);
+    assert.equal(store.size, 2);
+  });
+
+  await t.test("returns 0 when nothing to prune", () => {
+    const store = new ProposalFingerprintStore(100);
+    store.checkAndRecord(CONTRACT_ID, "p-1", makeCreatedData(), BASE_LEDGER);
+    const pruned = store.pruneExpired(BASE_LEDGER + 50);
+    assert.equal(pruned, 0);
+  });
+
+  await t.test("returns 0 on empty store", () => {
+    const store = new ProposalFingerprintStore(100);
+    const pruned = store.pruneExpired(BASE_LEDGER);
+    assert.equal(pruned, 0);
+  });
+});
+
+// ─── Consumer integration ──────────────────────────────────────────────────
+
+test("ProposalActivityConsumer fingerprint integration", async (t) => {
+  const { ProposalActivityConsumer } = await import("./consumer.js");
+  const { EventType } = await import("../events/types.js");
+  const { ProposalActivityType: PAT } = await import("./types.js");
+  type NE = import("../events/types.js").NormalizedEvent;
+
+  function makeCreatedEvent(
+    proposalId: string,
+    ledger: number,
+    overrides: Partial<Record<string, unknown>> = {},
+  ): NE {
+    return {
+      type: EventType.PROPOSAL_CREATED,
+      data: {
+        proposalId,
+        proposer: "GPROPOSER",
+        recipient: "GRECIPIENT",
+        token: "CTOKEN",
+        amount: "1000",
+        insuranceAmount: "100",
+        description: "Test",
+        ...overrides,
+      },
+      metadata: {
+        id: `event-${proposalId}-${ledger}`,
+        contractId: CONTRACT_ID,
+        ledger,
+        ledgerClosedAt: new Date().toISOString(),
+      },
+    };
+  }
+
+  await t.test("passes first unique PROPOSAL_CREATED through", async () => {
+    const saved: unknown[] = [];
+    const consumer = new ProposalActivityConsumer({ fingerprintWindowLedgers: 100 });
+    consumer.setPersistence({
+      save: async (r) => { saved.push(r); },
+      saveBatch: async () => {},
+      getByProposalId: async () => [],
+      getByContractId: async () => [],
+      getSummary: async () => null,
+    });
+
+    await consumer.process(makeCreatedEvent("p-1", 1000));
+    assert.equal(saved.length, 1);
+  });
+
+  await t.test("drops duplicate PROPOSAL_CREATED within window", async () => {
+    const saved: unknown[] = [];
+    const consumer = new ProposalActivityConsumer({ fingerprintWindowLedgers: 100 });
+    consumer.setPersistence({
+      save: async (r) => { saved.push(r); },
+      saveBatch: async () => {},
+      getByProposalId: async () => [],
+      getByContractId: async () => [],
+      getSummary: async () => null,
+    });
+
+    // First — allowed
+    await consumer.process(makeCreatedEvent("p-1", 1000));
+    // Same payload, same contract, within window — dropped
+    await consumer.process(makeCreatedEvent("p-2", 1050));
+    assert.equal(saved.length, 1);
+  });
+
+  await t.test("allows identical PROPOSAL_CREATED after window expires", async () => {
+    const saved: unknown[] = [];
+    const consumer = new ProposalActivityConsumer({ fingerprintWindowLedgers: 100 });
+    consumer.setPersistence({
+      save: async (r) => { saved.push(r); },
+      saveBatch: async () => {},
+      getByProposalId: async () => [],
+      getByContractId: async () => [],
+      getSummary: async () => null,
+    });
+
+    await consumer.process(makeCreatedEvent("p-1", 1000));
+    // age = 101 > 100 → allowed
+    await consumer.process(makeCreatedEvent("p-2", 1101));
+    assert.equal(saved.length, 2);
+  });
+
+  await t.test("does not fingerprint non-CREATED events", async () => {
+    const saved: unknown[] = [];
+    const consumer = new ProposalActivityConsumer({ fingerprintWindowLedgers: 100 });
+    consumer.setPersistence({
+      save: async (r) => { saved.push(r); },
+      saveBatch: async () => {},
+      getByProposalId: async () => [],
+      getByContractId: async () => [],
+      getSummary: async () => null,
+    });
+
+    const approvedEvent: NE = {
+      type: EventType.PROPOSAL_APPROVED,
+      data: { proposalId: "p-1", voter: "GVOTER", votesFor: "10", votesAgainst: "0", votesAbstain: "0" },
+      metadata: { id: "e-1", contractId: CONTRACT_ID, ledger: 1000, ledgerClosedAt: new Date().toISOString() },
+    };
+
+    // Process the same approved event twice — fingerprint store is not consulted
+    await consumer.process(approvedEvent);
+    // Note: event-level dedup (processedEventIds) will catch the exact duplicate,
+    // so change the key slightly
+    const approvedEvent2 = { ...approvedEvent, metadata: { ...approvedEvent.metadata, id: "e-2" } };
+    await consumer.process(approvedEvent2);
+
+    assert.equal(saved.length, 2, "APPROVED events should never be dropped by fingerprint store");
+  });
+
+  await t.test("getFingerprintStore exposes the internal store", () => {
+    const consumer = new ProposalActivityConsumer({ fingerprintWindowLedgers: 500 });
+    assert.equal(consumer.getFingerprintStore().window, 500);
+  });
+});

--- a/backend/src/modules/proposals/proposal-fingerprint.store.ts
+++ b/backend/src/modules/proposals/proposal-fingerprint.store.ts
@@ -1,0 +1,170 @@
+/**
+ * Proposal Fingerprint Store
+ *
+ * Uses SHA-256 to fingerprint incoming PROPOSAL_CREATED payloads and
+ * rejects duplicates only when the original fingerprint was recorded
+ * within a configurable ledger window.
+ *
+ * Motivation: a fingerprint recorded 6 months ago must not block a
+ * legitimate re-submission today. Operators set `windowLedgers` to
+ * control how long a fingerprint "holds" (default: 120,960 ≈ 7 days
+ * at ~5 s/ledger on Stellar).
+ */
+
+import { createHash } from "node:crypto";
+import { createLogger } from "../../shared/logging/logger.js";
+import type { ProposalCreatedActivityData } from "./types.js";
+
+/**
+ * The fields that define a proposal's content identity.
+ * Changes to any of these produce a different fingerprint.
+ */
+interface FingerprintableFields {
+  readonly contractId: string;
+  readonly proposer: string;
+  readonly recipient: string;
+  readonly token: string;
+  readonly amount: string;
+  readonly description?: string;
+}
+
+/**
+ * Internal record stored per fingerprint.
+ */
+interface FingerprintEntry {
+  /** Ledger at which this fingerprint was first seen. */
+  readonly ledger: number;
+  /** proposalId associated with the original event (for diagnostics). */
+  readonly proposalId: string;
+}
+
+/** Default duplicate window: 120,960 ledgers ≈ 7 days at ~5 s per ledger. */
+export const DEFAULT_FINGERPRINT_WINDOW_LEDGERS = 120_960;
+
+/**
+ * ProposalFingerprintStore
+ *
+ * Tracks SHA-256 fingerprints of PROPOSAL_CREATED payloads.
+ * A fingerprint collision is only considered a duplicate when the
+ * original was seen within `windowLedgers` of the current ledger.
+ *
+ * Once a fingerprint ages out of the window it is eligible for
+ * re-use, allowing identical proposals to be legitimately
+ * re-submitted after the cooling-off period.
+ */
+export class ProposalFingerprintStore {
+  private readonly logger = createLogger("proposal-fingerprint-store");
+  private readonly store = new Map<string, FingerprintEntry>();
+  private readonly windowLedgers: number;
+
+  constructor(windowLedgers: number = DEFAULT_FINGERPRINT_WINDOW_LEDGERS) {
+    if (!Number.isInteger(windowLedgers) || windowLedgers < 1) {
+      throw new RangeError(
+        `windowLedgers must be a positive integer, got ${windowLedgers}`,
+      );
+    }
+    this.windowLedgers = windowLedgers;
+  }
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /**
+   * Returns `true` and records the fingerprint when the proposal is new
+   * (no prior fingerprint, or the prior one is outside the window).
+   *
+   * Returns `false` when an identical proposal was seen within the
+   * current ledger window — i.e. it is a duplicate.
+   *
+   * @param contractId  Contract that emitted the event
+   * @param proposalId  ID of the incoming proposal (for diagnostics)
+   * @param data        PROPOSAL_CREATED activity data
+   * @param ledger      Ledger number of the incoming event
+   */
+  public checkAndRecord(
+    contractId: string,
+    proposalId: string,
+    data: ProposalCreatedActivityData,
+    ledger: number,
+  ): boolean {
+    const fp = this.computeFingerprint({ contractId, ...data });
+    const existing = this.store.get(fp);
+
+    if (existing !== undefined) {
+      const age = ledger - existing.ledger;
+      if (age <= this.windowLedgers) {
+        this.logger.debug(
+          `duplicate fingerprint detected: proposalId=${proposalId} ` +
+            `original=${existing.proposalId} age=${age} window=${this.windowLedgers}`,
+        );
+        return false; // within window → reject as duplicate
+      }
+
+      // Outside window — allow and refresh the entry
+      this.logger.debug(
+        `fingerprint outside window, allowing: proposalId=${proposalId} ` +
+          `age=${age} window=${this.windowLedgers}`,
+      );
+    }
+
+    this.store.set(fp, { ledger, proposalId });
+    return true;
+  }
+
+  /**
+   * Removes all fingerprint entries whose ledger is older than
+   * `currentLedger - windowLedgers`. Call periodically to bound memory.
+   *
+   * @returns Number of entries pruned.
+   */
+  public pruneExpired(currentLedger: number): number {
+    const cutoff = currentLedger - this.windowLedgers;
+    let pruned = 0;
+
+    for (const [fp, entry] of this.store) {
+      if (entry.ledger < cutoff) {
+        this.store.delete(fp);
+        pruned++;
+      }
+    }
+
+    if (pruned > 0) {
+      this.logger.debug(`pruned ${pruned} expired fingerprint(s)`);
+    }
+
+    return pruned;
+  }
+
+  /** Current number of fingerprints held in memory. */
+  public get size(): number {
+    return this.store.size;
+  }
+
+  /** Configured window in ledgers. */
+  public get window(): number {
+    return this.windowLedgers;
+  }
+
+  /** Clears all stored fingerprints. Useful between tests. */
+  public clear(): void {
+    this.store.clear();
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  /**
+   * Produces a stable, deterministic SHA-256 hex digest of the proposal's
+   * content-defining fields. Field order is fixed to ensure consistency.
+   */
+  private computeFingerprint(fields: FingerprintableFields): string {
+    const canonical = JSON.stringify({
+      contractId: fields.contractId,
+      proposer: fields.proposer,
+      recipient: fields.recipient,
+      token: fields.token,
+      amount: fields.amount,
+      description: fields.description ?? "",
+    });
+
+    return createHash("sha256").update(canonical, "utf8").digest("hex");
+  }
+}


### PR DESCRIPTION
closes #1346
closes #1347
closes #1352
closes #1348

# Proposal Fingerprint Deduplication

## Problem

The proposal consumer had no time-aware duplicate detection for `PROPOSAL_CREATED` events. A SHA-256 fingerprint recorded 6 months ago would permanently block an identical but legitimate re-submission today.

## Solution

Introduced a ledger-window-based fingerprint store. A collision is only treated as a duplicate when the original fingerprint was recorded **within the last N ledgers**. Once that window passes, the fingerprint expires and the same proposal content is allowed through again.

Default window: **120,960 ledgers ≈ 7 days** at ~5 s/ledger on Stellar.

---

## Files Changed

### New: `src/modules/proposals/proposal-fingerprint.store.ts`

Core implementation. Key behaviours:

- Computes a stable SHA-256 digest over `{ contractId, proposer, recipient, token, amount, description }` — field order is fixed so the hash is deterministic.
- `checkAndRecord(contractId, proposalId, data, ledger)` — returns `true` (allow) or `false` (duplicate). On expiry it refreshes the entry and returns `true`.
- `pruneExpired(currentLedger)` — removes entries older than `currentLedger - windowLedgers`. Call periodically to bound memory.
- Constructor throws `RangeError` on invalid `windowLedgers` (zero, negative, non-integer).

```
DEFAULT_FINGERPRINT_WINDOW_LEDGERS = 120_960
```

### Modified: `src/modules/proposals/consumer.ts`

- Imported `ProposalFingerprintStore`.
- Added `fingerprintStore` as a private field, constructed from `options.fingerprintWindowLedgers` (falls back to the default).
- In `toRecord()`: after mapping activity data, if `activityType === CREATED`, calls `checkAndRecord`. Returns `null` (drops the event) on collision within the window, and increments the `vaultdao_proposals_fingerprint_duplicates_total` metric counter.
- Exposed `getFingerprintStore()` for diagnostics and testing.
- Added `fingerprintWindowLedgers` option to the constructor and `createProposalConsumer` factory.

### Modified: `src/config/env.ts`

Added `proposalFingerprintWindowLedgers` to `BackendEnv`:

| Field | Env var | Default |
|---|---|---|
| `proposalFingerprintWindowLedgers` | `PROPOSAL_FINGERPRINT_WINDOW_LEDGERS` | `120_960` |

Updated both `loadEnv()` and `createTestEnv()`.

Also fixed a pre-existing syntax error: `wsMaxSubscriptionsPerClient` was missing its closing `)` in the `readPort` call.

### New: `src/modules/proposals/proposal-fingerprint.store.test.ts`

Full test coverage split across five groups:

- **Constructor** — valid window, custom window, RangeError on zero / negative / non-integer.
- **Basic allow / reject** — first-seen allowed, duplicate within window rejected, exact boundary rejected, one ledger past boundary allowed, different content fields co-exist, different contract IDs produce different fingerprints, `undefined` vs `""` description produces the same hash.
- **Window expiry** — entry refreshes after window expires then blocks again; default 120,960 value verified against the 7-day formula.
- **Old fingerprint re-use** — 6-month-old fingerprint is allowed through; 6-day-old fingerprint is still blocked.
- **`pruneExpired`** — removes strictly-expired entries, keeps in-window entries, returns correct prune count, handles empty store.
- **Consumer integration** — end-to-end: first unique CREATED passes, duplicate within window is dropped, duplicate after window expiry passes, non-CREATED events bypass the store entirely, `getFingerprintStore()` returns the configured window.

---

## Operator Configuration

Set the env variable before starting the backend:

```bash
# Extend window to 14 days (~241,920 ledgers)
PROPOSAL_FINGERPRINT_WINDOW_LEDGERS=241920

# Disable effective deduplication (1-ledger window — not recommended)
PROPOSAL_FINGERPRINT_WINDOW_LEDGERS=1
```

---

## Metrics

| Counter | Labels | Description |
|---|---|---|
| `vaultdao_proposals_fingerprint_duplicates_total` | — | Incremented each time a CREATED event is dropped as a fingerprint duplicate |
