### PR TITLE
Make batch execution atomic: simulate before committing, abort on any…

### DIFF
--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -368,6 +368,12 @@ pub enum VaultError {
     // =========================================================
     /// Gas-price oracle contract returned a zero or negative price
     GasPriceOracleInvalidPrice = 723,
+
+    // =========================================================
+    // Issue #1361: Atomic Batch Rollback
+    // =========================================================
+    /// A transfer failed during batch commit despite passing pre-commit simulation
+    BatchCommitFailed = 1120,
 }
 
 // Compatibility markers for CI source checks:

--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -443,11 +443,14 @@ pub fn emit_batch_executed(env: &Env, executor: &Address, executed_count: u32, f
     );
 }
 
-/// Emit when a batch execution partially failed and was rolled back
-pub fn emit_batch_rolled_back(env: &Env, executor: &Address, rolled_back_count: u32) {
+/// Emit when a batch execution failed and was rolled back / aborted.
+///
+/// `reason` is the `VaultError` discriminant (as u32) that caused the abort,
+/// so off-chain indexers can surface *why* the batch didn't commit.
+pub fn emit_batch_rolled_back(env: &Env, executor: &Address, rolled_back_count: u32, reason: u32) {
     env.events().publish(
         (Symbol::new(env, "batch_rolled_back"),),
-        (executor.clone(), rolled_back_count),
+        (executor.clone(), rolled_back_count, reason),
     );
 }
 

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -2138,8 +2138,16 @@ impl VaultDAO {
         Ok(())
     }
 
-    /// Execute a batch transaction atomically: either all proposals succeed or
-    /// any partial progress is attempted to be reversed and the batch is marked RolledBack.
+    /// Execute a batch transaction atomically: every transfer is validated and
+    /// simulated against current vault balances *before* any funds move, so a
+    /// batch either commits in full or aborts with nothing executed.
+    ///
+    /// Only if every simulated transfer would succeed does phase 3 actually
+    /// move funds. A commit-phase failure at that point is an unexpected
+    /// deviation from the simulation (e.g. a recipient deauthorized mid-flight)
+    /// and falls back to the previous best-effort reverse-transfer rollback,
+    /// which is not guaranteed to succeed since it requires recipient
+    /// cooperation - that fallback path is the exception, not the norm.
     pub fn execute_batch(env: Env, executor: Address, batch_id: u64) -> Result<(), VaultError> {
         executor.require_auth();
 
@@ -2153,46 +2161,83 @@ impl VaultDAO {
         batch.status = BatchStatus::Executing;
         storage::set_batch(&env, &batch);
 
-        let mut executed_transfers: Vec<(u64, Address, Address, i128)> = Vec::new(&env); // (proposal_id, token, recipient, amount)
-        let mut executed_count: u32 = 0;
-        let mut failed_count: u32 = 0;
-        let mut first_failure_reason: Option<VaultError> = None;
+        let mut planned_transfers: Vec<(u64, Address, Address, i128)> = Vec::new(&env); // (proposal_id, token, recipient, amount)
+        let mut abort_reason: Option<VaultError> = None;
 
-        // Phase 1: Validate all proposals before executing any transfers
+        // Phase 1: Validate every proposal and collect its planned transfer.
+        // Nothing is executed here - this only decides whether the batch is
+        // eligible to proceed to simulation.
         for i in 0..batch.proposal_ids.len() {
             let pid = batch.proposal_ids.get(i).unwrap();
             let proposal = match storage::get_proposal(&env, pid) {
                 Ok(p) => p,
                 Err(e) => {
-                    first_failure_reason = Some(e);
-                    failed_count += 1;
+                    abort_reason = Some(e);
                     break;
                 }
             };
 
             if proposal.status != ProposalStatus::Approved {
-                first_failure_reason = Some(VaultError::ProposalNotApproved);
-                failed_count += 1;
+                abort_reason = Some(VaultError::ProposalNotApproved);
                 break;
             }
 
             let current_ledger = env.ledger().sequence() as u64;
             if proposal.unlock_ledger > 0 && current_ledger < proposal.unlock_ledger {
-                first_failure_reason = Some(VaultError::TimelockNotExpired);
-                failed_count += 1;
+                abort_reason = Some(VaultError::TimelockNotExpired);
                 break;
             }
 
             // Ensure dependencies executed
             if let Err(e) = Self::ensure_dependencies_executable(&env, &proposal) {
-                first_failure_reason = Some(e);
-                failed_count += 1;
+                abort_reason = Some(e);
                 break;
+            }
+
+            planned_transfers.push_back((
+                pid,
+                proposal.token.clone(),
+                proposal.recipient.clone(),
+                proposal.amount,
+            ));
+        }
+
+        // Phase 2: Simulate - verify the vault holds enough of each token to
+        // cover every planned transfer, aggregated per token since several
+        // proposals in the same batch may draw on the same token balance.
+        // This never moves funds; it only reads current balances.
+        if abort_reason.is_none() {
+            let mut required_per_token: Vec<(Address, i128)> = Vec::new(&env);
+
+            for i in 0..planned_transfers.len() {
+                let (_, token_addr, _, amount) = planned_transfers.get(i).unwrap();
+                let mut found = false;
+                for j in 0..required_per_token.len() {
+                    let (existing_token, existing_amount) = required_per_token.get(j).unwrap();
+                    if existing_token == token_addr {
+                        required_per_token.set(j, (existing_token, existing_amount + amount));
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    required_per_token.push_back((token_addr, amount));
+                }
+            }
+
+            for i in 0..required_per_token.len() {
+                let (token_addr, required_amount) = required_per_token.get(i).unwrap();
+                if token::get_vault_balance(&env, &token_addr) < required_amount {
+                    abort_reason = Some(VaultError::InsufficientBalance);
+                    break;
+                }
             }
         }
 
-        // If validation failed, mark batch as failed without executing anything
-        if failed_count > 0 {
+        // If validation or simulation failed, abort the entire batch without
+        // executing a single transfer - there is nothing to roll back.
+        if let Some(reason) = abort_reason {
+            let failed_count = batch.proposal_ids.len();
             batch.status = BatchStatus::RolledBack;
             batch.executed_count = 0;
             batch.failed_count = failed_count;
@@ -2205,41 +2250,37 @@ impl VaultDAO {
                     failed_count,
                 },
             );
-            events::emit_batch_rolled_back(&env, &executor, 0);
-            return first_failure_reason.map_or(Ok(()), Err);
+            events::emit_batch_rolled_back(&env, &executor, 0, reason as u32);
+            return Err(reason);
         }
 
-        // Phase 2: Execute all transfers atomically
-        for i in 0..batch.proposal_ids.len() {
-            let pid = batch.proposal_ids.get(i).unwrap();
-            let mut proposal = storage::get_proposal(&env, pid).unwrap(); // Already validated above
+        // Phase 3: Every proposal validated and every transfer simulated
+        // successfully - commit them all.
+        let mut executed_transfers: Vec<(u64, Address, Address, i128)> = Vec::new(&env);
+        let mut executed_count: u32 = 0;
+        let mut commit_failure: Option<VaultError> = None;
 
-            // Attempt transfer using token::try_transfer to avoid panicking
-            if token::try_transfer(&env, &proposal.token, &proposal.recipient, proposal.amount)
-                .is_ok()
-            {
-                // Mark executed and store transfer details for potential rollback
+        for i in 0..planned_transfers.len() {
+            let (pid, token_addr, recipient, amount) = planned_transfers.get(i).unwrap();
+
+            if token::try_transfer(&env, &token_addr, &recipient, amount).is_ok() {
+                let mut proposal = storage::get_proposal(&env, pid).unwrap(); // validated above
                 proposal.status = ProposalStatus::Executed;
                 proposal.execution_ledger = env.ledger().sequence() as u64;
                 storage::set_proposal(&env, &proposal);
-                executed_transfers.push_back((
-                    pid,
-                    proposal.token.clone(),
-                    proposal.recipient.clone(),
-                    proposal.amount,
-                ));
+                executed_transfers.push_back((pid, token_addr.clone(), recipient.clone(), amount));
                 executed_count += 1;
                 storage::create_audit_entry(&env, AuditAction::ExecuteProposal, &executor, pid);
             } else {
-                // Transfer failed - initiate rollback
-                failed_count += 1;
+                // Unexpected: simulation predicted this transfer would
+                // succeed. Stop committing further transfers and unwind
+                // whatever this run already moved.
+                commit_failure = Some(VaultError::BatchCommitFailed);
                 break;
             }
         }
 
-        // Phase 3: Handle success or rollback
-        if failed_count == 0 {
-            // All transfers succeeded
+        if commit_failure.is_none() {
             batch.status = BatchStatus::Completed;
             batch.executed_count = executed_count;
             batch.failed_count = 0;
@@ -2249,31 +2290,24 @@ impl VaultDAO {
                 batch.id,
                 &BatchExecutionResult {
                     executed_count,
-                    failed_count,
+                    failed_count: 0,
                 },
             );
-            events::emit_batch_executed(&env, &executor, executed_count, failed_count);
+            events::emit_batch_executed(&env, &executor, executed_count, 0);
             return Ok(());
         }
 
-        // Partial failure: attempt rollback of completed transfers
+        // Best-effort rollback of the transfers this run already committed.
+        // Not guaranteed to succeed - it requires the recipient to authorize
+        // the reverse transfer - so the rollback state is persisted for
+        // off-chain reconciliation regardless of outcome.
         let mut rollback_entries: Vec<(Address, i128)> = Vec::new(&env);
-        let mut _rollback_successful = false;
 
         for j in 0..executed_transfers.len() {
             let (pid, token_addr, recipient, amount) = executed_transfers.get(j).unwrap();
-
-            // Record the recipient and amount for rollback state
             rollback_entries.push_back((recipient.clone(), amount));
 
-            // Attempt to transfer from the recipient back to vault
-            // This requires the recipient to have authorized the transfer or
-            // the token contract to allow this operation
-            if token::transfer_from_vault(&env, &token_addr, &recipient, amount).is_err() {
-                _rollback_successful = false;
-                // Continue attempting other rollbacks even if one fails
-            } else {
-                // Reset proposal status to Approved to reflect successful rollback
+            if token::transfer_from_vault(&env, &token_addr, &recipient, amount).is_ok() {
                 if let Ok(mut proposal) = storage::get_proposal(&env, pid) {
                     proposal.status = ProposalStatus::Approved;
                     storage::set_proposal(&env, &proposal);
@@ -2281,7 +2315,7 @@ impl VaultDAO {
             }
         }
 
-        // Update batch status and store rollback information
+        let failed_count = (planned_transfers.len() - executed_count) as u32;
         batch.status = BatchStatus::RolledBack;
         batch.executed_count = executed_count;
         batch.failed_count = failed_count;
@@ -2296,10 +2330,16 @@ impl VaultDAO {
             },
         );
 
-        events::emit_batch_rolled_back(&env, &executor, executed_count);
+        events::emit_batch_rolled_back(
+            &env,
+            &executor,
+            executed_count,
+            commit_failure.unwrap() as u32,
+        );
 
-        // Return success even if rollback partially failed - the rollback state is persisted
-        // for off-chain reconciliation
+        // Return success even though the commit-phase rollback may have
+        // partially failed - the rollback state is persisted above for
+        // off-chain reconciliation.
         Ok(())
     }
 

--- a/contracts/vault/src/storage.rs
+++ b/contracts/vault/src/storage.rs
@@ -4380,6 +4380,9 @@ pub fn increment_subscription_usage(env: &Env, subscription_id: u64, metric: &Sy
     let current = usage.get(metric.clone()).unwrap_or(0);
     usage.set(metric.clone(), current + amount);
     set_subscription_usage(env, subscription_id, &usage);
+}
+
+// ============================================================================
 // Issue #1414: Reentrancy Guard for Proposal Execution
 // ============================================================================
 

--- a/contracts/vault/src/test_regressions.rs
+++ b/contracts/vault/src/test_regressions.rs
@@ -18,6 +18,8 @@ fn init_config(
 ) -> InitConfig {
     InitConfig {
         veto_window_ledgers: 0,
+        approval_timeout_ledgers: 0,
+        arbitration_timeout_ledgers: 0,
         whitelist_mode: false,
         grace_period_ledgers: 100,
         vote_weight: crate::types::VoteWeight::Flat,
@@ -542,10 +544,11 @@ fn test_execute_before_timelock_expires_fails() {
     let result = client.try_execute_proposal(&signer, &proposal_id);
     assert_eq!(result, Err(Ok(VaultError::TimelockNotExpired)));
 }
-/// Test atomic multi-token batch execution with rollback functionality.
-/// Verifies all-or-nothing semantics and proper rollback state persistence.
+/// Test atomic multi-token batch execution success path.
+/// Verifies all proposals in a batch execute together when every transfer
+/// simulates successfully.
 #[test]
-fn test_atomic_batch_execution_with_rollback() {
+fn test_atomic_batch_execution_success() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_sequence_number(100);
@@ -623,7 +626,6 @@ fn test_atomic_batch_execution_with_rollback() {
     assert_eq!(batch.status, BatchStatus::Pending);
     assert_eq!(batch.proposal_ids.len(), 3);
 
-    // Test Case 1: Successful atomic execution
     // Record initial balances
     let initial_vault_balance1 =
         soroban_sdk::token::Client::new(&env, &token1).balance(&contract_id);
@@ -680,101 +682,236 @@ fn test_atomic_batch_execution_with_rollback() {
     let result = batch_result.unwrap();
     assert_eq!(result.executed_count, 3);
     assert_eq!(result.failed_count, 0);
+}
 
-    // Test Case 2: Batch execution with rollback
-    // Create another batch where one proposal will fail due to insufficient balance
-    // We'll create a third token with very little balance to force a failure
-    let token3 = env
+/// Issue #1361: A batch where one proposal would fail (insufficient vault
+/// balance for its token) must abort entirely *before* any transfer commits -
+/// no partial execution, and therefore nothing to roll back.
+///
+/// This is the exact scenario the bug report described: previously, the
+/// transfer(s) preceding the failing one were executed for real and only a
+/// best-effort (and unreliable) reverse-transfer was attempted afterwards.
+/// With pre-commit simulation, the vault balance shortfall is detected up
+/// front and no funds ever move.
+#[test]
+fn test_batch_simulation_failure_aborts_without_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_sequence_number(100);
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasurer = Address::generate(&env);
+    let recipient1 = Address::generate(&env);
+    let recipient2 = Address::generate(&env);
+
+    let token1 = env
         .register_stellar_asset_contract_v2(admin.clone())
         .address();
-    StellarAssetClient::new(&env, &token3).mint(&contract_id, &100); // Only 100 tokens
+    let token2 = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
 
-    let mut transfers2 = Vec::new(&env);
-    transfers2.push_back(TransferDetails {
+    StellarAssetClient::new(&env, &token1).mint(&contract_id, &100_000);
+    StellarAssetClient::new(&env, &token2).mint(&contract_id, &100); // Only 100 tokens - insufficient
+
+    let mut signers = Vec::new(&env);
+    signers.push_back(admin.clone());
+    signers.push_back(treasurer.clone());
+
+    let config = init_config(&env, signers, 1, ThresholdStrategy::Fixed);
+    client.initialize(&admin, &config);
+    client.set_role(&admin, &treasurer, &Role::Treasurer);
+
+    let mut transfers = Vec::new(&env);
+    transfers.push_back(TransferDetails {
         recipient: recipient1.clone(),
         token: token1.clone(),
-        amount: 500, // This should succeed
+        amount: 500, // Vault can easily cover this alone
     });
-    transfers2.push_back(TransferDetails {
+    transfers.push_back(TransferDetails {
         recipient: recipient2.clone(),
-        token: token3.clone(),
-        amount: 1000, // This will fail - token3 only has 100 tokens
+        token: token2.clone(),
+        amount: 1000, // Vault only holds 100 of token2 - must fail simulation
     });
 
-    let proposal_ids2 = client.batch_propose_transfers(
+    let proposal_ids = client.batch_propose_transfers(
         &treasurer,
-        &transfers2,
+        &transfers,
         &Priority::Normal,
         &Vec::new(&env),
         &ConditionLogic::And,
         &0i128,
     );
+    assert_eq!(proposal_ids.len(), 2);
 
-    // Approve all proposals
-    for i in 0..proposal_ids2.len() {
-        let pid = proposal_ids2.get(i).unwrap();
+    for i in 0..proposal_ids.len() {
+        let pid = proposal_ids.get(i).unwrap();
         client.approve_proposal(&admin, &pid);
     }
 
-    let batch_id2 = 2u64;
-    let batch2 = client.get_batch(&batch_id2);
-    assert_eq!(batch2.status, BatchStatus::Pending);
+    let batch_id = 1u64;
 
-    // Record balances before failed batch execution
-    let pre_fail_vault_balance1 =
+    let pre_vault_balance1 = soroban_sdk::token::Client::new(&env, &token1).balance(&contract_id);
+    let pre_vault_balance2 = soroban_sdk::token::Client::new(&env, &token2).balance(&contract_id);
+    let pre_recipient1_balance =
+        soroban_sdk::token::Client::new(&env, &token1).balance(&recipient1);
+
+    // The batch must abort entirely - simulation catches the shortfall before
+    // any transfer is committed.
+    let result = client.try_execute_batch(&admin, &batch_id);
+    assert_eq!(result, Err(Ok(VaultError::InsufficientBalance)));
+
+    let batch_after = client.get_batch(&batch_id);
+    assert_eq!(batch_after.status, BatchStatus::RolledBack);
+    assert_eq!(batch_after.executed_count, 0);
+    assert_eq!(batch_after.failed_count, 2);
+
+    // Nothing was ever committed, so there is no rollback state to persist.
+    let rollback_state = client.get_rollback_state(&batch_id);
+    assert_eq!(rollback_state.len(), 0);
+
+    // Neither proposal executed - the first proposal's transfer never moved,
+    // unlike the old best-effort-rollback design.
+    let proposal1 = client.get_proposal(&proposal_ids.get(0).unwrap());
+    let proposal2 = client.get_proposal(&proposal_ids.get(1).unwrap());
+    assert_eq!(proposal1.status, ProposalStatus::Approved);
+    assert_eq!(proposal2.status, ProposalStatus::Approved);
+
+    // Balances are completely untouched.
+    assert_eq!(
+        soroban_sdk::token::Client::new(&env, &token1).balance(&contract_id),
+        pre_vault_balance1
+    );
+    assert_eq!(
+        soroban_sdk::token::Client::new(&env, &token2).balance(&contract_id),
+        pre_vault_balance2
+    );
+    assert_eq!(
+        soroban_sdk::token::Client::new(&env, &token1).balance(&recipient1),
+        pre_recipient1_balance
+    );
+
+    let batch_result = client.get_batch_result(&batch_id);
+    assert!(batch_result.is_some());
+    let result = batch_result.unwrap();
+    assert_eq!(result.executed_count, 0);
+    assert_eq!(result.failed_count, 2);
+}
+
+/// Issue #1361: A transfer can still fail during the commit phase despite
+/// passing simulation (e.g. a recipient is deauthorized by the token
+/// contract between simulation and commit). This exercises the fallback
+/// best-effort reverse-transfer rollback path for whatever this run already
+/// committed. The reverse-transfer itself requires the recipient's
+/// authorization (recipient1 never authorized anything as part of this
+/// call's root invocation), so it is expected to fail here - the rollback
+/// state is still persisted for off-chain reconciliation.
+#[test]
+fn test_batch_commit_failure_falls_back_to_best_effort_rollback() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_sequence_number(100);
+
+    let contract_id = env.register(VaultDAO, ());
+    let client = VaultDAOClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let treasurer = Address::generate(&env);
+    let recipient1 = Address::generate(&env);
+    let recipient2 = Address::generate(&env);
+
+    let token1 = env
+        .register_stellar_asset_contract_v2(admin.clone())
+        .address();
+
+    StellarAssetClient::new(&env, &token1).mint(&contract_id, &100_000);
+
+    let mut signers = Vec::new(&env);
+    signers.push_back(admin.clone());
+    signers.push_back(treasurer.clone());
+
+    let config = init_config(&env, signers, 1, ThresholdStrategy::Fixed);
+    client.initialize(&admin, &config);
+    client.set_role(&admin, &treasurer, &Role::Treasurer);
+
+    let mut transfers = Vec::new(&env);
+    transfers.push_back(TransferDetails {
+        recipient: recipient1.clone(),
+        token: token1.clone(),
+        amount: 500,
+    });
+    transfers.push_back(TransferDetails {
+        recipient: recipient2.clone(),
+        token: token1.clone(),
+        amount: 700,
+    });
+
+    let proposal_ids = client.batch_propose_transfers(
+        &treasurer,
+        &transfers,
+        &Priority::Normal,
+        &Vec::new(&env),
+        &ConditionLogic::And,
+        &0i128,
+    );
+    assert_eq!(proposal_ids.len(), 2);
+
+    for i in 0..proposal_ids.len() {
+        let pid = proposal_ids.get(i).unwrap();
+        client.approve_proposal(&admin, &pid);
+    }
+
+    let batch_id = 1u64;
+
+    // Vault comfortably holds enough token1 for both transfers, so
+    // simulation passes. Deauthorize recipient2 so the SECOND transfer
+    // fails only once the batch actually tries to commit it.
+    StellarAssetClient::new(&env, &token1).set_authorized(&recipient2, &false);
+
+    let pre_fail_vault_balance =
         soroban_sdk::token::Client::new(&env, &token1).balance(&contract_id);
-    let pre_fail_vault_balance3 =
-        soroban_sdk::token::Client::new(&env, &token3).balance(&contract_id);
     let pre_fail_recipient1_balance =
         soroban_sdk::token::Client::new(&env, &token1).balance(&recipient1);
-    let pre_fail_recipient2_balance =
-        soroban_sdk::token::Client::new(&env, &token3).balance(&recipient2);
 
-    // Execute batch - should fail and rollback
-    client.execute_batch(&admin, &batch_id2);
+    // Commit-phase failures return Ok(()) - the rollback state is what
+    // reports the outcome, not the call result.
+    client.execute_batch(&admin, &batch_id);
 
-    // Verify batch status shows rollback
-    let batch2_after = client.get_batch(&batch_id2);
-    assert_eq!(batch2_after.status, BatchStatus::RolledBack);
-    assert_eq!(batch2_after.executed_count, 1); // First transfer succeeded before rollback
-    assert_eq!(batch2_after.failed_count, 1);
+    let batch_after = client.get_batch(&batch_id);
+    assert_eq!(batch_after.status, BatchStatus::RolledBack);
+    assert_eq!(batch_after.executed_count, 1); // First transfer committed before the failure
+    assert_eq!(batch_after.failed_count, 1);
 
-    // Verify rollback state is persisted and queryable
-    let rollback_state = client.get_rollback_state(&batch_id2);
-    assert_eq!(rollback_state.len(), 1); // One transfer was rolled back
+    // Rollback state is persisted for the transfer that did commit.
+    let rollback_state = client.get_rollback_state(&batch_id);
+    assert_eq!(rollback_state.len(), 1);
     let (rolled_back_recipient, rolled_back_amount) = rollback_state.get(0).unwrap();
     assert_eq!(rolled_back_recipient, recipient1);
     assert_eq!(rolled_back_amount, 500);
 
-    // Verify balances - rollback may not succeed in practice if recipients don't authorize
-    // The vault balance should reflect that the first transfer succeeded but wasn't rolled back
+    // The reverse-transfer requires recipient1's own authorization, which
+    // was never granted here, so the best-effort rollback does not actually
+    // restore funds - recipient1 keeps the 500 tokens.
     assert_eq!(
         soroban_sdk::token::Client::new(&env, &token1).balance(&contract_id),
-        pre_fail_vault_balance1 - 500 // First transfer succeeded but rollback failed
-    );
-    assert_eq!(
-        soroban_sdk::token::Client::new(&env, &token3).balance(&contract_id),
-        pre_fail_vault_balance3 // Second transfer never happened
+        pre_fail_vault_balance - 500
     );
     assert_eq!(
         soroban_sdk::token::Client::new(&env, &token1).balance(&recipient1),
-        pre_fail_recipient1_balance + 500 // Recipient kept the tokens from first transfer
-    );
-    assert_eq!(
-        soroban_sdk::token::Client::new(&env, &token3).balance(&recipient2),
-        pre_fail_recipient2_balance // No change for second recipient
+        pre_fail_recipient1_balance + 500
     );
 
-    // Verify proposals that were executed remain in Executed status since rollback failed
-    let proposal1 = client.get_proposal(&proposal_ids2.get(0).unwrap());
-    assert_eq!(proposal1.status, ProposalStatus::Executed); // Rollback failed, so status remains Executed
+    let proposal1 = client.get_proposal(&proposal_ids.get(0).unwrap());
+    assert_eq!(proposal1.status, ProposalStatus::Executed); // Rollback failed, status remains Executed
 
-    // Verify batch execution result for failed batch
-    let batch_result2 = client.get_batch_result(&batch_id2);
-    assert!(batch_result2.is_some());
-    let result2 = batch_result2.unwrap();
-    assert_eq!(result2.executed_count, 1);
-    assert_eq!(result2.failed_count, 1);
+    let batch_result = client.get_batch_result(&batch_id);
+    assert!(batch_result.is_some());
+    let result = batch_result.unwrap();
+    assert_eq!(result.executed_count, 1);
+    assert_eq!(result.failed_count, 1);
 }
 
 /// Test that batch size is enforced at creation time


### PR DESCRIPTION
… failure

Batch execution previously validated proposals up front but then executed transfers one at a time, only attempting to reverse already-committed transfers if a later one failed - and that reverse-transfer requires the recipient's own authorization, so it wasn't guaranteed to succeed. A batch of 5 succeeding and 1 failing could leave the first 5 executed for good.

execute_batch now collects every planned transfer, simulates them by checking the vault's balance per token (aggregated across proposals sharing a token) against what the batch needs, and only commits any transfer once every proposal and every simulated transfer has passed. Any validation or simulation failure aborts the whole batch with zero funds moved and emits a rollback event carrying the failure reason.

The previous best-effort reverse-transfer rollback is kept as a fallback for the rare case a transfer still fails during commit despite passing simulation (e.g. a recipient deauthorized mid-flight).

Also fixes a pre-existing missing closing brace in increment_subscription_usage (storage.rs) that broke compilation of the whole crate, and adds two missing InitConfig fields to the local test helper in test_regressions.rs so the new/existing batch tests can build.

Closes #1361

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #1361
Closes #1362
Closes #1357

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
