### PR TITLE
Add client-side error reporting endpoint and i18n coverage

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,8 @@ import { createProposalsRouter } from "./modules/proposals/proposals.routes.js";
 import { createRecurringRouter } from "./modules/recurring/recurring.routes.js";
 import { createTransactionsRouter } from "./modules/transactions/transactions.routes.js";
 import { createAuditRouter } from "./modules/audit/audit.routes.js";
+import { createErrorsRouter } from "./modules/errors/errors.routes.js";
+import { ErrorsService } from "./modules/errors/errors.service.js";
 import { createNotificationsRouter } from "./modules/notifications/notifications.routes.js";
 import { createWebhookRouter } from "./modules/notifications/webhook.routes.js";
 import { createCacheRouter } from "./shared/cache/cache.routes.js";
@@ -441,6 +443,12 @@ export async function createApp(env: BackendEnv, runtime: BackendRuntime) {
     hmacMiddleware,
     createAuditRouter(env.sorobanRpcUrl, adminAuthMiddleware),
   );
+
+  // Client-side error collection (ErrorBoundary reporting). POST is
+  // intentionally unauthenticated — the browser cannot hold an API key or
+  // HMAC secret — but is covered by the global/write rate limiters above.
+  // GET (listing) is admin-gated since it may surface sensitive stack traces.
+  v1Router.use("/errors", createErrorsRouter(new ErrorsService(), adminAuthMiddleware));
 
   if (runtime.cacheManager) {
     v1Router.use(

--- a/backend/src/modules/errors/errors.routes.test.ts
+++ b/backend/src/modules/errors/errors.routes.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createErrorsRouter } from "./errors.routes.js";
+import { ErrorsService } from "./errors.service.js";
+
+function makeRes() {
+  const state: { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+  };
+  const res = {
+    status(code: number) {
+      state.statusCode = code;
+      return this;
+    },
+    set(_k: string, _v: string) {
+      return this;
+    },
+    json(body: unknown) {
+      state.body = body;
+      return this;
+    },
+  };
+  return { res, state };
+}
+
+function getPostHandler(service: ErrorsService) {
+  const router = createErrorsRouter(service);
+  const layer = (router.stack as any[]).find(
+    (l) => l.route?.path === "/" && l.route?.methods?.post,
+  );
+  return layer.route.stack[0].handle;
+}
+
+test("POST /errors: rejects payloads without a message", async () => {
+  const service = new ErrorsService();
+  const handler = getPostHandler(service);
+  const { res, state } = makeRes();
+
+  await handler({ body: {} } as any, res as any, (() => {}) as any);
+
+  assert.strictEqual(state.statusCode, 400);
+});
+
+test("POST /errors: records a valid payload and returns an id", async () => {
+  const service = new ErrorsService();
+  const handler = getPostHandler(service);
+  const { res, state } = makeRes();
+
+  await handler(
+    { body: { code: "REACT_ERROR_BOUNDARY", message: "boom", user: "GABC", page: "/dashboard" } } as any,
+    res as any,
+    (() => {}) as any,
+  );
+
+  assert.strictEqual(state.statusCode, 201);
+  const body = state.body as any;
+  assert.strictEqual(body.success, true);
+  assert.ok(body.data.id);
+  assert.strictEqual(body.data.deduped, false);
+  assert.strictEqual(service.count(), 1);
+});
+
+test("POST /errors: deduplicates repeated errors across requests", async () => {
+  const service = new ErrorsService();
+  const handler = getPostHandler(service);
+
+  const first = makeRes();
+  await handler({ body: { code: "X", message: "boom" } } as any, first.res as any, (() => {}) as any);
+  const second = makeRes();
+  await handler({ body: { code: "X", message: "boom" } } as any, second.res as any, (() => {}) as any);
+
+  const secondBody = second.state.body as any;
+  assert.strictEqual(secondBody.data.deduped, true);
+  assert.strictEqual(service.count(), 1);
+});

--- a/backend/src/modules/errors/errors.routes.ts
+++ b/backend/src/modules/errors/errors.routes.ts
@@ -1,0 +1,65 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { ErrorsService } from "./errors.service.js";
+import { success, error } from "../../shared/http/response.js";
+import { ErrorCode } from "../../shared/http/errorCodes.js";
+import { createLogger } from "../../shared/logging/logger.js";
+
+const logger = createLogger("errors");
+
+/**
+ * Client-side error collection endpoint used by the frontend ErrorBoundary.
+ * POST is intentionally unauthenticated (the browser has no API key to sign
+ * requests with) but is covered by the global rate limiter in app.ts.
+ */
+export function createErrorsRouter(
+  service: ErrorsService,
+  adminAuthMiddleware?: (req: any, res: any, next: any) => void,
+): Router {
+  const router = Router();
+
+  router.post("/", (req: Request, res: Response) => {
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const message = typeof body["message"] === "string" ? body["message"].slice(0, 2000) : "";
+
+    if (!message) {
+      error(res, {
+        message: "message is required",
+        status: 400,
+        code: ErrorCode.VALIDATION_ERROR,
+      });
+      return;
+    }
+
+    const payload = {
+      code: typeof body["code"] === "string" ? body["code"] : "UNKNOWN",
+      message,
+      stack: typeof body["stack"] === "string" ? body["stack"].slice(0, 8000) : undefined,
+      context: typeof body["context"] === "string" ? body["context"] : undefined,
+      user: typeof body["user"] === "string" ? body["user"] : undefined,
+      page: typeof body["page"] === "string" ? body["page"] : undefined,
+      url: typeof body["url"] === "string" ? body["url"] : undefined,
+      userAgent: typeof body["userAgent"] === "string" ? body["userAgent"] : undefined,
+      timestamp: typeof body["timestamp"] === "string" ? body["timestamp"] : new Date().toISOString(),
+      retryCount: typeof body["retryCount"] === "number" ? body["retryCount"] : undefined,
+    };
+
+    const { id, deduped } = service.record(payload);
+    logger.warn("client error reported", { id, code: payload.code, deduped, page: payload.page });
+    success(res, { id, deduped }, { status: 201 });
+  });
+
+  const listHandler = (req: Request, res: Response) => {
+    const limitParam = parseInt((req.query["limit"] as string) ?? "50", 10);
+    const limit = Math.min(Number.isFinite(limitParam) && limitParam > 0 ? limitParam : 50, 500);
+    success(res, { events: service.getRecent(limit), total: service.count() });
+  };
+
+  if (adminAuthMiddleware) {
+    router.get("/", adminAuthMiddleware, listHandler);
+  } else {
+    router.get("/", listHandler);
+  }
+
+  return router;
+}

--- a/backend/src/modules/errors/errors.service.test.ts
+++ b/backend/src/modules/errors/errors.service.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ErrorsService } from "./errors.service.js";
+
+test("ErrorsService.record: stores a new error and returns a fresh id", () => {
+  const service = new ErrorsService();
+  const { id, deduped } = service.record({ code: "REACT_ERROR_BOUNDARY", message: "boom" });
+
+  assert.ok(id.length > 0);
+  assert.strictEqual(deduped, false);
+  assert.strictEqual(service.count(), 1);
+});
+
+test("ErrorsService.record: deduplicates repeated errors with the same code+message", () => {
+  const service = new ErrorsService();
+  const first = service.record({ code: "REACT_ERROR_BOUNDARY", message: "boom" });
+  const second = service.record({ code: "REACT_ERROR_BOUNDARY", message: "boom" });
+
+  assert.strictEqual(second.deduped, true);
+  assert.strictEqual(second.id, first.id);
+  assert.strictEqual(service.count(), 1);
+
+  const [stored] = service.getRecent(1);
+  assert.strictEqual(stored?.occurrences, 2);
+});
+
+test("ErrorsService.record: treats different messages as distinct errors", () => {
+  const service = new ErrorsService();
+  service.record({ code: "REACT_ERROR_BOUNDARY", message: "boom" });
+  service.record({ code: "REACT_ERROR_BOUNDARY", message: "bang" });
+
+  assert.strictEqual(service.count(), 2);
+});
+
+test("ErrorsService.getRecent: returns most recent errors first", () => {
+  const service = new ErrorsService();
+  service.record({ code: "A", message: "first" });
+  service.record({ code: "B", message: "second" });
+
+  const recent = service.getRecent(10);
+  assert.strictEqual(recent[0]?.message, "second");
+  assert.strictEqual(recent[1]?.message, "first");
+});
+
+test("ErrorsService.clear: empties the store", () => {
+  const service = new ErrorsService();
+  service.record({ code: "A", message: "first" });
+  service.clear();
+
+  assert.strictEqual(service.count(), 0);
+});

--- a/backend/src/modules/errors/errors.service.ts
+++ b/backend/src/modules/errors/errors.service.ts
@@ -1,0 +1,74 @@
+/**
+ * In-memory client error collection.
+ *
+ * Stores errors reported by the frontend ErrorBoundary, deduplicating
+ * repeated occurrences of the same (code, message) pair within a short
+ * window so a single crashing component doesn't flood storage.
+ */
+
+import type { ClientErrorPayload, StoredClientError } from "./errors.types.js";
+
+const MAX_STORED = 500;
+const DEDUP_WINDOW_MS = 5 * 60 * 1000;
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 10).toUpperCase();
+}
+
+function fingerprint(payload: Pick<ClientErrorPayload, "code" | "message">): string {
+  return `${payload.code}|${payload.message}`;
+}
+
+export class ErrorsService {
+  private events: (StoredClientError & { seq: number })[] = [];
+  private seqCounter = 0;
+
+  /** Record a client error, deduplicating recent repeats. Returns the (possibly existing) id. */
+  record(payload: ClientErrorPayload): { id: string; deduped: boolean } {
+    const now = Date.now();
+    const fp = fingerprint(payload);
+
+    const existing = this.events.find(
+      (e) => fingerprint(e) === fp && now - new Date(e.lastSeen).getTime() < DEDUP_WINDOW_MS,
+    );
+
+    if (existing) {
+      existing.occurrences += 1;
+      existing.lastSeen = new Date(now).toISOString();
+      existing.seq = ++this.seqCounter;
+      return { id: existing.id, deduped: true };
+    }
+
+    const id = generateId();
+    const stored: StoredClientError & { seq: number } = {
+      ...payload,
+      id,
+      firstSeen: new Date(now).toISOString(),
+      lastSeen: new Date(now).toISOString(),
+      occurrences: 1,
+      seq: ++this.seqCounter,
+    };
+
+    this.events.push(stored);
+    if (this.events.length > MAX_STORED) {
+      this.events = this.events.slice(-MAX_STORED);
+    }
+
+    return { id, deduped: false };
+  }
+
+  getRecent(limit = 50): StoredClientError[] {
+    return [...this.events]
+      .sort((a, b) => b.seq - a.seq)
+      .slice(0, limit)
+      .map(({ seq: _seq, ...rest }) => rest);
+  }
+
+  count(): number {
+    return this.events.length;
+  }
+
+  clear(): void {
+    this.events = [];
+  }
+}

--- a/backend/src/modules/errors/errors.types.ts
+++ b/backend/src/modules/errors/errors.types.ts
@@ -1,0 +1,21 @@
+export interface ClientErrorPayload {
+  code: string;
+  message: string;
+  stack?: string;
+  context?: string;
+  /** Wallet address or user identifier the error occurred for, if known. */
+  user?: string;
+  /** Route/page path the error occurred on. */
+  page?: string;
+  url?: string;
+  userAgent?: string;
+  timestamp?: string;
+  retryCount?: number;
+}
+
+export interface StoredClientError extends ClientErrorPayload {
+  id: string;
+  firstSeen: string;
+  lastSeen: string;
+  occurrences: number;
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -46,3 +46,8 @@ VITE_IPFS_API_URL=http://localhost:5001
 # IPFS gateway base URL for resolving/previewing CIDs
 # Default: https://ipfs.io/ipfs/
 VITE_IPFS_GATEWAY=https://ipfs.io/ipfs/
+
+# Backend endpoint that receives client-side error reports from ErrorBoundary
+# (see backend/src/modules/errors). Leave unset to disable backend reporting —
+# errors still get recorded locally for the in-app Error Dashboard.
+VITE_ERROR_REPORT_ENDPOINT=http://localhost:4000/api/v1/errors

--- a/frontend/public/locales/ar/translation.json
+++ b/frontend/public/locales/ar/translation.json
@@ -22,7 +22,17 @@
     "previous": "السابق",
     "retry": "حاول مرة أخرى",
     "notFound": "غير موجود",
-    "loadingEllipsis": "جاري التحميل..."
+    "loadingEllipsis": "جاري التحميل...",
+    "detected": "تم الكشف",
+    "installRequired": "التثبيت مطلوب",
+    "hide": "إخفاء",
+    "refresh": "تحديث",
+    "confirmDeleteTemplate": "هل أنت متأكد من رغبتك في حذف هذا القالب؟",
+    "templateImportedSuccess": "تم استيراد القالب بنجاح!",
+    "invalidTemplateFormat": "تنسيق القالب غير صالح",
+    "failedToImportTemplate": "فشل استيراد القالب",
+    "formSubmittedPreview": "تم إرسال النموذج بنجاح (وضع المعاينة)",
+    "confirmClearErrorHistory": "هل تريد مسح كل سجل الأخطاء؟"
   },
   "navigation": {
     "dashboard": "لوحة التحكم",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "عنوان عقد الرمز",
     "adding": "جاري الإضافة...",
     "failedToLoadBalance": "فشل في تحميل الرصيد",
-    "refreshBalance": "تحديث الرصيد"
+    "refreshBalance": "تحديث الرصيد",
+    "signers": "الموقعون"
   },
   "proposals": {
     "title": "الاقتراحات",
@@ -78,7 +89,8 @@
     "reject": "الرفض",
     "pending": "معلق",
     "approved": "موافق عليه",
-    "rejected": "مرفوض"
+    "rejected": "مرفوض",
+    "submittedSuccess": "تم تقديم الاقتراح بنجاح!"
   },
   "transactions": {
     "title": "المعاملات",
@@ -107,7 +119,8 @@
     "amount": "يرجى إدخال مبلغ صحيح",
     "selectOption": "يرجى اختيار خيار",
     "submit": "إرسال",
-    "reset": "إعادة تعيين"
+    "reset": "إعادة تعيين",
+    "circularDependencies": "اعتماديات دائرية في المنطق!"
   },
   "language": {
     "selectLanguage": "اختر اللغة",
@@ -145,5 +158,108 @@
     "approve": "يوافق",
     "reject": "يرفض",
     "create_payment": "إنشاء الدفع"
+  },
+  "nav": {
+    "overview": "نظرة عامة",
+    "proposals": "المقترحات",
+    "recurringPayments": "المدفوعات المتكررة",
+    "escrow": "الضمان",
+    "governance": "الحوكمة",
+    "activity": "النشاط",
+    "templates": "القوالب",
+    "analytics": "التحليلات",
+    "errorAnalytics": "تحليلات الأخطاء",
+    "settings": "الإعدادات"
+  },
+  "onboarding": {
+    "tourDesc": "قم بجولة سريعة للتعرف على جميع الميزات."
+  },
+  "portfolio": {
+    "title": "نظرة عامة على المحفظة",
+    "totalValue": "القيمة الإجمالية",
+    "allocation": "توزيع الرموز",
+    "lowBalance": "رصيد منخفض",
+    "estimate": "تقدير"
+  },
+  "voice": {
+    "start": "بدء الاستماع",
+    "stop": "إيقاف الاستماع",
+    "permissionRequired": "إذن الميكروفون مطلوب",
+    "timedOut": "انتهت مهلة الاستماع",
+    "timedOutHint": "حاول مرة أخرى أو قل كلمة التنبيه",
+    "settings": "إعدادات الصوت",
+    "wakeWord": "كلمة التنبيه",
+    "availableCommands": "الأوامر المتاحة",
+    "notSupported": "الإدخال الصوتي غير مدعوم في هذا المتصفح"
+  },
+  "settings": {
+    "title": "الإعدادات",
+    "vaultConfig": "إعدادات الخزنة",
+    "vaultConfigDesc": "الموقعون والحدود وقيود الإنفاق لهذه الخزنة",
+    "yourRole": "دورك",
+    "signerSetNote": "أنت أحد الموقعين على هذه الخزنة",
+    "notSignerSetNote": "أنت لست أحد الموقعين على هذه الخزنة",
+    "threshold": "حد الموافقة",
+    "approvalsNeeded": "عدد موافقات الموقعين المطلوبة لتنفيذ الاقتراح",
+    "timelock": "القفل الزمني",
+    "timelockTrigger": "يتم التفعيل فوق",
+    "timelockDelay": "التأخير",
+    "signers": "الموقعون",
+    "currentWallet": "محفظتك",
+    "signerListUnavailable": "قائمة الموقعين غير متوفرة",
+    "spendingLimits": "حدود الإنفاق",
+    "perProposal": "لكل اقتراح",
+    "daily": "يومي",
+    "weekly": "أسبوعي",
+    "supportedWallets": "المحافظ المدعومة",
+    "supportedWalletsDesc": "المحافظ التي يمكنك استخدامها للاتصال بـ VaultDAO",
+    "roleManagement": "إدارة الأدوار",
+    "exportHistory": "سجل التصدير",
+    "exportHistoryDesc": "ملفات التدقيق والتوقيع المُصدَّرة سابقًا",
+    "reExport": "إعادة التصدير",
+    "clearHistory": "مسح السجل",
+    "noExportHistory": "لا يوجد سجل تصدير",
+    "noExportHistoryDesc": "ستظهر الملفات المُصدَّرة هنا",
+    "recipientLists": "قوائم المستلمين",
+    "manageLists": "إدارة القوائم",
+    "recipientListsDesc": "عناوين المستلمين في القوائم البيضاء والسوداء",
+    "onboarding": "التأهيل",
+    "restartTour": "إعادة تشغيل الجولة",
+    "onboardingDesc": "إعادة تشغيل الجولة الإرشادية للمنتج",
+    "wrongNetwork": "شبكة خاطئة",
+    "viewOnExplorer": "عرض في المستكشف",
+    "loadingVaultConfig": "جارٍ تحميل إعدادات الخزنة...",
+    "updateThreshold": "تحديث الحد",
+    "readOnly": "للقراءة فقط",
+    "removeSignerTitle": "إزالة الموقّع",
+    "addSigner": "إضافة موقّع",
+    "stellarAddressPlaceholder": "عنوان ستيلر G...",
+    "downloadAgain": "تنزيل مرة أخرى",
+    "reDownloadUnavailable": "إعادة التنزيل غير متاحة (لا يوجد محتوى مخزّن)",
+    "reExportAria": "إعادة تصدير {{filename}}",
+    "reExportUnavailable": "إعادة التصدير غير متاحة",
+    "clearExportHistoryAria": "مسح سجل التصدير",
+    "removeSignerModalTitle": "إزالة الموقّع",
+    "removeSignerModalMessage": "هل تريد إزالة {{address}} من موقّعي الخزنة؟ لا يمكن التراجع عن هذا إلا بإعادة إضافته.",
+    "removing": "جارٍ الإزالة…",
+    "remove": "إزالة",
+    "language": "اللغة",
+    "languageDesc": "اختر لغة العرض لـ VaultDAO"
+  },
+  "performance": {
+    "title": "الأداء",
+    "subtitle": "مؤشرات الويب الأساسية ومقاييس الموارد",
+    "thresholds": "الحدود",
+    "good": "جيد",
+    "warning": "يحتاج إلى تحسين",
+    "largestResources": "أكبر الموارد",
+    "allGood": "جميع المقاييس تبدو جيدة",
+    "lcp": "أكبر عرض للمحتوى",
+    "fid": "تأخير أول إدخال",
+    "cls": "التحول التراكمي للتخطيط",
+    "ttfb": "الوقت حتى أول بايت",
+    "fcp": "أول عرض للمحتوى",
+    "memoryUsage": "استخدام الذاكرة",
+    "heapUsage": "استخدام الكومة"
   }
 }

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -22,7 +22,17 @@
     "previous": "Previous",
     "retry": "Retry",
     "notFound": "Not Found",
-    "loadingEllipsis": "Loading..."
+    "loadingEllipsis": "Loading...",
+    "detected": "Detected",
+    "installRequired": "Install Required",
+    "hide": "Hide",
+    "refresh": "Refresh",
+    "confirmDeleteTemplate": "Are you sure you want to delete this template?",
+    "templateImportedSuccess": "Template imported successfully!",
+    "invalidTemplateFormat": "Invalid template format",
+    "failedToImportTemplate": "Failed to import template",
+    "formSubmittedPreview": "Form submitted successfully (Preview Mode)",
+    "confirmClearErrorHistory": "Clear all error history?"
   },
   "navigation": {
     "dashboard": "Dashboard",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "Token Contract Address",
     "adding": "Adding...",
     "failedToLoadBalance": "Failed to load balance",
-    "refreshBalance": "Refresh balance"
+    "refreshBalance": "Refresh balance",
+    "signers": "Signers"
   },
   "proposals": {
     "title": "Proposals",
@@ -78,7 +89,8 @@
     "reject": "Reject",
     "pending": "Pending",
     "approved": "Approved",
-    "rejected": "Rejected"
+    "rejected": "Rejected",
+    "submittedSuccess": "Proposal submitted successfully!"
   },
   "transactions": {
     "title": "Transactions",
@@ -107,7 +119,8 @@
     "amount": "Please enter a valid amount",
     "selectOption": "Please select an option",
     "submit": "Submit",
-    "reset": "Reset"
+    "reset": "Reset",
+    "circularDependencies": "Circular dependencies in logic!"
   },
   "language": {
     "selectLanguage": "Select Language",
@@ -145,5 +158,108 @@
     "approve": "Approve",
     "reject": "Reject",
     "create_payment": "Create Payment"
+  },
+  "nav": {
+    "overview": "Overview",
+    "proposals": "Proposals",
+    "recurringPayments": "Recurring Payments",
+    "escrow": "Escrow",
+    "governance": "Governance",
+    "activity": "Activity",
+    "templates": "Templates",
+    "analytics": "Analytics",
+    "errorAnalytics": "Error Analytics",
+    "settings": "Settings"
+  },
+  "onboarding": {
+    "tourDesc": "Take a quick tour to learn about all the features."
+  },
+  "portfolio": {
+    "title": "Portfolio Overview",
+    "totalValue": "Total Value",
+    "allocation": "Token Allocation",
+    "lowBalance": "Low Balance",
+    "estimate": "estimate"
+  },
+  "voice": {
+    "start": "Start Listening",
+    "stop": "Stop Listening",
+    "permissionRequired": "Microphone permission required",
+    "timedOut": "Listening timed out",
+    "timedOutHint": "Try again or say the wake word",
+    "settings": "Voice Settings",
+    "wakeWord": "Wake word",
+    "availableCommands": "Available commands",
+    "notSupported": "Voice input not supported in this browser"
+  },
+  "settings": {
+    "title": "Settings",
+    "vaultConfig": "Vault Configuration",
+    "vaultConfigDesc": "Signers, thresholds, and spending limits for this vault",
+    "yourRole": "Your Role",
+    "signerSetNote": "You are a signer on this vault",
+    "notSignerSetNote": "You are not a signer on this vault",
+    "threshold": "Approval Threshold",
+    "approvalsNeeded": "Number of signer approvals required to execute a proposal",
+    "timelock": "Timelock",
+    "timelockTrigger": "Triggers above",
+    "timelockDelay": "Delay",
+    "signers": "Signers",
+    "currentWallet": "Your wallet",
+    "signerListUnavailable": "Signer list is unavailable",
+    "spendingLimits": "Spending Limits",
+    "perProposal": "Per proposal",
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "supportedWallets": "Supported Wallets",
+    "supportedWalletsDesc": "Wallets you can use to connect to VaultDAO",
+    "roleManagement": "Role Management",
+    "exportHistory": "Export History",
+    "exportHistoryDesc": "Previously exported audit and signature files",
+    "reExport": "Re-export",
+    "clearHistory": "Clear History",
+    "noExportHistory": "No export history",
+    "noExportHistoryDesc": "Exported files will appear here",
+    "recipientLists": "Recipient Lists",
+    "manageLists": "Manage Lists",
+    "recipientListsDesc": "Whitelisted and blacklisted recipient addresses",
+    "onboarding": "Onboarding",
+    "restartTour": "Restart Tour",
+    "onboardingDesc": "Replay the guided product tour",
+    "wrongNetwork": "Wrong network",
+    "viewOnExplorer": "View on Explorer",
+    "loadingVaultConfig": "Loading vault configuration...",
+    "updateThreshold": "Update Threshold",
+    "readOnly": "Read-only",
+    "removeSignerTitle": "Remove signer",
+    "addSigner": "Add Signer",
+    "stellarAddressPlaceholder": "G... Stellar address",
+    "downloadAgain": "Download again",
+    "reDownloadUnavailable": "Re-download not available (no stored content)",
+    "reExportAria": "Re-export {{filename}}",
+    "reExportUnavailable": "Re-export not available",
+    "clearExportHistoryAria": "Clear export history",
+    "removeSignerModalTitle": "Remove Signer",
+    "removeSignerModalMessage": "Remove {{address}} from the vault signers? This cannot be undone without re-adding them.",
+    "removing": "Removing…",
+    "remove": "Remove",
+    "language": "Language",
+    "languageDesc": "Choose the display language for VaultDAO"
+  },
+  "performance": {
+    "title": "Performance",
+    "subtitle": "Core Web Vitals and resource metrics",
+    "thresholds": "Thresholds",
+    "good": "Good",
+    "warning": "Needs improvement",
+    "largestResources": "Largest Resources",
+    "allGood": "All metrics look good",
+    "lcp": "Largest Contentful Paint",
+    "fid": "First Input Delay",
+    "cls": "Cumulative Layout Shift",
+    "ttfb": "Time to First Byte",
+    "fcp": "First Contentful Paint",
+    "memoryUsage": "Memory Usage",
+    "heapUsage": "Heap Usage"
   }
 }

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -22,7 +22,17 @@
     "previous": "Anterior",
     "retry": "Reintentar",
     "notFound": "No Encontrado",
-    "loadingEllipsis": "Cargando..."
+    "loadingEllipsis": "Cargando...",
+    "detected": "Detectado",
+    "installRequired": "Instalación requerida",
+    "hide": "Ocultar",
+    "refresh": "Actualizar",
+    "confirmDeleteTemplate": "¿Seguro que quieres eliminar esta plantilla?",
+    "templateImportedSuccess": "¡Plantilla importada correctamente!",
+    "invalidTemplateFormat": "Formato de plantilla no válido",
+    "failedToImportTemplate": "No se pudo importar la plantilla",
+    "formSubmittedPreview": "Formulario enviado correctamente (Modo Vista Previa)",
+    "confirmClearErrorHistory": "¿Borrar todo el historial de errores?"
   },
   "navigation": {
     "dashboard": "Panel de Control",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "Dirección del Contrato de Token",
     "adding": "Agregando...",
     "failedToLoadBalance": "Error al cargar el saldo",
-    "refreshBalance": "Actualizar equilibrio"
+    "refreshBalance": "Actualizar equilibrio",
+    "signers": "Firmantes"
   },
   "proposals": {
     "title": "Propuestas",
@@ -78,7 +89,8 @@
     "reject": "Rechazar",
     "pending": "Pendiente",
     "approved": "Aprobado",
-    "rejected": "Rechazado"
+    "rejected": "Rechazado",
+    "submittedSuccess": "¡Propuesta enviada correctamente!"
   },
   "transactions": {
     "title": "Transacciones",
@@ -107,7 +119,8 @@
     "amount": "Por favor, introduce una cantidad válida",
     "selectOption": "Por favor, selecciona una opción",
     "submit": "Enviar",
-    "reset": "Restablecer"
+    "reset": "Restablecer",
+    "circularDependencies": "¡Dependencias circulares en la lógica!"
   },
   "language": {
     "selectLanguage": "Seleccionar Idioma",
@@ -145,5 +158,108 @@
     "approve": "Aprobar",
     "reject": "Rechazar",
     "create_payment": "Crear Pago"
+  },
+  "nav": {
+    "overview": "Resumen",
+    "proposals": "Propuestas",
+    "recurringPayments": "Pagos Recurrentes",
+    "escrow": "Depósito en garantía",
+    "governance": "Gobernanza",
+    "activity": "Actividad",
+    "templates": "Plantillas",
+    "analytics": "Análisis",
+    "errorAnalytics": "Análisis de Errores",
+    "settings": "Configuración"
+  },
+  "onboarding": {
+    "tourDesc": "Haz un recorrido rápido para conocer todas las funciones."
+  },
+  "portfolio": {
+    "title": "Resumen de Cartera",
+    "totalValue": "Valor Total",
+    "allocation": "Asignación de Tokens",
+    "lowBalance": "Saldo Bajo",
+    "estimate": "estimado"
+  },
+  "voice": {
+    "start": "Iniciar Escucha",
+    "stop": "Detener Escucha",
+    "permissionRequired": "Se requiere permiso del micrófono",
+    "timedOut": "La escucha expiró",
+    "timedOutHint": "Intenta de nuevo o di la palabra de activación",
+    "settings": "Configuración de Voz",
+    "wakeWord": "Palabra de activación",
+    "availableCommands": "Comandos disponibles",
+    "notSupported": "La entrada de voz no es compatible con este navegador"
+  },
+  "settings": {
+    "title": "Configuración",
+    "vaultConfig": "Configuración de la Bóveda",
+    "vaultConfigDesc": "Firmantes, umbrales y límites de gasto de esta bóveda",
+    "yourRole": "Tu Rol",
+    "signerSetNote": "Eres firmante de esta bóveda",
+    "notSignerSetNote": "No eres firmante de esta bóveda",
+    "threshold": "Umbral de Aprobación",
+    "approvalsNeeded": "Número de aprobaciones de firmantes necesarias para ejecutar una propuesta",
+    "timelock": "Bloqueo Temporal",
+    "timelockTrigger": "Se activa por encima de",
+    "timelockDelay": "Retraso",
+    "signers": "Firmantes",
+    "currentWallet": "Tu billetera",
+    "signerListUnavailable": "La lista de firmantes no está disponible",
+    "spendingLimits": "Límites de Gasto",
+    "perProposal": "Por propuesta",
+    "daily": "Diario",
+    "weekly": "Semanal",
+    "supportedWallets": "Billeteras Compatibles",
+    "supportedWalletsDesc": "Billeteras que puedes usar para conectarte a VaultDAO",
+    "roleManagement": "Gestión de Roles",
+    "exportHistory": "Historial de Exportaciones",
+    "exportHistoryDesc": "Archivos de auditoría y firmas exportados anteriormente",
+    "reExport": "Reexportar",
+    "clearHistory": "Borrar Historial",
+    "noExportHistory": "Sin historial de exportaciones",
+    "noExportHistoryDesc": "Los archivos exportados aparecerán aquí",
+    "recipientLists": "Listas de Destinatarios",
+    "manageLists": "Administrar Listas",
+    "recipientListsDesc": "Direcciones de destinatarios en listas blancas y negras",
+    "onboarding": "Incorporación",
+    "restartTour": "Reiniciar Recorrido",
+    "onboardingDesc": "Repetir el recorrido guiado del producto",
+    "wrongNetwork": "Red incorrecta",
+    "viewOnExplorer": "Ver en el Explorador",
+    "loadingVaultConfig": "Cargando configuración de la bóveda...",
+    "updateThreshold": "Actualizar Umbral",
+    "readOnly": "Solo lectura",
+    "removeSignerTitle": "Eliminar firmante",
+    "addSigner": "Agregar Firmante",
+    "stellarAddressPlaceholder": "Dirección de Stellar G...",
+    "downloadAgain": "Descargar de nuevo",
+    "reDownloadUnavailable": "No se puede volver a descargar (sin contenido almacenado)",
+    "reExportAria": "Reexportar {{filename}}",
+    "reExportUnavailable": "Reexportación no disponible",
+    "clearExportHistoryAria": "Borrar historial de exportaciones",
+    "removeSignerModalTitle": "Eliminar Firmante",
+    "removeSignerModalMessage": "¿Eliminar a {{address}} de los firmantes de la bóveda? Esto no se puede deshacer sin volver a agregarlo.",
+    "removing": "Eliminando…",
+    "remove": "Eliminar",
+    "language": "Idioma",
+    "languageDesc": "Elige el idioma de visualización de VaultDAO"
+  },
+  "performance": {
+    "title": "Rendimiento",
+    "subtitle": "Core Web Vitals y métricas de recursos",
+    "thresholds": "Umbrales",
+    "good": "Bueno",
+    "warning": "Necesita mejorar",
+    "largestResources": "Recursos Más Grandes",
+    "allGood": "Todas las métricas se ven bien",
+    "lcp": "Mayor Renderizado de Contenido",
+    "fid": "Retraso en la Primera Entrada",
+    "cls": "Cambio Acumulativo de Diseño",
+    "ttfb": "Tiempo al Primer Byte",
+    "fcp": "Primer Renderizado de Contenido",
+    "memoryUsage": "Uso de Memoria",
+    "heapUsage": "Uso del Heap"
   }
 }

--- a/frontend/public/locales/fr/translation.json
+++ b/frontend/public/locales/fr/translation.json
@@ -22,7 +22,17 @@
     "previous": "Précédent",
     "retry": "Réessayer",
     "notFound": "Non trouvé",
-    "loadingEllipsis": "Chargement..."
+    "loadingEllipsis": "Chargement...",
+    "detected": "Détecté",
+    "installRequired": "Installation requise",
+    "hide": "Masquer",
+    "refresh": "Actualiser",
+    "confirmDeleteTemplate": "Voulez-vous vraiment supprimer ce modèle ?",
+    "templateImportedSuccess": "Modèle importé avec succès !",
+    "invalidTemplateFormat": "Format de modèle invalide",
+    "failedToImportTemplate": "Échec de l'importation du modèle",
+    "formSubmittedPreview": "Formulaire envoyé avec succès (mode aperçu)",
+    "confirmClearErrorHistory": "Effacer tout l'historique des erreurs ?"
   },
   "navigation": {
     "dashboard": "Tableau de Bord",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "Adresse du Contrat de Jeton",
     "adding": "Ajout...",
     "failedToLoadBalance": "Impossible de charger le solde",
-    "refreshBalance": "Actualiser le solde"
+    "refreshBalance": "Actualiser le solde",
+    "signers": "Signataires"
   },
   "proposals": {
     "title": "Propositions",
@@ -78,7 +89,8 @@
     "reject": "Rejeter",
     "pending": "En Attente",
     "approved": "Approuvé",
-    "rejected": "Rejeté"
+    "rejected": "Rejeté",
+    "submittedSuccess": "Proposition soumise avec succès !"
   },
   "transactions": {
     "title": "Transactions",
@@ -107,7 +119,8 @@
     "amount": "Veuillez entrer un montant valide",
     "selectOption": "Veuillez sélectionner une option",
     "submit": "Soumettre",
-    "reset": "Réinitialiser"
+    "reset": "Réinitialiser",
+    "circularDependencies": "Dépendances circulaires dans la logique !"
   },
   "language": {
     "selectLanguage": "Sélectionner la Langue",
@@ -145,5 +158,108 @@
     "approve": "Approuver",
     "reject": "Rejeter",
     "create_payment": "Créer un paiement"
+  },
+  "nav": {
+    "overview": "Aperçu",
+    "proposals": "Propositions",
+    "recurringPayments": "Paiements récurrents",
+    "escrow": "Séquestre",
+    "governance": "Gouvernance",
+    "activity": "Activité",
+    "templates": "Modèles",
+    "analytics": "Analytique",
+    "errorAnalytics": "Analytique des erreurs",
+    "settings": "Paramètres"
+  },
+  "onboarding": {
+    "tourDesc": "Faites une visite rapide pour découvrir toutes les fonctionnalités."
+  },
+  "portfolio": {
+    "title": "Aperçu du portefeuille",
+    "totalValue": "Valeur totale",
+    "allocation": "Allocation des jetons",
+    "lowBalance": "Solde faible",
+    "estimate": "estimation"
+  },
+  "voice": {
+    "start": "Démarrer l'écoute",
+    "stop": "Arrêter l'écoute",
+    "permissionRequired": "Autorisation du microphone requise",
+    "timedOut": "L'écoute a expiré",
+    "timedOutHint": "Réessayez ou dites le mot de réveil",
+    "settings": "Paramètres vocaux",
+    "wakeWord": "Mot de réveil",
+    "availableCommands": "Commandes disponibles",
+    "notSupported": "La saisie vocale n'est pas prise en charge par ce navigateur"
+  },
+  "settings": {
+    "title": "Paramètres",
+    "vaultConfig": "Configuration du coffre",
+    "vaultConfigDesc": "Signataires, seuils et limites de dépenses de ce coffre",
+    "yourRole": "Votre rôle",
+    "signerSetNote": "Vous êtes signataire de ce coffre",
+    "notSignerSetNote": "Vous n'êtes pas signataire de ce coffre",
+    "threshold": "Seuil d'approbation",
+    "approvalsNeeded": "Nombre d'approbations de signataires requises pour exécuter une proposition",
+    "timelock": "Verrouillage temporel",
+    "timelockTrigger": "Se déclenche au-dessus de",
+    "timelockDelay": "Délai",
+    "signers": "Signataires",
+    "currentWallet": "Votre portefeuille",
+    "signerListUnavailable": "La liste des signataires n'est pas disponible",
+    "spendingLimits": "Limites de dépenses",
+    "perProposal": "Par proposition",
+    "daily": "Quotidien",
+    "weekly": "Hebdomadaire",
+    "supportedWallets": "Portefeuilles pris en charge",
+    "supportedWalletsDesc": "Portefeuilles que vous pouvez utiliser pour vous connecter à VaultDAO",
+    "roleManagement": "Gestion des rôles",
+    "exportHistory": "Historique des exports",
+    "exportHistoryDesc": "Fichiers d'audit et de signature précédemment exportés",
+    "reExport": "Réexporter",
+    "clearHistory": "Effacer l'historique",
+    "noExportHistory": "Aucun historique d'export",
+    "noExportHistoryDesc": "Les fichiers exportés apparaîtront ici",
+    "recipientLists": "Listes de destinataires",
+    "manageLists": "Gérer les listes",
+    "recipientListsDesc": "Adresses de destinataires en liste blanche et noire",
+    "onboarding": "Intégration",
+    "restartTour": "Redémarrer la visite",
+    "onboardingDesc": "Rejouer la visite guidée du produit",
+    "wrongNetwork": "Mauvais réseau",
+    "viewOnExplorer": "Voir sur l'explorateur",
+    "loadingVaultConfig": "Chargement de la configuration du coffre...",
+    "updateThreshold": "Mettre à jour le seuil",
+    "readOnly": "Lecture seule",
+    "removeSignerTitle": "Supprimer le signataire",
+    "addSigner": "Ajouter un signataire",
+    "stellarAddressPlaceholder": "Adresse Stellar G...",
+    "downloadAgain": "Télécharger à nouveau",
+    "reDownloadUnavailable": "Retéléchargement indisponible (aucun contenu enregistré)",
+    "reExportAria": "Réexporter {{filename}}",
+    "reExportUnavailable": "Réexportation indisponible",
+    "clearExportHistoryAria": "Effacer l'historique des exports",
+    "removeSignerModalTitle": "Supprimer le signataire",
+    "removeSignerModalMessage": "Retirer {{address}} des signataires du coffre ? Cette action est irréversible sans le rajouter.",
+    "removing": "Suppression…",
+    "remove": "Supprimer",
+    "language": "Langue",
+    "languageDesc": "Choisissez la langue d'affichage de VaultDAO"
+  },
+  "performance": {
+    "title": "Performance",
+    "subtitle": "Core Web Vitals et métriques des ressources",
+    "thresholds": "Seuils",
+    "good": "Bon",
+    "warning": "À améliorer",
+    "largestResources": "Ressources les plus volumineuses",
+    "allGood": "Toutes les métriques sont bonnes",
+    "lcp": "Largest Contentful Paint",
+    "fid": "Délai de première entrée",
+    "cls": "Changement de mise en page cumulé",
+    "ttfb": "Délai jusqu'au premier octet",
+    "fcp": "First Contentful Paint",
+    "memoryUsage": "Utilisation de la mémoire",
+    "heapUsage": "Utilisation du tas"
   }
 }

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -22,7 +22,17 @@
     "previous": "上一步",
     "retry": "重试",
     "notFound": "未找到",
-    "loadingEllipsis": "加载中..."
+    "loadingEllipsis": "加载中...",
+    "detected": "已检测",
+    "installRequired": "需要安装",
+    "hide": "隐藏",
+    "refresh": "刷新",
+    "confirmDeleteTemplate": "确定要删除此模板吗？",
+    "templateImportedSuccess": "模板导入成功！",
+    "invalidTemplateFormat": "模板格式无效",
+    "failedToImportTemplate": "导入模板失败",
+    "formSubmittedPreview": "表单提交成功（预览模式）",
+    "confirmClearErrorHistory": "要清除所有错误历史记录吗？"
   },
   "navigation": {
     "dashboard": "仪表板",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "代币合约地址",
     "adding": "添加中...",
     "failedToLoadBalance": "加载余额失败",
-    "refreshBalance": "刷新余额"
+    "refreshBalance": "刷新余额",
+    "signers": "签署人"
   },
   "proposals": {
     "title": "提案",
@@ -78,7 +89,8 @@
     "reject": "拒绝",
     "pending": "待处理",
     "approved": "已批准",
-    "rejected": "已拒绝"
+    "rejected": "已拒绝",
+    "submittedSuccess": "提案提交成功！"
   },
   "transactions": {
     "title": "交易",
@@ -107,7 +119,8 @@
     "amount": "请输入有效金额",
     "selectOption": "请选择一个选项",
     "submit": "提交",
-    "reset": "重置"
+    "reset": "重置",
+    "circularDependencies": "逻辑中存在循环依赖！"
   },
   "language": {
     "selectLanguage": "选择语言",
@@ -145,5 +158,108 @@
     "approve": "批准",
     "reject": "拒绝",
     "create_payment": "创建付款"
+  },
+  "nav": {
+    "overview": "概览",
+    "proposals": "提案",
+    "recurringPayments": "定期付款",
+    "escrow": "托管",
+    "governance": "治理",
+    "activity": "活动",
+    "templates": "模板",
+    "analytics": "分析",
+    "errorAnalytics": "错误分析",
+    "settings": "设置"
+  },
+  "onboarding": {
+    "tourDesc": "快速浏览一下，了解所有功能。"
+  },
+  "portfolio": {
+    "title": "投资组合概览",
+    "totalValue": "总价值",
+    "allocation": "代币分配",
+    "lowBalance": "余额不足",
+    "estimate": "估算"
+  },
+  "voice": {
+    "start": "开始聆听",
+    "stop": "停止聆听",
+    "permissionRequired": "需要麦克风权限",
+    "timedOut": "聆听超时",
+    "timedOutHint": "请重试或说出唤醒词",
+    "settings": "语音设置",
+    "wakeWord": "唤醒词",
+    "availableCommands": "可用命令",
+    "notSupported": "此浏览器不支持语音输入"
+  },
+  "settings": {
+    "title": "设置",
+    "vaultConfig": "金库配置",
+    "vaultConfigDesc": "此金库的签署人、阈值和支出限额",
+    "yourRole": "您的角色",
+    "signerSetNote": "您是此金库的签署人",
+    "notSignerSetNote": "您不是此金库的签署人",
+    "threshold": "批准阈值",
+    "approvalsNeeded": "执行提案所需的签署人批准数量",
+    "timelock": "时间锁",
+    "timelockTrigger": "触发阈值",
+    "timelockDelay": "延迟",
+    "signers": "签署人",
+    "currentWallet": "您的钱包",
+    "signerListUnavailable": "签署人列表不可用",
+    "spendingLimits": "支出限额",
+    "perProposal": "每项提案",
+    "daily": "每日",
+    "weekly": "每周",
+    "supportedWallets": "支持的钱包",
+    "supportedWalletsDesc": "您可用于连接 VaultDAO 的钱包",
+    "roleManagement": "角色管理",
+    "exportHistory": "导出历史",
+    "exportHistoryDesc": "先前导出的审计和签名文件",
+    "reExport": "重新导出",
+    "clearHistory": "清除历史记录",
+    "noExportHistory": "没有导出历史记录",
+    "noExportHistoryDesc": "导出的文件将显示在此处",
+    "recipientLists": "收件人列表",
+    "manageLists": "管理列表",
+    "recipientListsDesc": "白名单和黑名单收件人地址",
+    "onboarding": "入门引导",
+    "restartTour": "重新开始导览",
+    "onboardingDesc": "重新播放产品引导教程",
+    "wrongNetwork": "网络错误",
+    "viewOnExplorer": "在浏览器中查看",
+    "loadingVaultConfig": "正在加载金库配置...",
+    "updateThreshold": "更新阈值",
+    "readOnly": "只读",
+    "removeSignerTitle": "移除签署人",
+    "addSigner": "添加签署人",
+    "stellarAddressPlaceholder": "G... Stellar 地址",
+    "downloadAgain": "再次下载",
+    "reDownloadUnavailable": "无法重新下载（没有存储的内容）",
+    "reExportAria": "重新导出 {{filename}}",
+    "reExportUnavailable": "无法重新导出",
+    "clearExportHistoryAria": "清除导出历史记录",
+    "removeSignerModalTitle": "移除签署人",
+    "removeSignerModalMessage": "要将 {{address}} 从金库签署人中移除吗？除非重新添加，否则无法撤销此操作。",
+    "removing": "正在移除…",
+    "remove": "移除",
+    "language": "语言",
+    "languageDesc": "选择 VaultDAO 的显示语言"
+  },
+  "performance": {
+    "title": "性能",
+    "subtitle": "核心网页指标和资源指标",
+    "thresholds": "阈值",
+    "good": "良好",
+    "warning": "需要改进",
+    "largestResources": "最大资源",
+    "allGood": "所有指标状态良好",
+    "lcp": "最大内容绘制",
+    "fid": "首次输入延迟",
+    "cls": "累积布局偏移",
+    "ttfb": "首字节时间",
+    "fcp": "首次内容绘制",
+    "memoryUsage": "内存使用情况",
+    "heapUsage": "堆内存使用情况"
   }
 }

--- a/frontend/src/app/dashboard/Settings.tsx
+++ b/frontend/src/app/dashboard/Settings.tsx
@@ -38,6 +38,8 @@ import { useOnboarding } from '../../context/OnboardingProvider';
 import { Play } from 'lucide-react';
 import PerformanceDashboard from '../../components/PerformanceDashboard';
 import { AccessibilitySettings } from '../../components/AccessibilitySettings';
+import { LanguageSwitcher } from '../../components/LanguageSwitcher';
+import { Globe } from 'lucide-react';
 
 /** Item with stored content for re-download (when ExportModal saves it) */
 interface ExportItemWithContent extends ExportHistoryItem {
@@ -250,14 +252,14 @@ const Settings: React.FC = () => {
             className="min-h-[44px] px-4 py-2 rounded-lg bg-gray-700 hover:bg-gray-600 disabled:opacity-60 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-2 touch-manipulation"
           >
             {configLoading ? <Loader2 size={16} className="animate-spin" /> : <RefreshCw size={16} />}
-            Refresh
+            {t('common.refresh')}
           </button>
         </div>
 
         {configLoading && !vaultConfig ? (
           <div className="flex items-center gap-2 text-gray-300 py-4">
             <Loader2 size={16} className="animate-spin" />
-            Loading vault configuration...
+            {t('settings.loadingVaultConfig')}
           </div>
         ) : null}
 
@@ -308,7 +310,7 @@ const Settings: React.FC = () => {
                     className="w-full flex items-center justify-center gap-2 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-medium py-2 rounded-lg transition-colors"
                   >
                     {thresholdLoading ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
-                    Update Threshold
+                    {t('settings.updateThreshold')}
                   </button>
                 </div>
               )}
@@ -336,7 +338,7 @@ const Settings: React.FC = () => {
                 </p>
                 {!isAdmin && (
                   <span className="text-xs text-gray-500 italic flex items-center gap-1">
-                    <Shield size={12} /> Read-only
+                    <Shield size={12} /> {t('settings.readOnly')}
                   </span>
                 )}
               </div>
@@ -365,7 +367,7 @@ const Settings: React.FC = () => {
                           <button
                             onClick={() => setRemoveConfirmAddress(signer)}
                             className="p-1.5 rounded text-red-400 hover:bg-red-500/10 transition-colors"
-                            title="Remove signer"
+                            title={t('settings.removeSignerTitle')}
                           >
                             <X size={14} />
                           </button>
@@ -379,13 +381,13 @@ const Settings: React.FC = () => {
               )}
               {isAdmin && (
                 <div className="mt-4 space-y-2 pt-4 border-t border-gray-700">
-                  <p className="text-xs text-gray-400 font-medium">Add Signer</p>
+                  <p className="text-xs text-gray-400 font-medium">{t('settings.addSigner')}</p>
                   <div className="flex gap-2">
                     <input
                       type="text"
                       value={newSignerAddress}
                       onChange={(e) => { setNewSignerAddress(e.target.value); setAddSignerError(null); }}
-                      placeholder="G... Stellar address"
+                      placeholder={t('settings.stellarAddressPlaceholder')}
                       className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white font-mono focus:ring-2 focus:ring-purple-500 outline-none"
                     />
                     <button
@@ -394,7 +396,7 @@ const Settings: React.FC = () => {
                       className="flex items-center gap-1.5 bg-purple-600 hover:bg-purple-700 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-medium px-3 py-2 rounded-lg transition-colors"
                     >
                       {addSignerLoading ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
-                      Add
+                      {t('common.add')}
                     </button>
                   </div>
                   {addSignerError && <p className="text-xs text-red-400">{addSignerError}</p>}
@@ -467,11 +469,15 @@ const Settings: React.FC = () => {
                       disabled={!hasStoredContent(item)}
                       title={
                         hasStoredContent(item)
-                          ? 'Download again'
-                          : 'Re-download not available (no stored content)'
+                          ? t('settings.downloadAgain')
+                          : t('settings.reDownloadUnavailable')
                       }
                       className="min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-gray-700 hover:bg-gray-600 text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed touch-manipulation focus:outline-none focus:ring-2 focus:ring-purple-500"
-                      aria-label={hasStoredContent(item) ? `Re-export ${item.filename}` : 'Re-export not available'}
+                      aria-label={
+                        hasStoredContent(item)
+                          ? t('settings.reExportAria', { filename: item.filename })
+                          : t('settings.reExportUnavailable')
+                      }
                     >
                       <Download size={18} aria-hidden="true" />
                       <span className="hidden sm:inline">{t('settings.reExport')}</span>
@@ -486,7 +492,7 @@ const Settings: React.FC = () => {
                 type="button"
                 onClick={handleClearHistory}
                 className="min-h-[44px] flex items-center gap-2 px-4 py-2.5 rounded-lg bg-gray-700 hover:bg-red-600/80 text-white text-sm touch-manipulation focus:outline-none focus:ring-2 focus:ring-purple-500"
-                aria-label="Clear export history"
+                aria-label={t('settings.clearExportHistoryAria')}
               >
                 <Trash2 size={18} aria-hidden="true" />
                 {t('settings.clearHistory')}
@@ -540,6 +546,20 @@ const Settings: React.FC = () => {
         <p className="text-gray-400 text-sm">{t('settings.onboardingDesc')}</p>
       </div>
 
+      {/* Language Settings */}
+      <div className="bg-gray-800 rounded-xl border border-gray-700 p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Globe className="text-blue-400" size={24} aria-hidden="true" />
+            <div>
+              <h3 className="text-lg font-semibold">{t('settings.language')}</h3>
+              <p className="text-gray-400 text-sm mt-1">{t('settings.languageDesc')}</p>
+            </div>
+          </div>
+          <LanguageSwitcher />
+        </div>
+      </div>
+
       {/* Accessibility Settings */}
       <div className="bg-gray-800 rounded-xl border border-gray-700 p-6">
         <AccessibilitySettings />
@@ -556,9 +576,11 @@ const Settings: React.FC = () => {
 
       <ConfirmationModal
         isOpen={!!removeConfirmAddress}
-        title="Remove Signer"
-        message={`Remove ${removeConfirmAddress ? truncateAddress(removeConfirmAddress, 8, 6) : ''} from the vault signers? This cannot be undone without re-adding them.`}
-        confirmText={removeSignerLoading ? 'Removing…' : 'Remove'}
+        title={t('settings.removeSignerModalTitle')}
+        message={t('settings.removeSignerModalMessage', {
+          address: removeConfirmAddress ? truncateAddress(removeConfirmAddress, 8, 6) : '',
+        })}
+        confirmText={removeSignerLoading ? t('settings.removing') : t('settings.remove')}
         onConfirm={handleRemoveSigner}
         onCancel={() => setRemoveConfirmAddress(null)}
         isDestructive={true}

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,17 +1,38 @@
 import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { Copy, RefreshCw, ChevronDown, ChevronUp } from 'lucide-react';
-import { recordError } from '../utils/errorAnalytics';
+import { reportError } from './ErrorReporting';
 
 export type ErrorBoundaryContext = 'payment' | 'proposal' | 'dashboard' | 'generic';
 
 export const ERROR_DETAIL_KEY = 'vaultdao_last_error_detail';
+const LAST_ACCOUNT_KEY = 'vaultdao_last_account';
 
 export interface ErrorDetail {
   message: string;
   stack?: string;
   componentStack?: string;
   context: ErrorBoundaryContext;
+  user?: string;
+  page?: string;
   timestamp: string;
+}
+
+/**
+ * Best-effort current-user lookup for error metadata. ErrorBoundary is a
+ * class component mounted above the router/wallet providers, so it can't use
+ * the WalletContext hook — WalletContext persists the last-connected address
+ * to localStorage under this key on every connect, which we read directly.
+ */
+function getCurrentUserForErrorReport(): string | undefined {
+  try {
+    return localStorage.getItem(LAST_ACCOUNT_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getCurrentPageForErrorReport(): string | undefined {
+  return typeof window !== 'undefined' ? window.location.pathname : undefined;
 }
 
 export function storeErrorDetail(detail: ErrorDetail): void {
@@ -94,13 +115,13 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    const isReportingEnabled = import.meta.env.VITE_ERROR_REPORTING_ENABLED;
-
     const redactedMessage = redactWalletAddresses(error.message || 'Unknown error');
     const redactedStack = error.stack ? redactWalletAddresses(error.stack) : undefined;
     const redactedContext = errorInfo.componentStack
       ? redactWalletAddresses(errorInfo.componentStack)
       : undefined;
+    const user = getCurrentUserForErrorReport();
+    const page = getCurrentPageForErrorReport();
 
     this.setState({ componentStack: redactedContext || null });
 
@@ -110,22 +131,27 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       stack: redactedStack,
       componentStack: redactedContext,
       context: this.props.context ?? 'generic',
+      user,
+      page,
       timestamp: new Date().toISOString(),
     });
 
-    if (isReportingEnabled) {
-      let errorId = '';
-      try {
-        errorId = recordError({
-          code: 'REACT_ERROR_BOUNDARY',
-          message: redactedMessage,
-          stack: redactedStack,
-          context: redactedContext,
-        });
-        this.setState({ errorId });
-      } catch (reportingError) {
-        console.error('Failed to report error to analytics:', reportingError);
-      }
+    // Always record locally (for the error ID shown below) and attempt to
+    // forward to the backend error-collection API — reportError() handles
+    // dedup, offline queueing, and silently no-ops the backend call when
+    // VITE_ERROR_REPORT_ENDPOINT isn't configured.
+    try {
+      const errorId = reportError({
+        code: 'REACT_ERROR_BOUNDARY',
+        message: redactedMessage,
+        stack: redactedStack,
+        context: redactedContext,
+        user,
+        page,
+      });
+      this.setState({ errorId });
+    } catch (reportingError) {
+      console.error('Failed to report error to analytics:', reportingError);
     }
 
     if (import.meta.env.DEV) {

--- a/frontend/src/components/ErrorDashboard.tsx
+++ b/frontend/src/components/ErrorDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { AlertCircle, BarChart3, RefreshCw, Trash2, Download, ChevronDown, ChevronUp, ExternalLink, Copy } from 'lucide-react';
 import {
   getErrorEvents,
@@ -31,6 +32,7 @@ interface GroupedError {
 }
 
 export default function ErrorDashboard() {
+  const { t } = useTranslation();
   const [events, setEvents] = useState<ErrorEvent[]>([]);
   const [counts, setCounts] = useState<Record<string, number>>({});
   const [total, setTotal] = useState(0);
@@ -53,7 +55,7 @@ export default function ErrorDashboard() {
     for (const ev of events) {
       const existing = groups.get(ev.message);
       if (existing) {
-        existing.count += 1;
+        existing.count += ev.occurrences ?? 1;
         existing.events.push(ev);
         if (ev.timestamp > existing.latestEvent.timestamp) {
           existing.latestEvent = ev;
@@ -61,7 +63,7 @@ export default function ErrorDashboard() {
       } else {
         groups.set(ev.message, {
           message: ev.message,
-          count: 1,
+          count: ev.occurrences ?? 1,
           latestEvent: ev,
           events: [ev],
         });
@@ -73,7 +75,7 @@ export default function ErrorDashboard() {
   }, [events]);
 
   const handleClear = () => {
-    if (window.confirm('Clear all error history?')) {
+    if (window.confirm(t('common.confirmClearErrorHistory'))) {
       clearErrorAnalytics();
       refresh();
     }

--- a/frontend/src/components/ErrorReporting.tsx
+++ b/frontend/src/components/ErrorReporting.tsx
@@ -15,6 +15,8 @@ export interface ReportPayload {
   message: string;
   stack?: string;
   context?: string;
+  user?: string;
+  page?: string;
   retryCount?: number;
 }
 
@@ -65,21 +67,26 @@ async function sendToBackend(payload: ReportPayload): Promise<boolean> {
 
 /**
  * Report an error: record for analytics, queue if offline, send to backend if online.
+ * Returns the local analytics id (for display as a support reference).
  */
-export function reportError(error: VaultError | ReportPayload): void {
+export function reportError(error: VaultError | ReportPayload): string {
   const payload: ReportPayload = {
     code: 'code' in error ? error.code : 'UNKNOWN',
     message: 'message' in error ? error.message : String(error),
     stack: 'stack' in error ? (error as { stack?: string }).stack : undefined,
     context: 'context' in error ? error.context : undefined,
+    user: 'user' in error ? (error as ReportPayload).user : undefined,
+    page: 'page' in error ? (error as ReportPayload).page : undefined,
     retryCount: 'retryCount' in error ? (error as ReportPayload).retryCount : undefined,
   };
 
-  recordError({
+  const id = recordError({
     code: payload.code,
     message: payload.message,
     stack: payload.stack,
     context: payload.context,
+    user: payload.user,
+    page: payload.page,
     retryCount: payload.retryCount,
   });
 
@@ -96,6 +103,8 @@ export function reportError(error: VaultError | ReportPayload): void {
     q.push(payload);
     setQueue(q);
   }
+
+  return id;
 }
 
 /**

--- a/frontend/src/components/FormBuilder.tsx
+++ b/frontend/src/components/FormBuilder.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, type DragEndEvent } from '@dnd-kit/core';
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { FormField, FormConfig, FieldType } from '../types/formBuilder';
@@ -12,6 +13,7 @@ import FormPreview from './FormPreview';
 interface FormBuilderProps { initialConfig?: FormConfig; onSave?: (config: FormConfig) => void; onCancel?: () => void; }
 
 const FormBuilder: React.FC<FormBuilderProps> = ({ initialConfig, onSave, onCancel }) => {
+  const { t } = useTranslation();
   const [fields, setFields] = useState<FormField[]>(initialConfig?.fields ?? []);
   const [selectedFieldId, setSelectedFieldId] = useState<string | undefined>();
   const [previewMode, setPreviewMode] = useState(false);
@@ -42,7 +44,7 @@ const FormBuilder: React.FC<FormBuilderProps> = ({ initialConfig, onSave, onCanc
   const duplicateField = (id: string) => { const f = fields.find(x => x.id === id); if (f) addField(f.type); };
 
   const onSaveClick = () => {
-    if (!validateConditionalLogic(fields).valid) return alert('Circular dependencies in logic!');
+    if (!validateConditionalLogic(fields).valid) return alert(t('forms.circularDependencies'));
     onSave?.({ id: initialConfig?.id ?? `form-${Date.now()}`, name: formName || 'Untitled', description: formDescription, fields, createdAt: initialConfig?.createdAt ?? Date.now(), updatedAt: Date.now(), version: (initialConfig?.version ?? 0) + 1 });
   };
 

--- a/frontend/src/components/FormPreview.tsx
+++ b/frontend/src/components/FormPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import type { FormField } from '../types/formBuilder';
 import FormRenderer from './FormRenderer';
 
@@ -8,6 +9,7 @@ interface FormPreviewProps {
 }
 
 const FormPreview: React.FC<FormPreviewProps> = ({ fields, onPreviewSubmit }) => {
+  const { t } = useTranslation();
   const config = {
     id: 'preview',
     name: 'Live Preview',
@@ -35,7 +37,7 @@ const FormPreview: React.FC<FormPreviewProps> = ({ fields, onPreviewSubmit }) =>
         onSubmit={(data) => {
           console.log('Preview form submitted:', data);
           onPreviewSubmit?.(data);
-          alert('Form submitted successfully (Preview Mode)');
+          alert(t('common.formSubmittedPreview'));
         }}
         submitButtonText="Submit Proposal"
       />

--- a/frontend/src/components/FormTemplates.tsx
+++ b/frontend/src/components/FormTemplates.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Copy, Trash2, Download, Upload } from 'lucide-react';
 import type { FormTemplate } from '../types/formBuilder';
 import {
@@ -14,20 +15,21 @@ interface FormTemplatesProps {
 }
 
 const FormTemplates: React.FC<FormTemplatesProps> = ({ onSelectTemplate }: FormTemplatesProps) => {
+  const { t } = useTranslation();
   const [templates, setTemplates] = useState<FormTemplate[]>(getAllTemplates());
   const [filterCategory, setFilterCategory] = useState<'all' | 'standard' | 'payroll' | 'invoice' | 'custom'>('all');
   const [searchQuery, setSearchQuery] = useState('');
 
   const filteredTemplates = useMemo(() => {
-    return templates.filter(t => {
-      const matchesCategory = filterCategory === 'all' || t.category === filterCategory;
-      const matchesSearch = !searchQuery || t.name.toLowerCase().includes(searchQuery.toLowerCase()) || t.description.toLowerCase().includes(searchQuery.toLowerCase());
+    return templates.filter(tpl => {
+      const matchesCategory = filterCategory === 'all' || tpl.category === filterCategory;
+      const matchesSearch = !searchQuery || tpl.name.toLowerCase().includes(searchQuery.toLowerCase()) || tpl.description.toLowerCase().includes(searchQuery.toLowerCase());
       return matchesCategory && matchesSearch;
     });
   }, [templates, filterCategory, searchQuery]);
 
   const handleDeleteTemplate = (id: string) => {
-    if (confirm('Are you sure you want to delete this template?')) {
+    if (confirm(t('common.confirmDeleteTemplate'))) {
       deleteCustomTemplate(id);
       setTemplates(getAllTemplates());
     }
@@ -58,12 +60,12 @@ const FormTemplates: React.FC<FormTemplatesProps> = ({ onSelectTemplate }: FormT
           template.isPublic = false;
           saveCustomTemplate(template);
           setTemplates(getAllTemplates());
-          alert('Template imported successfully!');
+          alert(t('common.templateImportedSuccess'));
         } else {
-          alert('Invalid template format');
+          alert(t('common.invalidTemplateFormat'));
         }
       } catch {
-        alert('Failed to import template');
+        alert(t('common.failedToImportTemplate'));
       }
     };
     reader.readAsText(file);

--- a/frontend/src/components/VoiceToText.tsx
+++ b/frontend/src/components/VoiceToText.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import type { InputHTMLAttributes } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Mic, MicOff } from 'lucide-react';
 
 interface VoiceToTextProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
@@ -10,6 +11,7 @@ interface VoiceToTextProps extends Omit<InputHTMLAttributes<HTMLInputElement>, '
 }
 
 export default function VoiceToText({ value, onChange, placeholder, className = '', ...inputProps }: VoiceToTextProps) {
+  const { t } = useTranslation();
   const [isListening, setIsListening] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
 
@@ -46,7 +48,7 @@ export default function VoiceToText({ value, onChange, placeholder, className = 
 
   const toggleListening = async () => {
     if (!recognitionRef.current) {
-      alert('Voice input not supported in this browser');
+      alert(t('voice.notSupported'));
       return;
     }
 
@@ -60,7 +62,7 @@ export default function VoiceToText({ value, onChange, placeholder, className = 
         recognitionRef.current.start();
         setIsListening(true);
       } catch {
-        alert('Microphone permission required');
+        alert(t('voice.permissionRequired'));
       }
     }
   };

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -73,9 +73,7 @@ describe('ErrorBoundary', () => {
     expect(screen.getByText('Go Home')).toBeInTheDocument();
   });
 
-  it('logs error to analytics when VITE_ERROR_REPORTING_ENABLED is set', () => {
-    vi.stubEnv('VITE_ERROR_REPORTING_ENABLED', 'true');
-
+  it('always logs error to analytics and displays the generated error ID', () => {
     render(
       <ErrorBoundary>
         <ThrowingComponent message="Analytics test error" />
@@ -88,20 +86,24 @@ describe('ErrorBoundary', () => {
         message: 'Analytics test error',
       })
     );
-
-    vi.unstubAllEnvs();
+    expect(screen.getByText('MOCK_ID_1')).toBeInTheDocument();
   });
 
-  it('does NOT log error to analytics when VITE_ERROR_REPORTING_ENABLED is not set', () => {
-    vi.unstubAllEnvs();
+  it('attaches the current wallet address and page path as error metadata', () => {
+    localStorage.setItem('vaultdao_last_account', 'GTESTACCOUNT123');
 
     render(
       <ErrorBoundary>
-        <ThrowingComponent message="Should not report" />
+        <ThrowingComponent message="metadata test error" />
       </ErrorBoundary>
     );
 
-    expect(recordError).not.toHaveBeenCalled();
+    expect(recordError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: 'GTESTACCOUNT123',
+        page: window.location.pathname,
+      })
+    );
   });
 
   // ── Context-specific recovery actions ──────────────────────────────────────

--- a/frontend/src/components/proposals/CreateProposalWizard.tsx
+++ b/frontend/src/components/proposals/CreateProposalWizard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useCollaboration } from '../../hooks/useCollaboration';
 import { TypingIndicator } from './TypingIndicator';
 import { OnlineUsers } from './OnlineUsers';
@@ -8,6 +9,7 @@ import { Users, AlertTriangle, Save, Globe } from 'lucide-react';
 import type { ProposalDraft } from '../../types/collaboration';
 
 export const CreateProposalWizard: React.FC = () => {
+  const { t } = useTranslation();
   const { address } = useWallet();
   const [draftId] = useState<string>(() => {
     const savedId = localStorage.getItem('vaultdao_current_draft_id');
@@ -76,7 +78,7 @@ export const CreateProposalWizard: React.FC = () => {
     
     // Process submission logic here (e.g. smart contract interaction)
     console.log('Submitting proposal:', formState);
-    alert('Proposal submitted successfully!');
+    alert(t('proposals.submittedSuccess'));
     localStorage.removeItem('vaultdao_current_draft_id');
     localStorage.removeItem(`draft-${draftId}`);
   };

--- a/frontend/src/translations/ar.json
+++ b/frontend/src/translations/ar.json
@@ -22,7 +22,17 @@
     "previous": "السابق",
     "retry": "حاول مرة أخرى",
     "notFound": "غير موجود",
-    "loadingEllipsis": "جاري التحميل..."
+    "loadingEllipsis": "جاري التحميل...",
+    "detected": "تم الكشف",
+    "installRequired": "التثبيت مطلوب",
+    "hide": "إخفاء",
+    "refresh": "تحديث",
+    "confirmDeleteTemplate": "هل أنت متأكد من رغبتك في حذف هذا القالب؟",
+    "templateImportedSuccess": "تم استيراد القالب بنجاح!",
+    "invalidTemplateFormat": "تنسيق القالب غير صالح",
+    "failedToImportTemplate": "فشل استيراد القالب",
+    "formSubmittedPreview": "تم إرسال النموذج بنجاح (وضع المعاينة)",
+    "confirmClearErrorHistory": "هل تريد مسح كل سجل الأخطاء؟"
   },
   "navigation": {
     "dashboard": "لوحة التحكم",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "عنوان عقد الرمز",
     "adding": "جاري الإضافة...",
     "failedToLoadBalance": "فشل في تحميل الرصيد",
-    "refreshBalance": "تحديث الرصيد"
+    "refreshBalance": "تحديث الرصيد",
+    "signers": "الموقعون"
   },
   "proposals": {
     "title": "الاقتراحات",
@@ -78,7 +89,8 @@
     "reject": "الرفض",
     "pending": "معلق",
     "approved": "موافق عليه",
-    "rejected": "مرفوض"
+    "rejected": "مرفوض",
+    "submittedSuccess": "تم تقديم الاقتراح بنجاح!"
   },
   "transactions": {
     "title": "المعاملات",
@@ -107,7 +119,8 @@
     "amount": "يرجى إدخال مبلغ صحيح",
     "selectOption": "يرجى اختيار خيار",
     "submit": "إرسال",
-    "reset": "إعادة تعيين"
+    "reset": "إعادة تعيين",
+    "circularDependencies": "اعتماديات دائرية في المنطق!"
   },
   "language": {
     "selectLanguage": "اختر اللغة",
@@ -145,5 +158,108 @@
     "approve": "يوافق",
     "reject": "يرفض",
     "create_payment": "إنشاء الدفع"
+  },
+  "nav": {
+    "overview": "نظرة عامة",
+    "proposals": "المقترحات",
+    "recurringPayments": "المدفوعات المتكررة",
+    "escrow": "الضمان",
+    "governance": "الحوكمة",
+    "activity": "النشاط",
+    "templates": "القوالب",
+    "analytics": "التحليلات",
+    "errorAnalytics": "تحليلات الأخطاء",
+    "settings": "الإعدادات"
+  },
+  "onboarding": {
+    "tourDesc": "قم بجولة سريعة للتعرف على جميع الميزات."
+  },
+  "portfolio": {
+    "title": "نظرة عامة على المحفظة",
+    "totalValue": "القيمة الإجمالية",
+    "allocation": "توزيع الرموز",
+    "lowBalance": "رصيد منخفض",
+    "estimate": "تقدير"
+  },
+  "voice": {
+    "start": "بدء الاستماع",
+    "stop": "إيقاف الاستماع",
+    "permissionRequired": "إذن الميكروفون مطلوب",
+    "timedOut": "انتهت مهلة الاستماع",
+    "timedOutHint": "حاول مرة أخرى أو قل كلمة التنبيه",
+    "settings": "إعدادات الصوت",
+    "wakeWord": "كلمة التنبيه",
+    "availableCommands": "الأوامر المتاحة",
+    "notSupported": "الإدخال الصوتي غير مدعوم في هذا المتصفح"
+  },
+  "settings": {
+    "title": "الإعدادات",
+    "vaultConfig": "إعدادات الخزنة",
+    "vaultConfigDesc": "الموقعون والحدود وقيود الإنفاق لهذه الخزنة",
+    "yourRole": "دورك",
+    "signerSetNote": "أنت أحد الموقعين على هذه الخزنة",
+    "notSignerSetNote": "أنت لست أحد الموقعين على هذه الخزنة",
+    "threshold": "حد الموافقة",
+    "approvalsNeeded": "عدد موافقات الموقعين المطلوبة لتنفيذ الاقتراح",
+    "timelock": "القفل الزمني",
+    "timelockTrigger": "يتم التفعيل فوق",
+    "timelockDelay": "التأخير",
+    "signers": "الموقعون",
+    "currentWallet": "محفظتك",
+    "signerListUnavailable": "قائمة الموقعين غير متوفرة",
+    "spendingLimits": "حدود الإنفاق",
+    "perProposal": "لكل اقتراح",
+    "daily": "يومي",
+    "weekly": "أسبوعي",
+    "supportedWallets": "المحافظ المدعومة",
+    "supportedWalletsDesc": "المحافظ التي يمكنك استخدامها للاتصال بـ VaultDAO",
+    "roleManagement": "إدارة الأدوار",
+    "exportHistory": "سجل التصدير",
+    "exportHistoryDesc": "ملفات التدقيق والتوقيع المُصدَّرة سابقًا",
+    "reExport": "إعادة التصدير",
+    "clearHistory": "مسح السجل",
+    "noExportHistory": "لا يوجد سجل تصدير",
+    "noExportHistoryDesc": "ستظهر الملفات المُصدَّرة هنا",
+    "recipientLists": "قوائم المستلمين",
+    "manageLists": "إدارة القوائم",
+    "recipientListsDesc": "عناوين المستلمين في القوائم البيضاء والسوداء",
+    "onboarding": "التأهيل",
+    "restartTour": "إعادة تشغيل الجولة",
+    "onboardingDesc": "إعادة تشغيل الجولة الإرشادية للمنتج",
+    "wrongNetwork": "شبكة خاطئة",
+    "viewOnExplorer": "عرض في المستكشف",
+    "loadingVaultConfig": "جارٍ تحميل إعدادات الخزنة...",
+    "updateThreshold": "تحديث الحد",
+    "readOnly": "للقراءة فقط",
+    "removeSignerTitle": "إزالة الموقّع",
+    "addSigner": "إضافة موقّع",
+    "stellarAddressPlaceholder": "عنوان ستيلر G...",
+    "downloadAgain": "تنزيل مرة أخرى",
+    "reDownloadUnavailable": "إعادة التنزيل غير متاحة (لا يوجد محتوى مخزّن)",
+    "reExportAria": "إعادة تصدير {{filename}}",
+    "reExportUnavailable": "إعادة التصدير غير متاحة",
+    "clearExportHistoryAria": "مسح سجل التصدير",
+    "removeSignerModalTitle": "إزالة الموقّع",
+    "removeSignerModalMessage": "هل تريد إزالة {{address}} من موقّعي الخزنة؟ لا يمكن التراجع عن هذا إلا بإعادة إضافته.",
+    "removing": "جارٍ الإزالة…",
+    "remove": "إزالة",
+    "language": "اللغة",
+    "languageDesc": "اختر لغة العرض لـ VaultDAO"
+  },
+  "performance": {
+    "title": "الأداء",
+    "subtitle": "مؤشرات الويب الأساسية ومقاييس الموارد",
+    "thresholds": "الحدود",
+    "good": "جيد",
+    "warning": "يحتاج إلى تحسين",
+    "largestResources": "أكبر الموارد",
+    "allGood": "جميع المقاييس تبدو جيدة",
+    "lcp": "أكبر عرض للمحتوى",
+    "fid": "تأخير أول إدخال",
+    "cls": "التحول التراكمي للتخطيط",
+    "ttfb": "الوقت حتى أول بايت",
+    "fcp": "أول عرض للمحتوى",
+    "memoryUsage": "استخدام الذاكرة",
+    "heapUsage": "استخدام الكومة"
   }
 }

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -22,7 +22,17 @@
     "previous": "Previous",
     "retry": "Retry",
     "notFound": "Not Found",
-    "loadingEllipsis": "Loading..."
+    "loadingEllipsis": "Loading...",
+    "detected": "Detected",
+    "installRequired": "Install Required",
+    "hide": "Hide",
+    "refresh": "Refresh",
+    "confirmDeleteTemplate": "Are you sure you want to delete this template?",
+    "templateImportedSuccess": "Template imported successfully!",
+    "invalidTemplateFormat": "Invalid template format",
+    "failedToImportTemplate": "Failed to import template",
+    "formSubmittedPreview": "Form submitted successfully (Preview Mode)",
+    "confirmClearErrorHistory": "Clear all error history?"
   },
   "navigation": {
     "dashboard": "Dashboard",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "Token Contract Address",
     "adding": "Adding...",
     "failedToLoadBalance": "Failed to load balance",
-    "refreshBalance": "Refresh balance"
+    "refreshBalance": "Refresh balance",
+    "signers": "Signers"
   },
   "proposals": {
     "title": "Proposals",
@@ -78,7 +89,8 @@
     "reject": "Reject",
     "pending": "Pending",
     "approved": "Approved",
-    "rejected": "Rejected"
+    "rejected": "Rejected",
+    "submittedSuccess": "Proposal submitted successfully!"
   },
   "transactions": {
     "title": "Transactions",
@@ -107,7 +119,8 @@
     "amount": "Please enter a valid amount",
     "selectOption": "Please select an option",
     "submit": "Submit",
-    "reset": "Reset"
+    "reset": "Reset",
+    "circularDependencies": "Circular dependencies in logic!"
   },
   "language": {
     "selectLanguage": "Select Language",
@@ -145,5 +158,108 @@
     "approve": "Approve",
     "reject": "Reject",
     "create_payment": "Create Payment"
+  },
+  "nav": {
+    "overview": "Overview",
+    "proposals": "Proposals",
+    "recurringPayments": "Recurring Payments",
+    "escrow": "Escrow",
+    "governance": "Governance",
+    "activity": "Activity",
+    "templates": "Templates",
+    "analytics": "Analytics",
+    "errorAnalytics": "Error Analytics",
+    "settings": "Settings"
+  },
+  "onboarding": {
+    "tourDesc": "Take a quick tour to learn about all the features."
+  },
+  "portfolio": {
+    "title": "Portfolio Overview",
+    "totalValue": "Total Value",
+    "allocation": "Token Allocation",
+    "lowBalance": "Low Balance",
+    "estimate": "estimate"
+  },
+  "voice": {
+    "start": "Start Listening",
+    "stop": "Stop Listening",
+    "permissionRequired": "Microphone permission required",
+    "timedOut": "Listening timed out",
+    "timedOutHint": "Try again or say the wake word",
+    "settings": "Voice Settings",
+    "wakeWord": "Wake word",
+    "availableCommands": "Available commands",
+    "notSupported": "Voice input not supported in this browser"
+  },
+  "settings": {
+    "title": "Settings",
+    "vaultConfig": "Vault Configuration",
+    "vaultConfigDesc": "Signers, thresholds, and spending limits for this vault",
+    "yourRole": "Your Role",
+    "signerSetNote": "You are a signer on this vault",
+    "notSignerSetNote": "You are not a signer on this vault",
+    "threshold": "Approval Threshold",
+    "approvalsNeeded": "Number of signer approvals required to execute a proposal",
+    "timelock": "Timelock",
+    "timelockTrigger": "Triggers above",
+    "timelockDelay": "Delay",
+    "signers": "Signers",
+    "currentWallet": "Your wallet",
+    "signerListUnavailable": "Signer list is unavailable",
+    "spendingLimits": "Spending Limits",
+    "perProposal": "Per proposal",
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "supportedWallets": "Supported Wallets",
+    "supportedWalletsDesc": "Wallets you can use to connect to VaultDAO",
+    "roleManagement": "Role Management",
+    "exportHistory": "Export History",
+    "exportHistoryDesc": "Previously exported audit and signature files",
+    "reExport": "Re-export",
+    "clearHistory": "Clear History",
+    "noExportHistory": "No export history",
+    "noExportHistoryDesc": "Exported files will appear here",
+    "recipientLists": "Recipient Lists",
+    "manageLists": "Manage Lists",
+    "recipientListsDesc": "Whitelisted and blacklisted recipient addresses",
+    "onboarding": "Onboarding",
+    "restartTour": "Restart Tour",
+    "onboardingDesc": "Replay the guided product tour",
+    "wrongNetwork": "Wrong network",
+    "viewOnExplorer": "View on Explorer",
+    "loadingVaultConfig": "Loading vault configuration...",
+    "updateThreshold": "Update Threshold",
+    "readOnly": "Read-only",
+    "removeSignerTitle": "Remove signer",
+    "addSigner": "Add Signer",
+    "stellarAddressPlaceholder": "G... Stellar address",
+    "downloadAgain": "Download again",
+    "reDownloadUnavailable": "Re-download not available (no stored content)",
+    "reExportAria": "Re-export {{filename}}",
+    "reExportUnavailable": "Re-export not available",
+    "clearExportHistoryAria": "Clear export history",
+    "removeSignerModalTitle": "Remove Signer",
+    "removeSignerModalMessage": "Remove {{address}} from the vault signers? This cannot be undone without re-adding them.",
+    "removing": "Removing…",
+    "remove": "Remove",
+    "language": "Language",
+    "languageDesc": "Choose the display language for VaultDAO"
+  },
+  "performance": {
+    "title": "Performance",
+    "subtitle": "Core Web Vitals and resource metrics",
+    "thresholds": "Thresholds",
+    "good": "Good",
+    "warning": "Needs improvement",
+    "largestResources": "Largest Resources",
+    "allGood": "All metrics look good",
+    "lcp": "Largest Contentful Paint",
+    "fid": "First Input Delay",
+    "cls": "Cumulative Layout Shift",
+    "ttfb": "Time to First Byte",
+    "fcp": "First Contentful Paint",
+    "memoryUsage": "Memory Usage",
+    "heapUsage": "Heap Usage"
   }
 }

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -22,7 +22,17 @@
     "previous": "Anterior",
     "retry": "Reintentar",
     "notFound": "No Encontrado",
-    "loadingEllipsis": "Cargando..."
+    "loadingEllipsis": "Cargando...",
+    "detected": "Detectado",
+    "installRequired": "Instalación requerida",
+    "hide": "Ocultar",
+    "refresh": "Actualizar",
+    "confirmDeleteTemplate": "¿Seguro que quieres eliminar esta plantilla?",
+    "templateImportedSuccess": "¡Plantilla importada correctamente!",
+    "invalidTemplateFormat": "Formato de plantilla no válido",
+    "failedToImportTemplate": "No se pudo importar la plantilla",
+    "formSubmittedPreview": "Formulario enviado correctamente (Modo Vista Previa)",
+    "confirmClearErrorHistory": "¿Borrar todo el historial de errores?"
   },
   "navigation": {
     "dashboard": "Panel de Control",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "Dirección del Contrato de Token",
     "adding": "Agregando...",
     "failedToLoadBalance": "Error al cargar el saldo",
-    "refreshBalance": "Actualizar equilibrio"
+    "refreshBalance": "Actualizar equilibrio",
+    "signers": "Firmantes"
   },
   "proposals": {
     "title": "Propuestas",
@@ -78,7 +89,8 @@
     "reject": "Rechazar",
     "pending": "Pendiente",
     "approved": "Aprobado",
-    "rejected": "Rechazado"
+    "rejected": "Rechazado",
+    "submittedSuccess": "¡Propuesta enviada correctamente!"
   },
   "transactions": {
     "title": "Transacciones",
@@ -107,7 +119,8 @@
     "amount": "Por favor, introduce una cantidad válida",
     "selectOption": "Por favor, selecciona una opción",
     "submit": "Enviar",
-    "reset": "Restablecer"
+    "reset": "Restablecer",
+    "circularDependencies": "¡Dependencias circulares en la lógica!"
   },
   "language": {
     "selectLanguage": "Seleccionar Idioma",
@@ -145,5 +158,108 @@
     "approve": "Aprobar",
     "reject": "Rechazar",
     "create_payment": "Crear Pago"
+  },
+  "nav": {
+    "overview": "Resumen",
+    "proposals": "Propuestas",
+    "recurringPayments": "Pagos Recurrentes",
+    "escrow": "Depósito en garantía",
+    "governance": "Gobernanza",
+    "activity": "Actividad",
+    "templates": "Plantillas",
+    "analytics": "Análisis",
+    "errorAnalytics": "Análisis de Errores",
+    "settings": "Configuración"
+  },
+  "onboarding": {
+    "tourDesc": "Haz un recorrido rápido para conocer todas las funciones."
+  },
+  "portfolio": {
+    "title": "Resumen de Cartera",
+    "totalValue": "Valor Total",
+    "allocation": "Asignación de Tokens",
+    "lowBalance": "Saldo Bajo",
+    "estimate": "estimado"
+  },
+  "voice": {
+    "start": "Iniciar Escucha",
+    "stop": "Detener Escucha",
+    "permissionRequired": "Se requiere permiso del micrófono",
+    "timedOut": "La escucha expiró",
+    "timedOutHint": "Intenta de nuevo o di la palabra de activación",
+    "settings": "Configuración de Voz",
+    "wakeWord": "Palabra de activación",
+    "availableCommands": "Comandos disponibles",
+    "notSupported": "La entrada de voz no es compatible con este navegador"
+  },
+  "settings": {
+    "title": "Configuración",
+    "vaultConfig": "Configuración de la Bóveda",
+    "vaultConfigDesc": "Firmantes, umbrales y límites de gasto de esta bóveda",
+    "yourRole": "Tu Rol",
+    "signerSetNote": "Eres firmante de esta bóveda",
+    "notSignerSetNote": "No eres firmante de esta bóveda",
+    "threshold": "Umbral de Aprobación",
+    "approvalsNeeded": "Número de aprobaciones de firmantes necesarias para ejecutar una propuesta",
+    "timelock": "Bloqueo Temporal",
+    "timelockTrigger": "Se activa por encima de",
+    "timelockDelay": "Retraso",
+    "signers": "Firmantes",
+    "currentWallet": "Tu billetera",
+    "signerListUnavailable": "La lista de firmantes no está disponible",
+    "spendingLimits": "Límites de Gasto",
+    "perProposal": "Por propuesta",
+    "daily": "Diario",
+    "weekly": "Semanal",
+    "supportedWallets": "Billeteras Compatibles",
+    "supportedWalletsDesc": "Billeteras que puedes usar para conectarte a VaultDAO",
+    "roleManagement": "Gestión de Roles",
+    "exportHistory": "Historial de Exportaciones",
+    "exportHistoryDesc": "Archivos de auditoría y firmas exportados anteriormente",
+    "reExport": "Reexportar",
+    "clearHistory": "Borrar Historial",
+    "noExportHistory": "Sin historial de exportaciones",
+    "noExportHistoryDesc": "Los archivos exportados aparecerán aquí",
+    "recipientLists": "Listas de Destinatarios",
+    "manageLists": "Administrar Listas",
+    "recipientListsDesc": "Direcciones de destinatarios en listas blancas y negras",
+    "onboarding": "Incorporación",
+    "restartTour": "Reiniciar Recorrido",
+    "onboardingDesc": "Repetir el recorrido guiado del producto",
+    "wrongNetwork": "Red incorrecta",
+    "viewOnExplorer": "Ver en el Explorador",
+    "loadingVaultConfig": "Cargando configuración de la bóveda...",
+    "updateThreshold": "Actualizar Umbral",
+    "readOnly": "Solo lectura",
+    "removeSignerTitle": "Eliminar firmante",
+    "addSigner": "Agregar Firmante",
+    "stellarAddressPlaceholder": "Dirección de Stellar G...",
+    "downloadAgain": "Descargar de nuevo",
+    "reDownloadUnavailable": "No se puede volver a descargar (sin contenido almacenado)",
+    "reExportAria": "Reexportar {{filename}}",
+    "reExportUnavailable": "Reexportación no disponible",
+    "clearExportHistoryAria": "Borrar historial de exportaciones",
+    "removeSignerModalTitle": "Eliminar Firmante",
+    "removeSignerModalMessage": "¿Eliminar a {{address}} de los firmantes de la bóveda? Esto no se puede deshacer sin volver a agregarlo.",
+    "removing": "Eliminando…",
+    "remove": "Eliminar",
+    "language": "Idioma",
+    "languageDesc": "Elige el idioma de visualización de VaultDAO"
+  },
+  "performance": {
+    "title": "Rendimiento",
+    "subtitle": "Core Web Vitals y métricas de recursos",
+    "thresholds": "Umbrales",
+    "good": "Bueno",
+    "warning": "Necesita mejorar",
+    "largestResources": "Recursos Más Grandes",
+    "allGood": "Todas las métricas se ven bien",
+    "lcp": "Mayor Renderizado de Contenido",
+    "fid": "Retraso en la Primera Entrada",
+    "cls": "Cambio Acumulativo de Diseño",
+    "ttfb": "Tiempo al Primer Byte",
+    "fcp": "Primer Renderizado de Contenido",
+    "memoryUsage": "Uso de Memoria",
+    "heapUsage": "Uso del Heap"
   }
 }

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -22,7 +22,17 @@
     "previous": "Précédent",
     "retry": "Réessayer",
     "notFound": "Non trouvé",
-    "loadingEllipsis": "Chargement..."
+    "loadingEllipsis": "Chargement...",
+    "detected": "Détecté",
+    "installRequired": "Installation requise",
+    "hide": "Masquer",
+    "refresh": "Actualiser",
+    "confirmDeleteTemplate": "Voulez-vous vraiment supprimer ce modèle ?",
+    "templateImportedSuccess": "Modèle importé avec succès !",
+    "invalidTemplateFormat": "Format de modèle invalide",
+    "failedToImportTemplate": "Échec de l'importation du modèle",
+    "formSubmittedPreview": "Formulaire envoyé avec succès (mode aperçu)",
+    "confirmClearErrorHistory": "Effacer tout l'historique des erreurs ?"
   },
   "navigation": {
     "dashboard": "Tableau de Bord",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "Adresse du Contrat de Jeton",
     "adding": "Ajout...",
     "failedToLoadBalance": "Impossible de charger le solde",
-    "refreshBalance": "Actualiser le solde"
+    "refreshBalance": "Actualiser le solde",
+    "signers": "Signataires"
   },
   "proposals": {
     "title": "Propositions",
@@ -78,7 +89,8 @@
     "reject": "Rejeter",
     "pending": "En Attente",
     "approved": "Approuvé",
-    "rejected": "Rejeté"
+    "rejected": "Rejeté",
+    "submittedSuccess": "Proposition soumise avec succès !"
   },
   "transactions": {
     "title": "Transactions",
@@ -107,7 +119,8 @@
     "amount": "Veuillez entrer un montant valide",
     "selectOption": "Veuillez sélectionner une option",
     "submit": "Soumettre",
-    "reset": "Réinitialiser"
+    "reset": "Réinitialiser",
+    "circularDependencies": "Dépendances circulaires dans la logique !"
   },
   "language": {
     "selectLanguage": "Sélectionner la Langue",
@@ -145,5 +158,108 @@
     "approve": "Approuver",
     "reject": "Rejeter",
     "create_payment": "Créer un paiement"
+  },
+  "nav": {
+    "overview": "Aperçu",
+    "proposals": "Propositions",
+    "recurringPayments": "Paiements récurrents",
+    "escrow": "Séquestre",
+    "governance": "Gouvernance",
+    "activity": "Activité",
+    "templates": "Modèles",
+    "analytics": "Analytique",
+    "errorAnalytics": "Analytique des erreurs",
+    "settings": "Paramètres"
+  },
+  "onboarding": {
+    "tourDesc": "Faites une visite rapide pour découvrir toutes les fonctionnalités."
+  },
+  "portfolio": {
+    "title": "Aperçu du portefeuille",
+    "totalValue": "Valeur totale",
+    "allocation": "Allocation des jetons",
+    "lowBalance": "Solde faible",
+    "estimate": "estimation"
+  },
+  "voice": {
+    "start": "Démarrer l'écoute",
+    "stop": "Arrêter l'écoute",
+    "permissionRequired": "Autorisation du microphone requise",
+    "timedOut": "L'écoute a expiré",
+    "timedOutHint": "Réessayez ou dites le mot de réveil",
+    "settings": "Paramètres vocaux",
+    "wakeWord": "Mot de réveil",
+    "availableCommands": "Commandes disponibles",
+    "notSupported": "La saisie vocale n'est pas prise en charge par ce navigateur"
+  },
+  "settings": {
+    "title": "Paramètres",
+    "vaultConfig": "Configuration du coffre",
+    "vaultConfigDesc": "Signataires, seuils et limites de dépenses de ce coffre",
+    "yourRole": "Votre rôle",
+    "signerSetNote": "Vous êtes signataire de ce coffre",
+    "notSignerSetNote": "Vous n'êtes pas signataire de ce coffre",
+    "threshold": "Seuil d'approbation",
+    "approvalsNeeded": "Nombre d'approbations de signataires requises pour exécuter une proposition",
+    "timelock": "Verrouillage temporel",
+    "timelockTrigger": "Se déclenche au-dessus de",
+    "timelockDelay": "Délai",
+    "signers": "Signataires",
+    "currentWallet": "Votre portefeuille",
+    "signerListUnavailable": "La liste des signataires n'est pas disponible",
+    "spendingLimits": "Limites de dépenses",
+    "perProposal": "Par proposition",
+    "daily": "Quotidien",
+    "weekly": "Hebdomadaire",
+    "supportedWallets": "Portefeuilles pris en charge",
+    "supportedWalletsDesc": "Portefeuilles que vous pouvez utiliser pour vous connecter à VaultDAO",
+    "roleManagement": "Gestion des rôles",
+    "exportHistory": "Historique des exports",
+    "exportHistoryDesc": "Fichiers d'audit et de signature précédemment exportés",
+    "reExport": "Réexporter",
+    "clearHistory": "Effacer l'historique",
+    "noExportHistory": "Aucun historique d'export",
+    "noExportHistoryDesc": "Les fichiers exportés apparaîtront ici",
+    "recipientLists": "Listes de destinataires",
+    "manageLists": "Gérer les listes",
+    "recipientListsDesc": "Adresses de destinataires en liste blanche et noire",
+    "onboarding": "Intégration",
+    "restartTour": "Redémarrer la visite",
+    "onboardingDesc": "Rejouer la visite guidée du produit",
+    "wrongNetwork": "Mauvais réseau",
+    "viewOnExplorer": "Voir sur l'explorateur",
+    "loadingVaultConfig": "Chargement de la configuration du coffre...",
+    "updateThreshold": "Mettre à jour le seuil",
+    "readOnly": "Lecture seule",
+    "removeSignerTitle": "Supprimer le signataire",
+    "addSigner": "Ajouter un signataire",
+    "stellarAddressPlaceholder": "Adresse Stellar G...",
+    "downloadAgain": "Télécharger à nouveau",
+    "reDownloadUnavailable": "Retéléchargement indisponible (aucun contenu enregistré)",
+    "reExportAria": "Réexporter {{filename}}",
+    "reExportUnavailable": "Réexportation indisponible",
+    "clearExportHistoryAria": "Effacer l'historique des exports",
+    "removeSignerModalTitle": "Supprimer le signataire",
+    "removeSignerModalMessage": "Retirer {{address}} des signataires du coffre ? Cette action est irréversible sans le rajouter.",
+    "removing": "Suppression…",
+    "remove": "Supprimer",
+    "language": "Langue",
+    "languageDesc": "Choisissez la langue d'affichage de VaultDAO"
+  },
+  "performance": {
+    "title": "Performance",
+    "subtitle": "Core Web Vitals et métriques des ressources",
+    "thresholds": "Seuils",
+    "good": "Bon",
+    "warning": "À améliorer",
+    "largestResources": "Ressources les plus volumineuses",
+    "allGood": "Toutes les métriques sont bonnes",
+    "lcp": "Largest Contentful Paint",
+    "fid": "Délai de première entrée",
+    "cls": "Changement de mise en page cumulé",
+    "ttfb": "Délai jusqu'au premier octet",
+    "fcp": "First Contentful Paint",
+    "memoryUsage": "Utilisation de la mémoire",
+    "heapUsage": "Utilisation du tas"
   }
 }

--- a/frontend/src/translations/zh.json
+++ b/frontend/src/translations/zh.json
@@ -22,7 +22,17 @@
     "previous": "上一步",
     "retry": "重试",
     "notFound": "未找到",
-    "loadingEllipsis": "加载中..."
+    "loadingEllipsis": "加载中...",
+    "detected": "已检测",
+    "installRequired": "需要安装",
+    "hide": "隐藏",
+    "refresh": "刷新",
+    "confirmDeleteTemplate": "确定要删除此模板吗？",
+    "templateImportedSuccess": "模板导入成功！",
+    "invalidTemplateFormat": "模板格式无效",
+    "failedToImportTemplate": "导入模板失败",
+    "formSubmittedPreview": "表单提交成功（预览模式）",
+    "confirmClearErrorHistory": "要清除所有错误历史记录吗？"
   },
   "navigation": {
     "dashboard": "仪表板",
@@ -66,7 +76,8 @@
     "tokenContractAddress": "代币合约地址",
     "adding": "添加中...",
     "failedToLoadBalance": "加载余额失败",
-    "refreshBalance": "刷新余额"
+    "refreshBalance": "刷新余额",
+    "signers": "签署人"
   },
   "proposals": {
     "title": "提案",
@@ -78,7 +89,8 @@
     "reject": "拒绝",
     "pending": "待处理",
     "approved": "已批准",
-    "rejected": "已拒绝"
+    "rejected": "已拒绝",
+    "submittedSuccess": "提案提交成功！"
   },
   "transactions": {
     "title": "交易",
@@ -107,7 +119,8 @@
     "amount": "请输入有效金额",
     "selectOption": "请选择一个选项",
     "submit": "提交",
-    "reset": "重置"
+    "reset": "重置",
+    "circularDependencies": "逻辑中存在循环依赖！"
   },
   "language": {
     "selectLanguage": "选择语言",
@@ -145,5 +158,108 @@
     "approve": "批准",
     "reject": "拒绝",
     "create_payment": "创建付款"
+  },
+  "nav": {
+    "overview": "概览",
+    "proposals": "提案",
+    "recurringPayments": "定期付款",
+    "escrow": "托管",
+    "governance": "治理",
+    "activity": "活动",
+    "templates": "模板",
+    "analytics": "分析",
+    "errorAnalytics": "错误分析",
+    "settings": "设置"
+  },
+  "onboarding": {
+    "tourDesc": "快速浏览一下，了解所有功能。"
+  },
+  "portfolio": {
+    "title": "投资组合概览",
+    "totalValue": "总价值",
+    "allocation": "代币分配",
+    "lowBalance": "余额不足",
+    "estimate": "估算"
+  },
+  "voice": {
+    "start": "开始聆听",
+    "stop": "停止聆听",
+    "permissionRequired": "需要麦克风权限",
+    "timedOut": "聆听超时",
+    "timedOutHint": "请重试或说出唤醒词",
+    "settings": "语音设置",
+    "wakeWord": "唤醒词",
+    "availableCommands": "可用命令",
+    "notSupported": "此浏览器不支持语音输入"
+  },
+  "settings": {
+    "title": "设置",
+    "vaultConfig": "金库配置",
+    "vaultConfigDesc": "此金库的签署人、阈值和支出限额",
+    "yourRole": "您的角色",
+    "signerSetNote": "您是此金库的签署人",
+    "notSignerSetNote": "您不是此金库的签署人",
+    "threshold": "批准阈值",
+    "approvalsNeeded": "执行提案所需的签署人批准数量",
+    "timelock": "时间锁",
+    "timelockTrigger": "触发阈值",
+    "timelockDelay": "延迟",
+    "signers": "签署人",
+    "currentWallet": "您的钱包",
+    "signerListUnavailable": "签署人列表不可用",
+    "spendingLimits": "支出限额",
+    "perProposal": "每项提案",
+    "daily": "每日",
+    "weekly": "每周",
+    "supportedWallets": "支持的钱包",
+    "supportedWalletsDesc": "您可用于连接 VaultDAO 的钱包",
+    "roleManagement": "角色管理",
+    "exportHistory": "导出历史",
+    "exportHistoryDesc": "先前导出的审计和签名文件",
+    "reExport": "重新导出",
+    "clearHistory": "清除历史记录",
+    "noExportHistory": "没有导出历史记录",
+    "noExportHistoryDesc": "导出的文件将显示在此处",
+    "recipientLists": "收件人列表",
+    "manageLists": "管理列表",
+    "recipientListsDesc": "白名单和黑名单收件人地址",
+    "onboarding": "入门引导",
+    "restartTour": "重新开始导览",
+    "onboardingDesc": "重新播放产品引导教程",
+    "wrongNetwork": "网络错误",
+    "viewOnExplorer": "在浏览器中查看",
+    "loadingVaultConfig": "正在加载金库配置...",
+    "updateThreshold": "更新阈值",
+    "readOnly": "只读",
+    "removeSignerTitle": "移除签署人",
+    "addSigner": "添加签署人",
+    "stellarAddressPlaceholder": "G... Stellar 地址",
+    "downloadAgain": "再次下载",
+    "reDownloadUnavailable": "无法重新下载（没有存储的内容）",
+    "reExportAria": "重新导出 {{filename}}",
+    "reExportUnavailable": "无法重新导出",
+    "clearExportHistoryAria": "清除导出历史记录",
+    "removeSignerModalTitle": "移除签署人",
+    "removeSignerModalMessage": "要将 {{address}} 从金库签署人中移除吗？除非重新添加，否则无法撤销此操作。",
+    "removing": "正在移除…",
+    "remove": "移除",
+    "language": "语言",
+    "languageDesc": "选择 VaultDAO 的显示语言"
+  },
+  "performance": {
+    "title": "性能",
+    "subtitle": "核心网页指标和资源指标",
+    "thresholds": "阈值",
+    "good": "良好",
+    "warning": "需要改进",
+    "largestResources": "最大资源",
+    "allGood": "所有指标状态良好",
+    "lcp": "最大内容绘制",
+    "fid": "首次输入延迟",
+    "cls": "累积布局偏移",
+    "ttfb": "首字节时间",
+    "fcp": "首次内容绘制",
+    "memoryUsage": "内存使用情况",
+    "heapUsage": "堆内存使用情况"
   }
 }

--- a/frontend/src/utils/errorAnalytics.ts
+++ b/frontend/src/utils/errorAnalytics.ts
@@ -9,14 +9,23 @@ export interface ErrorEvent {
   message: string;
   stack?: string;
   context?: string;
+  /** Wallet address of the signed-in user when the error occurred, if known. */
+  user?: string;
+  /** Route/pathname the error occurred on. */
+  page?: string;
   timestamp: number;
   userAgent: string;
   url: string;
   retryCount?: number;
+  /** Number of times this same (code, message) pair has recurred within the dedup window. */
+  occurrences: number;
 }
 
 const STORAGE_KEY = 'vaultdao_error_events';
 const MAX_STORED = 100;
+// Repeated errors with the same code+message within this window are folded
+// into a single event (occurrences incremented) instead of creating noise.
+const DEDUP_WINDOW_MS = 5 * 60 * 1000;
 
 // Initialize from localStorage
 const loadEvents = (): ErrorEvent[] => {
@@ -40,21 +49,40 @@ const persistEvents = () => {
 };
 
 /**
- * Record an error for analytics.
+ * Record an error for analytics. Repeated errors (same code + message) within
+ * DEDUP_WINDOW_MS are folded into the existing event rather than creating a
+ * new entry, so a crash loop doesn't flood the store or the dashboard.
  */
 export function recordError(payload: {
   code: string;
   message: string;
   stack?: string;
   context?: string;
+  user?: string;
+  page?: string;
   retryCount?: number;
 }): string {
+  const now = Date.now();
+  const existing = events.find(
+    (e) => e.code === payload.code && e.message === payload.message && now - e.timestamp < DEDUP_WINDOW_MS,
+  );
+
+  if (existing) {
+    existing.occurrences += 1;
+    existing.timestamp = now;
+    if (payload.user) existing.user = payload.user;
+    if (payload.page) existing.page = payload.page;
+    persistEvents();
+    return existing.id;
+  }
+
   // 8-character uppercase UUID for support reference
   const id = Math.random().toString(36).substring(2, 10).toUpperCase();
   const event: ErrorEvent = {
     ...payload,
     id,
-    timestamp: Date.now(),
+    timestamp: now,
+    occurrences: 1,
     userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown',
     url: typeof window !== 'undefined' ? window.location.href : 'unknown',
   };


### PR DESCRIPTION
Backend gains a POST /v1/errors endpoint (unauthenticated, rate-limited, deduplicated) for the frontend ErrorBoundary to report crashes, with an admin-gated GET for listing. Frontend error UI (ErrorBoundary, ErrorDashboard, ErrorReporting, errorAnalytics) wires up to it via VITE_ERROR_REPORT_ENDPOINT, and translation strings are extended across ar/en/es/fr/zh for the new error-reporting and settings UI.

## Summary

What does this PR change, and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Tests

## Related issues

Closes #1396
closes #1397 
closes #1398 
closes #1399 

## Test plan

- [ ] `cd contracts/vault && cargo test` (contract changes)
- [ ] `cd frontend && npm test` (UI changes)
- [ ] `npm run backend:typecheck && npm run backend:test` (backend changes)

## Checklist

- [ ] Code follows project conventions (formatting, no panics in contracts)
- [ ] Tests added or updated where behavior changed
- [ ] Documentation updated if user-facing behavior changed
- [ ] No secrets or `.env` files committed
