### PR TITLE
Feature/event replay and filter validation

### DIFF
--- a/backend/src/modules/events/filters/event-filter.types.ts
+++ b/backend/src/modules/events/filters/event-filter.types.ts
@@ -1,0 +1,18 @@
+/**
+ * User-supplied event subscription filter (e.g. WebSocket `subscribe` params).
+ *
+ * Every field is optional on input, but {@link validateEventFilter} requires
+ * at least one of `eventTypes` / `contractIds` to be present so a filter
+ * can't silently match nothing (or, historically, crash the normalizer on
+ * malformed input further downstream).
+ */
+export interface EventFilter {
+  readonly eventTypes: string[];
+  readonly contractIds?: string[];
+  readonly minLedger?: number;
+  readonly maxLedger?: number;
+}
+
+export type EventFilterValidationResult =
+  | { readonly ok: true; readonly filter: EventFilter }
+  | { readonly ok: false; readonly errors: string[] };

--- a/backend/src/modules/events/filters/event-filter.validator.test.ts
+++ b/backend/src/modules/events/filters/event-filter.validator.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  validateEventFilter,
+  MAX_FILTER_ARRAY_SIZE,
+  MAX_FILTER_STRING_LENGTH,
+} from "./event-filter.validator.js";
+
+function expectOk(result: ReturnType<typeof validateEventFilter>) {
+  assert.equal(result.ok, true, `expected ok, got errors: ${JSON.stringify((result as any).errors)}`);
+  return (result as any).filter;
+}
+
+function expectErrors(result: ReturnType<typeof validateEventFilter>) {
+  assert.equal(result.ok, false, "expected validation to fail");
+  return (result as any).errors as string[];
+}
+
+test("validateEventFilter — valid filters", async (t) => {
+  await t.test("accepts a simple eventTypes filter", () => {
+    const filter = expectOk(validateEventFilter({ eventTypes: ["PROPOSAL_CREATED"] }));
+    assert.deepEqual(filter.eventTypes, ["PROPOSAL_CREATED"]);
+  });
+
+  await t.test("accepts legacy short topic names", () => {
+    const filter = expectOk(validateEventFilter({ eventTypes: ["proposal_executed"] }));
+    assert.deepEqual(filter.eventTypes, ["proposal_executed"]);
+  });
+
+  await t.test("accepts fully-namespaced topics with wildcards", () => {
+    const filter = expectOk(
+      validateEventFilter({ eventTypes: ["notification:events:*"] }),
+    );
+    assert.deepEqual(filter.eventTypes, ["notification:events:*"]);
+  });
+
+  await t.test("accepts contractIds instead of eventTypes", () => {
+    const filter = expectOk(validateEventFilter({ contractIds: ["CDTEST123"] }));
+    assert.deepEqual(filter.contractIds, ["CDTEST123"]);
+  });
+
+  await t.test("accepts a ledger range with minLedger <= maxLedger", () => {
+    const filter = expectOk(
+      validateEventFilter({ eventTypes: ["PROPOSAL_CREATED"], minLedger: 10, maxLedger: 20 }),
+    );
+    assert.equal(filter.minLedger, 10);
+    assert.equal(filter.maxLedger, 20);
+  });
+
+  await t.test("accepts an array at exactly the max size", () => {
+    const entries = Array.from({ length: MAX_FILTER_ARRAY_SIZE }, (_, i) => `TYPE_${i}`);
+    const filter = expectOk(validateEventFilter({ eventTypes: entries }));
+    assert.equal(filter.eventTypes.length, MAX_FILTER_ARRAY_SIZE);
+  });
+
+  await t.test("accepts a string at exactly the max length", () => {
+    const entry = "A".repeat(MAX_FILTER_STRING_LENGTH);
+    const filter = expectOk(validateEventFilter({ eventTypes: [entry] }));
+    assert.equal(filter.eventTypes[0], entry);
+  });
+});
+
+test("validateEventFilter — invalid filters", async (t) => {
+  await t.test("rejects non-object input", () => {
+    assert.equal(validateEventFilter(null).ok, false);
+    assert.equal(validateEventFilter(undefined).ok, false);
+    assert.equal(validateEventFilter("eventTypes").ok, false);
+    assert.equal(validateEventFilter(42).ok, false);
+    assert.equal(validateEventFilter(["PROPOSAL_CREATED"]).ok, false);
+  });
+
+  await t.test("rejects a filter with neither eventTypes nor contractIds", () => {
+    const errors = expectErrors(validateEventFilter({ minLedger: 1 }));
+    assert.ok(errors.some((e) => e.includes("at least one of eventTypes or contractIds")));
+  });
+
+  await t.test("rejects eventTypes that is not an array", () => {
+    const errors = expectErrors(validateEventFilter({ eventTypes: "PROPOSAL_CREATED" }));
+    assert.ok(errors.some((e) => e.includes("eventTypes must be an array")));
+  });
+
+  await t.test("rejects an empty eventTypes array", () => {
+    const errors = expectErrors(validateEventFilter({ eventTypes: [] }));
+    assert.ok(errors.some((e) => e.includes("must not be empty")));
+  });
+
+  await t.test("rejects arrays larger than the max size", () => {
+    const entries = Array.from({ length: MAX_FILTER_ARRAY_SIZE + 1 }, (_, i) => `T${i}`);
+    const errors = expectErrors(validateEventFilter({ eventTypes: entries }));
+    assert.ok(errors.some((e) => e.includes(`at most ${MAX_FILTER_ARRAY_SIZE}`)));
+  });
+
+  await t.test("rejects non-string array entries instead of crashing", () => {
+    const errors = expectErrors(
+      validateEventFilter({ eventTypes: ["PROPOSAL_CREATED", 42, { evil: true }, null] }),
+    );
+    assert.ok(errors.some((e) => e.includes("eventTypes[1] must be a string")));
+    assert.ok(errors.some((e) => e.includes("eventTypes[2] must be a string")));
+    assert.ok(errors.some((e) => e.includes("eventTypes[3] must be a string")));
+  });
+
+  await t.test("rejects strings longer than the max length", () => {
+    const errors = expectErrors(
+      validateEventFilter({ eventTypes: ["A".repeat(MAX_FILTER_STRING_LENGTH + 1)] }),
+    );
+    assert.ok(errors.some((e) => e.includes(`between 1 and ${MAX_FILTER_STRING_LENGTH}`)));
+  });
+
+  await t.test("rejects SQL-like syntax", () => {
+    const cases = [
+      "PROPOSAL'; DROP TABLE events; --",
+      "x' OR 1=1 --",
+      "UNION SELECT * FROM users",
+      "/* comment */ SELECT",
+    ];
+    for (const value of cases) {
+      const errors = expectErrors(validateEventFilter({ eventTypes: [value] }));
+      assert.ok(
+        errors.some((e) => e.includes("SQL-like syntax") || e.includes("invalid characters")),
+        `expected "${value}" to be rejected, got: ${JSON.stringify(errors)}`,
+      );
+    }
+  });
+
+  await t.test("rejects entries with disallowed characters", () => {
+    const errors = expectErrors(validateEventFilter({ eventTypes: ["hello world!"] }));
+    assert.ok(errors.some((e) => e.includes("invalid characters")));
+  });
+
+  await t.test("rejects a non-integer minLedger", () => {
+    const errors = expectErrors(
+      validateEventFilter({ eventTypes: ["PROPOSAL_CREATED"], minLedger: 1.5 }),
+    );
+    assert.ok(errors.some((e) => e.includes("minLedger must be an integer")));
+  });
+
+  await t.test("rejects a negative maxLedger", () => {
+    const errors = expectErrors(
+      validateEventFilter({ eventTypes: ["PROPOSAL_CREATED"], maxLedger: -1 }),
+    );
+    assert.ok(errors.some((e) => e.includes("maxLedger must be an integer") || e.includes("within [0")));
+  });
+
+  await t.test("rejects minLedger > maxLedger", () => {
+    const errors = expectErrors(
+      validateEventFilter({ eventTypes: ["PROPOSAL_CREATED"], minLedger: 100, maxLedger: 10 }),
+    );
+    assert.ok(errors.some((e) => e.includes("must be <=")));
+  });
+
+  await t.test("rejects unknown filter fields", () => {
+    const errors = expectErrors(
+      validateEventFilter({ eventTypes: ["PROPOSAL_CREATED"], $where: "1=1" }),
+    );
+    assert.ok(errors.some((e) => e.includes('unknown filter field: "$where"')));
+  });
+
+  await t.test("collects multiple errors at once", () => {
+    const errors = expectErrors(
+      validateEventFilter({
+        eventTypes: [],
+        minLedger: 100,
+        maxLedger: 10,
+        surprise: true,
+      }),
+    );
+    assert.ok(errors.length >= 3);
+  });
+});

--- a/backend/src/modules/events/filters/event-filter.validator.ts
+++ b/backend/src/modules/events/filters/event-filter.validator.ts
@@ -1,0 +1,159 @@
+/**
+ * Validation for user-supplied event filters (subscribe params).
+ *
+ * Subscribe requests arrive as untrusted JSON over the WebSocket connection.
+ * Before this validator existed, a malformed filter (wrong field types,
+ * oversized arrays, non-string array entries) could throw deep inside the
+ * subscribe/normalize path instead of failing with a clear client-facing
+ * error. `validateEventFilter` checks field types, value ranges, and array
+ * sizes up front and rejects suspicious patterns (e.g. SQL-like syntax)
+ * before a filter is ever used.
+ */
+
+import type { EventFilter, EventFilterValidationResult } from "./event-filter.types.js";
+
+/** Maximum number of entries allowed in any filter array field. */
+export const MAX_FILTER_ARRAY_SIZE = 50;
+
+/** Maximum length of any single filter string entry. */
+export const MAX_FILTER_STRING_LENGTH = 128;
+
+/**
+ * Whitelisted charset for filter string entries: alphanumerics, underscore,
+ * colon (topic namespacing), asterisk (wildcard), and hyphen.
+ */
+const SAFE_TOKEN_PATTERN = /^[A-Za-z0-9_:*-]+$/;
+
+/**
+ * Blacklist of SQL-like syntax: statement separators, comment markers, and
+ * common SQL keywords. Defense-in-depth alongside the charset whitelist, and
+ * gives a clearer error message than a generic "invalid characters" one.
+ */
+const SQL_LIKE_PATTERN =
+  /(--|;|\/\*|\*\/)|(\b(select|insert|update|delete|drop|union|exec|alter|create|where|from)\b)/i;
+
+const KNOWN_FILTER_FIELDS = new Set([
+  "eventTypes",
+  "contractIds",
+  "minLedger",
+  "maxLedger",
+]);
+
+function validateStringArray(
+  value: unknown,
+  fieldName: string,
+  errors: string[],
+): string[] | undefined {
+  if (value === undefined) return undefined;
+
+  if (!Array.isArray(value)) {
+    errors.push(`${fieldName} must be an array`);
+    return undefined;
+  }
+  if (value.length === 0) {
+    errors.push(`${fieldName} must not be empty`);
+    return undefined;
+  }
+  if (value.length > MAX_FILTER_ARRAY_SIZE) {
+    errors.push(
+      `${fieldName} must contain at most ${MAX_FILTER_ARRAY_SIZE} entries (got ${value.length})`,
+    );
+    return undefined;
+  }
+
+  const result: string[] = [];
+  for (let i = 0; i < value.length; i++) {
+    const entry = value[i];
+
+    if (typeof entry !== "string") {
+      errors.push(`${fieldName}[${i}] must be a string`);
+      continue;
+    }
+    if (entry.length === 0 || entry.length > MAX_FILTER_STRING_LENGTH) {
+      errors.push(
+        `${fieldName}[${i}] must be between 1 and ${MAX_FILTER_STRING_LENGTH} characters`,
+      );
+      continue;
+    }
+    if (SQL_LIKE_PATTERN.test(entry)) {
+      errors.push(
+        `${fieldName}[${i}] contains disallowed SQL-like syntax: "${entry}"`,
+      );
+      continue;
+    }
+    if (!SAFE_TOKEN_PATTERN.test(entry)) {
+      errors.push(`${fieldName}[${i}] contains invalid characters: "${entry}"`);
+      continue;
+    }
+    result.push(entry);
+  }
+
+  return result;
+}
+
+function validateLedgerBound(
+  value: unknown,
+  fieldName: string,
+  errors: string[],
+): number | undefined {
+  if (value === undefined) return undefined;
+
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value)) {
+    errors.push(`${fieldName} must be an integer`);
+    return undefined;
+  }
+  if (value < 0 || value > Number.MAX_SAFE_INTEGER) {
+    errors.push(`${fieldName} must be within [0, ${Number.MAX_SAFE_INTEGER}]`);
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Validates a user-supplied event filter (subscribe params).
+ *
+ * Accepts `unknown` so it can sit directly in front of untrusted JSON —
+ * callers never need to assume the shape is even an object before calling
+ * this. Returns either the parsed, safe {@link EventFilter} or a list of
+ * human-readable error messages describing every problem found.
+ */
+export function validateEventFilter(filter: unknown): EventFilterValidationResult {
+  if (filter === null || typeof filter !== "object" || Array.isArray(filter)) {
+    return { ok: false, errors: ["filter must be a non-null object"] };
+  }
+
+  const f = filter as Record<string, unknown>;
+  const errors: string[] = [];
+
+  const eventTypes = validateStringArray(f["eventTypes"], "eventTypes", errors);
+  const contractIds = validateStringArray(f["contractIds"], "contractIds", errors);
+  const minLedger = validateLedgerBound(f["minLedger"], "minLedger", errors);
+  const maxLedger = validateLedgerBound(f["maxLedger"], "maxLedger", errors);
+
+  if (f["eventTypes"] === undefined && f["contractIds"] === undefined) {
+    errors.push("filter must specify at least one of eventTypes or contractIds");
+  }
+
+  if (minLedger !== undefined && maxLedger !== undefined && minLedger > maxLedger) {
+    errors.push(`minLedger (${minLedger}) must be <= maxLedger (${maxLedger})`);
+  }
+
+  for (const key of Object.keys(f)) {
+    if (!KNOWN_FILTER_FIELDS.has(key)) {
+      errors.push(`unknown filter field: "${key}"`);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const result: EventFilter = {
+    eventTypes: eventTypes ?? [],
+    ...(contractIds !== undefined ? { contractIds } : {}),
+    ...(minLedger !== undefined ? { minLedger } : {}),
+    ...(maxLedger !== undefined ? { maxLedger } : {}),
+  };
+
+  return { ok: true, filter: result };
+}

--- a/backend/src/modules/events/replay/event-sequence.test.ts
+++ b/backend/src/modules/events/replay/event-sequence.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseEventSequenceKey,
+  compareEventSequence,
+  sortAndSequenceEvents,
+  dedupeEvents,
+  validateReplayIntegrity,
+} from "./event-sequence.js";
+import type { ContractEvent } from "../events.types.js";
+
+function makeEvent(overrides: Partial<ContractEvent> = {}): ContractEvent {
+  return {
+    id: "100-0-0",
+    contractId: "CDTEST",
+    topic: ["proposal_created"],
+    value: {},
+    ledger: 100,
+    ledgerClosedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+test("parseEventSequenceKey", async (t) => {
+  await t.test("parses ledger-tx_index-event_index id format", () => {
+    const key = parseEventSequenceKey(makeEvent({ id: "205-3-1", ledger: 205 }));
+    assert.deepEqual(key, { ledger: 205, txIndex: 3, eventIndex: 1 });
+  });
+
+  await t.test("falls back to ledger-only key for non-conforming ids", () => {
+    const key = parseEventSequenceKey(makeEvent({ id: "evt-abc", ledger: 42 }));
+    assert.deepEqual(key, { ledger: 42, txIndex: 0, eventIndex: 0 });
+  });
+
+  await t.test("falls back for non-numeric components", () => {
+    const key = parseEventSequenceKey(makeEvent({ id: "100-1-abc", ledger: 100 }));
+    assert.deepEqual(key, { ledger: 100, txIndex: 0, eventIndex: 0 });
+  });
+});
+
+test("compareEventSequence orders by ledger, then tx_index, then event_index", () => {
+  const a = makeEvent({ id: "100-0-0", ledger: 100 });
+  const b = makeEvent({ id: "100-0-1", ledger: 100 });
+  const c = makeEvent({ id: "100-1-0", ledger: 100 });
+  const d = makeEvent({ id: "101-0-0", ledger: 101 });
+
+  assert.ok(compareEventSequence(a, b) < 0);
+  assert.ok(compareEventSequence(b, c) < 0);
+  assert.ok(compareEventSequence(c, d) < 0);
+  assert.ok(compareEventSequence(d, a) > 0);
+  assert.equal(compareEventSequence(a, a), 0);
+});
+
+test("sortAndSequenceEvents", async (t) => {
+  await t.test("restores deterministic order for reordered transactions", () => {
+    // Simulate RPC returning events out of order within/across ledgers.
+    const shuffled = [
+      makeEvent({ id: "101-2-0", ledger: 101 }),
+      makeEvent({ id: "100-1-0", ledger: 100 }),
+      makeEvent({ id: "100-0-1", ledger: 100 }),
+      makeEvent({ id: "101-0-0", ledger: 101 }),
+      makeEvent({ id: "100-0-0", ledger: 100 }),
+    ];
+
+    const result = sortAndSequenceEvents(shuffled);
+
+    assert.deepEqual(
+      result.map((e) => e.id),
+      ["100-0-0", "100-0-1", "100-1-0", "101-0-0", "101-2-0"],
+    );
+  });
+
+  await t.test("assigns a 0-based sequence number that resets per ledger", () => {
+    const events = [
+      makeEvent({ id: "100-0-0", ledger: 100 }),
+      makeEvent({ id: "100-0-1", ledger: 100 }),
+      makeEvent({ id: "100-1-0", ledger: 100 }),
+      makeEvent({ id: "101-0-0", ledger: 101 }),
+    ];
+
+    const result = sortAndSequenceEvents(events);
+
+    assert.deepEqual(
+      result.map((e) => e.eventSequenceNumber),
+      [0, 1, 2, 0],
+    );
+  });
+
+  await t.test("does not mutate the input array", () => {
+    const events = [
+      makeEvent({ id: "100-1-0", ledger: 100 }),
+      makeEvent({ id: "100-0-0", ledger: 100 }),
+    ];
+    const original = [...events];
+    sortAndSequenceEvents(events);
+    assert.deepEqual(events, original);
+  });
+
+  await t.test("handles an empty input", () => {
+    assert.deepEqual(sortAndSequenceEvents([]), []);
+  });
+});
+
+test("dedupeEvents keeps the first occurrence in order", () => {
+  const events = [
+    makeEvent({ id: "100-0-0" }),
+    makeEvent({ id: "100-0-1" }),
+    makeEvent({ id: "100-0-0" }), // duplicate, overlapping poll window
+  ];
+
+  const result = dedupeEvents(events);
+
+  assert.deepEqual(
+    result.map((e) => e.id),
+    ["100-0-0", "100-0-1"],
+  );
+});
+
+test("validateReplayIntegrity", async (t) => {
+  await t.test("reports no issues for a clean, contiguous sequence", () => {
+    const events = sortAndSequenceEvents([
+      makeEvent({ id: "100-0-0", ledger: 100 }),
+      makeEvent({ id: "100-0-1", ledger: 100 }),
+      makeEvent({ id: "100-1-0", ledger: 100 }),
+    ]);
+
+    const report = validateReplayIntegrity(events);
+
+    assert.deepEqual(report.duplicateIds, []);
+    assert.deepEqual(report.possibleGaps, []);
+  });
+
+  await t.test("flags duplicate ids", () => {
+    const events = [
+      makeEvent({ id: "100-0-0" }),
+      makeEvent({ id: "100-0-1" }),
+      makeEvent({ id: "100-0-0" }),
+    ];
+
+    const report = validateReplayIntegrity(events);
+
+    assert.deepEqual(report.duplicateIds, ["100-0-0"]);
+  });
+
+  await t.test("flags a gap in event_index within the same transaction", () => {
+    const events = sortAndSequenceEvents([
+      makeEvent({ id: "100-0-0", ledger: 100 }),
+      makeEvent({ id: "100-0-3", ledger: 100 }), // skipped event_index 1, 2
+    ]);
+
+    const report = validateReplayIntegrity(events);
+
+    assert.equal(report.possibleGaps.length, 1);
+    assert.deepEqual(report.possibleGaps[0], {
+      ledger: 100,
+      txIndex: 0,
+      fromEventIndex: 0,
+      toEventIndex: 3,
+    });
+  });
+
+  await t.test("does not flag a gap across different transactions", () => {
+    const events = sortAndSequenceEvents([
+      makeEvent({ id: "100-0-5", ledger: 100 }),
+      makeEvent({ id: "100-1-0", ledger: 100 }),
+    ]);
+
+    const report = validateReplayIntegrity(events);
+    assert.deepEqual(report.possibleGaps, []);
+  });
+});

--- a/backend/src/modules/events/replay/event-sequence.ts
+++ b/backend/src/modules/events/replay/event-sequence.ts
@@ -1,0 +1,171 @@
+/**
+ * Event sequencing utilities for deterministic replay.
+ *
+ * The Soroban RPC can return events out of order when transactions within a
+ * ledger are reordered upstream (see events.service.ts / normalizer-cache.ts
+ * for the established convention that `event.id` — the paging token — is
+ * formatted as `<ledger>-<tx_index>-<event_index>`). Consumers that assume
+ * RPC response order is authoritative can therefore process events in the
+ * wrong order across a poll cycle.
+ *
+ * This module provides a pure, dependency-free sort/sequence/validate layer
+ * that any replay path (live polling or historical backfill) can apply to
+ * restore a deterministic, gap-aware event ordering.
+ */
+
+import type { ContractEvent } from "../events.types.js";
+
+export interface EventSequenceKey {
+  readonly ledger: number;
+  readonly txIndex: number;
+  readonly eventIndex: number;
+}
+
+/**
+ * Parses `event.id` into its `(ledger, tx_index, event_index)` components.
+ *
+ * Falls back to `{ ledger: event.ledger, txIndex: 0, eventIndex: 0 }` when the
+ * id doesn't match the expected 3-part numeric shape (e.g. synthetic ids used
+ * in tests, or an RPC provider that doesn't follow the convention) — this
+ * function never throws, it just can't guarantee a tie-break order for those
+ * events beyond their ledger.
+ */
+export function parseEventSequenceKey(
+  event: Pick<ContractEvent, "id" | "ledger">,
+): EventSequenceKey {
+  const parts = event.id.split("-");
+  if (parts.length === 3) {
+    const ledger = Number(parts[0]);
+    const txIndex = Number(parts[1]);
+    const eventIndex = Number(parts[2]);
+    if (
+      Number.isInteger(ledger) &&
+      Number.isInteger(txIndex) &&
+      Number.isInteger(eventIndex) &&
+      ledger >= 0 &&
+      txIndex >= 0 &&
+      eventIndex >= 0
+    ) {
+      return { ledger, txIndex, eventIndex };
+    }
+  }
+  return { ledger: event.ledger, txIndex: 0, eventIndex: 0 };
+}
+
+/** Orders events by `(ledger, tx_index, event_index)` ascending. */
+export function compareEventSequence(a: ContractEvent, b: ContractEvent): number {
+  const ka = parseEventSequenceKey(a);
+  const kb = parseEventSequenceKey(b);
+  if (ka.ledger !== kb.ledger) return ka.ledger - kb.ledger;
+  if (ka.txIndex !== kb.txIndex) return ka.txIndex - kb.txIndex;
+  return ka.eventIndex - kb.eventIndex;
+}
+
+export interface SequencedEvent extends ContractEvent {
+  /**
+   * Monotonic sequence number assigned during replay, 0-based and reset at
+   * the start of every ledger (i.e. it counts events "globally per ledger",
+   * across all transactions in that ledger, ordered by tx_index/event_index).
+   */
+  readonly eventSequenceNumber: number;
+}
+
+/**
+ * Sorts events deterministically by `(ledger, tx_index, event_index)` and
+ * assigns a per-ledger `eventSequenceNumber`. Input order is never trusted —
+ * this is what makes replay immune to upstream transaction reordering.
+ */
+export function sortAndSequenceEvents<T extends ContractEvent>(
+  events: readonly T[],
+): Array<T & SequencedEvent> {
+  const sorted = [...events].sort(compareEventSequence);
+
+  let currentLedger: number | null = null;
+  let seq = 0;
+  return sorted.map((event) => {
+    if (event.ledger !== currentLedger) {
+      currentLedger = event.ledger;
+      seq = 0;
+    }
+    return { ...event, eventSequenceNumber: seq++ };
+  });
+}
+
+/**
+ * Removes duplicate events by `id`, keeping the first occurrence in the
+ * given order (callers should sort first so "first" means "earliest").
+ */
+export function dedupeEvents<T extends ContractEvent>(
+  events: readonly T[],
+): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const event of events) {
+    if (seen.has(event.id)) continue;
+    seen.add(event.id);
+    result.push(event);
+  }
+  return result;
+}
+
+export interface ReplayIntegrityReport {
+  /** Event ids that appeared more than once in the input. */
+  readonly duplicateIds: string[];
+  /**
+   * Gaps detected in `event_index` within a single `(ledger, tx_index)` pair
+   * — a best-effort signal that events may have been skipped. This cannot
+   * detect gaps across the very first/last event of a transaction or missing
+   * transactions entirely, since no independent total count is available.
+   */
+  readonly possibleGaps: ReadonlyArray<{
+    readonly ledger: number;
+    readonly txIndex: number;
+    readonly fromEventIndex: number;
+    readonly toEventIndex: number;
+  }>;
+}
+
+/**
+ * Validates that a (ideally already-sorted) event list contains no duplicate
+ * ids and flags any apparent skips within a transaction's event_index
+ * sequence. Intended to run after {@link sortAndSequenceEvents}.
+ */
+export function validateReplayIntegrity(
+  events: readonly ContractEvent[],
+): ReplayIntegrityReport {
+  const seen = new Set<string>();
+  const duplicateIds: string[] = [];
+  const possibleGaps: Array<{
+    ledger: number;
+    txIndex: number;
+    fromEventIndex: number;
+    toEventIndex: number;
+  }> = [];
+
+  let prevKey: EventSequenceKey | null = null;
+  for (const event of events) {
+    if (seen.has(event.id)) {
+      duplicateIds.push(event.id);
+    } else {
+      seen.add(event.id);
+    }
+
+    const key = parseEventSequenceKey(event);
+    if (
+      prevKey &&
+      prevKey.ledger === key.ledger &&
+      prevKey.txIndex === key.txIndex &&
+      key.eventIndex - prevKey.eventIndex > 1
+    ) {
+      possibleGaps.push({
+        ledger: key.ledger,
+        txIndex: key.txIndex,
+        fromEventIndex: prevKey.eventIndex,
+        toEventIndex: key.eventIndex,
+      });
+    }
+    prevKey = key;
+  }
+
+  return { duplicateIds, possibleGaps };
+}

--- a/backend/src/modules/events/replay/replay.service.test.ts
+++ b/backend/src/modules/events/replay/replay.service.test.ts
@@ -90,3 +90,170 @@ test("EventReplayService forwards normalized events to registered consumers", as
   assert.equal(seenBatchSizes.length, 1);
   assert.equal(seenBatchSizes[0], 1);
 });
+
+// ─── replayEvents(): deterministic ordering for reordered transactions ─────
+
+function rawEvent(id: string, ledger: number, topic = "unknown_topic") {
+  return {
+    id,
+    contractId: "CDTEST",
+    topic: [topic],
+    value: { xdr: "AAAA" },
+    ledger,
+    ledgerClosedAt: new Date().toISOString(),
+  };
+}
+
+test("EventReplayService.replayEvents", async (t) => {
+  await t.test(
+    "restores deterministic order when the RPC returns transactions out of order",
+    async () => {
+      const service = new EventReplayService(baseEnv, {
+        startLedger: 100,
+        endLedger: 100,
+        batchSize: 100,
+        dryRun: true,
+        verbose: false,
+        clear: false,
+      });
+
+      (service as any).rpc = {
+        async getContractEvents() {
+          // Deliberately shuffled — simulates transaction reordering.
+          return [
+            rawEvent("100-2-0", 100),
+            rawEvent("100-0-1", 100),
+            rawEvent("100-0-0", 100),
+            rawEvent("100-1-0", 100),
+          ];
+        },
+      };
+
+      const result = await service.replayEvents(100, 100);
+
+      assert.deepEqual(
+        result.map((e) => e.id),
+        ["100-0-0", "100-0-1", "100-1-0", "100-2-0"],
+      );
+      assert.deepEqual(
+        result.map((e) => e.eventSequenceNumber),
+        [0, 1, 2, 3],
+      );
+    },
+  );
+
+  await t.test("sorts across ledgers and resets sequence number per ledger", async () => {
+    const service = new EventReplayService(baseEnv, {
+      startLedger: 200,
+      endLedger: 201,
+      batchSize: 100,
+      dryRun: true,
+      verbose: false,
+      clear: false,
+    });
+
+    (service as any).rpc = {
+      async getContractEvents(params: { startLedger: number }) {
+        if (params.startLedger === 200) {
+          return [rawEvent("201-0-0", 201), rawEvent("200-0-0", 200)];
+        }
+        return [];
+      },
+    };
+
+    const result = await service.replayEvents(200, 201);
+
+    assert.deepEqual(
+      result.map((e) => `${e.ledger}:${e.eventSequenceNumber}`),
+      ["200:0", "201:0"],
+    );
+  });
+
+  await t.test("deduplicates events that appear more than once", async () => {
+    const service = new EventReplayService(baseEnv, {
+      startLedger: 300,
+      endLedger: 300,
+      batchSize: 100,
+      dryRun: true,
+      verbose: false,
+      clear: false,
+    });
+
+    (service as any).rpc = {
+      async getContractEvents() {
+        return [
+          rawEvent("300-0-0", 300),
+          rawEvent("300-0-0", 300), // overlapping-window duplicate
+          rawEvent("300-0-1", 300),
+        ];
+      },
+    };
+
+    const result = await service.replayEvents(300, 300);
+
+    assert.deepEqual(
+      result.map((e) => e.id),
+      ["300-0-0", "300-0-1"],
+    );
+  });
+
+  await t.test("aggregates events across multiple ledger-chunk batches", async () => {
+    const service = new EventReplayService(baseEnv, {
+      startLedger: 400,
+      endLedger: 402,
+      batchSize: 1, // force one ledger per RPC call
+      dryRun: true,
+      verbose: false,
+      clear: false,
+    });
+
+    const calls: number[] = [];
+    (service as any).rpc = {
+      async getContractEvents(params: { startLedger: number }) {
+        calls.push(params.startLedger);
+        return [rawEvent(`${params.startLedger}-0-0`, params.startLedger)];
+      },
+    };
+
+    const result = await service.replayEvents(400, 402);
+
+    assert.deepEqual(calls, [400, 401, 402]);
+    assert.deepEqual(
+      result.map((e) => e.id),
+      ["400-0-0", "401-0-0", "402-0-0"],
+    );
+  });
+
+  await t.test("returns an empty array when no events are found", async () => {
+    const service = new EventReplayService(baseEnv, {
+      startLedger: 500,
+      endLedger: 500,
+      batchSize: 100,
+      dryRun: true,
+      verbose: false,
+      clear: false,
+    });
+
+    (service as any).rpc = {
+      async getContractEvents() {
+        return [];
+      },
+    };
+
+    const result = await service.replayEvents(500, 500);
+    assert.deepEqual(result, []);
+  });
+
+  await t.test("rejects an invalid ledger range", async () => {
+    const service = new EventReplayService(baseEnv, {
+      startLedger: 0,
+      batchSize: 100,
+      dryRun: true,
+      verbose: false,
+      clear: false,
+    });
+
+    await assert.rejects(() => service.replayEvents(50, 10), RangeError);
+    await assert.rejects(() => service.replayEvents(-1, 10), RangeError);
+  });
+});

--- a/backend/src/modules/events/replay/replay.service.ts
+++ b/backend/src/modules/events/replay/replay.service.ts
@@ -8,6 +8,12 @@
 import { EventNormalizer } from "../normalizers/index.js";
 import { FileCursorAdapter } from "../cursor/file-cursor.adapter.js";
 import { SorobanRpcClient } from "../../../shared/rpc/soroban-rpc.client.js";
+import {
+  sortAndSequenceEvents,
+  dedupeEvents,
+  validateReplayIntegrity,
+  type SequencedEvent,
+} from "./event-sequence.js";
 import type {
   ReplayOptions,
   EventProcessingResult,
@@ -211,13 +217,85 @@ export class EventReplayService {
     // Filter to the requested ledger window (RPC returns from startLedger onwards)
     const inRange = events.filter((e) => e.ledger <= endLedger);
 
+    // Transaction reordering upstream can make the RPC return events out of
+    // order within/across ledgers — restore deterministic order before the
+    // batch is handed to consumers.
+    const ordered = sortAndSequenceEvents(inRange);
+
     return {
-      events: inRange,
+      events: ordered,
       startLedger,
       endLedger,
       latestLedger: endLedger,
       hasMore: events.length > inRange.length,
     };
+  }
+
+  /**
+   * Fetches, deterministically orders, and deduplicates all contract events
+   * in `[fromLedger, toLedger]` (inclusive), without dispatching them to any
+   * registered consumers or touching cursor state.
+   *
+   * Events are sorted by `(ledger, tx_index, event_index)` — never trusting
+   * RPC response order — and each is annotated with a per-ledger
+   * `eventSequenceNumber`. Duplicate ids (e.g. from overlapping fetch
+   * windows) are removed, keeping the earliest occurrence in sequence order.
+   */
+  public async replayEvents(
+    fromLedger: number,
+    toLedger: number,
+  ): Promise<SequencedEvent[]> {
+    if (
+      !Number.isInteger(fromLedger) ||
+      !Number.isInteger(toLedger) ||
+      fromLedger < 0 ||
+      toLedger < fromLedger
+    ) {
+      throw new RangeError(
+        `Invalid replay range: fromLedger=${fromLedger}, toLedger=${toLedger}`,
+      );
+    }
+
+    const contractId = this.options.contractId ?? this.env.contractId;
+    const collected: ContractEvent[] = [];
+    let currentLedger = fromLedger;
+
+    while (currentLedger <= toLedger) {
+      const batchEndLedger = Math.min(
+        currentLedger + this.options.batchSize - 1,
+        toLedger,
+      );
+
+      const events = await this.rpc.getContractEvents({
+        startLedger: currentLedger,
+        filters: [{ type: "contract", contractIds: [contractId] }],
+        pagination: { limit: this.options.batchSize },
+      });
+
+      for (const event of events) {
+        if (event.ledger >= currentLedger && event.ledger <= batchEndLedger) {
+          collected.push(event);
+        }
+      }
+
+      currentLedger = batchEndLedger + 1;
+    }
+
+    const sorted = sortAndSequenceEvents(collected);
+
+    const integrity = validateReplayIntegrity(sorted);
+    if (integrity.duplicateIds.length > 0) {
+      this.log(
+        `[replay] replayEvents: ${integrity.duplicateIds.length} duplicate event id(s) detected in range ${fromLedger}-${toLedger}; de-duplicating.`,
+      );
+    }
+    if (integrity.possibleGaps.length > 0) {
+      this.log(
+        `[replay] replayEvents: ${integrity.possibleGaps.length} possible event_index gap(s) detected in range ${fromLedger}-${toLedger}.`,
+      );
+    }
+
+    return dedupeEvents(sorted);
   }
 
   /**

--- a/backend/src/modules/websocket/websocket.filter-validation.test.ts
+++ b/backend/src/modules/websocket/websocket.filter-validation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for subscribe-filter validation (malformed filters are rejected with
+ * a clear error instead of crashing the subscribe/normalize path).
+ *
+ * Constructs EventWebSocketServer directly against a plain node http.Server
+ * rather than going through server.ts, so this suite stays independent of
+ * unrelated modules wired into the full app.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createServer } from "node:http";
+import { WebSocket } from "ws";
+import { EventWebSocketServer } from "./websocket.server.js";
+
+function waitForMessage(
+  ws: WebSocket,
+  predicate: (msg: any) => boolean,
+  timeoutMs = 2000,
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("timed out waiting for message")),
+      timeoutMs,
+    );
+    const handler = (data: Buffer) => {
+      const msg = JSON.parse(data.toString());
+      if (predicate(msg)) {
+        clearTimeout(timeout);
+        ws.off("message", handler);
+        resolve(msg);
+      }
+    };
+    ws.on("message", handler);
+  });
+}
+
+async function withServer(
+  fn: (wsUrl: string) => Promise<void>,
+): Promise<void> {
+  const httpServer = createServer();
+  const wsServer = new EventWebSocketServer(httpServer);
+
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+  const address: any = httpServer.address();
+  const wsUrl = `ws://127.0.0.1:${address.port}`;
+
+  try {
+    await fn(wsUrl);
+  } finally {
+    wsServer.stop();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  }
+}
+
+test("subscribe filter validation", async (t) => {
+  await t.test("valid topics still subscribe successfully", () =>
+    withServer(async (wsUrl) => {
+      const ws = new WebSocket(wsUrl);
+      await new Promise((resolve) => ws.on("open", resolve));
+
+      ws.send(JSON.stringify({ type: "subscribe", topics: ["proposal_executed"] }));
+      const confirmation = await waitForMessage(ws, (m) => m.type === "subscribed");
+      assert.deepEqual(confirmation.topics, ["proposal_executed"]);
+
+      ws.close();
+    }),
+  );
+
+  await t.test(
+    "non-string topic entries are rejected with INVALID_FILTER instead of crashing the connection",
+    () =>
+      withServer(async (wsUrl) => {
+        const ws = new WebSocket(wsUrl);
+        await new Promise((resolve) => ws.on("open", resolve));
+
+        ws.send(
+          JSON.stringify({
+            type: "subscribe",
+            topics: ["proposal_executed", 42, { evil: true }],
+          }),
+        );
+
+        const err = await waitForMessage(ws, (m) => m.type === "error");
+        assert.equal(err.code, "INVALID_FILTER");
+        assert.ok(Array.isArray(err.errors) && err.errors.length > 0);
+
+        // Connection must still be alive and usable afterwards.
+        ws.send(JSON.stringify({ type: "subscribe", topics: ["proposal_executed"] }));
+        const confirmation = await waitForMessage(ws, (m) => m.type === "subscribed");
+        assert.deepEqual(confirmation.topics, ["proposal_executed"]);
+
+        ws.close();
+      }),
+  );
+
+  await t.test("SQL-like topic strings are rejected", () =>
+    withServer(async (wsUrl) => {
+      const ws = new WebSocket(wsUrl);
+      await new Promise((resolve) => ws.on("open", resolve));
+
+      ws.send(
+        JSON.stringify({
+          type: "subscribe",
+          topics: ["x'; DROP TABLE events; --"],
+        }),
+      );
+
+      const err = await waitForMessage(ws, (m) => m.type === "error");
+      assert.equal(err.code, "INVALID_FILTER");
+
+      ws.close();
+    }),
+  );
+
+  await t.test("oversized topic arrays are rejected", () =>
+    withServer(async (wsUrl) => {
+      const ws = new WebSocket(wsUrl);
+      await new Promise((resolve) => ws.on("open", resolve));
+
+      const tooMany = Array.from({ length: 51 }, (_, i) => `topic_${i}`);
+      ws.send(JSON.stringify({ type: "subscribe", topics: tooMany }));
+
+      const err = await waitForMessage(ws, (m) => m.type === "error");
+      assert.equal(err.code, "INVALID_FILTER");
+      assert.ok(err.errors.some((e: string) => e.includes("at most 50")));
+
+      ws.close();
+    }),
+  );
+
+  await t.test("legacy payload.eventTypes form is still validated the same way", () =>
+    withServer(async (wsUrl) => {
+      const ws = new WebSocket(wsUrl);
+      await new Promise((resolve) => ws.on("open", resolve));
+
+      ws.send(
+        JSON.stringify({ type: "subscribe", payload: { eventTypes: [null, 1] } }),
+      );
+
+      const err = await waitForMessage(ws, (m) => m.type === "error");
+      assert.equal(err.code, "INVALID_FILTER");
+
+      ws.close();
+    }),
+  );
+});

--- a/backend/src/modules/websocket/websocket.server.ts
+++ b/backend/src/modules/websocket/websocket.server.ts
@@ -6,6 +6,7 @@ import type { Server } from "node:http";
 import { createLogger } from "../../shared/logging/logger.js";
 import type { ContractEvent } from "../events/events.types.js";
 import type { MetricsRegistry } from "../health/metrics.registry.js";
+import { validateEventFilter } from "../events/filters/event-filter.validator.js";
 
 const logger = createLogger("websocket-server");
 
@@ -139,14 +140,16 @@ export class EventWebSocketServer extends EventEmitter {
   /** room → set of WebSocket connections */
   private rooms: Map<string, Set<WebSocket>> = new Map();
   private readonly maxSubscriptionsPerClient: number;
-
-  constructor(server: Server, maxSubscriptionsPerClient = 100) {
-    this.maxSubscriptionsPerClient = maxSubscriptionsPerClient;
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
   private readonly metrics: MetricsRegistry | null;
 
-  constructor(server: Server, metrics?: MetricsRegistry) {
+  constructor(
+    server: Server,
+    maxSubscriptionsPerClient = 100,
+    metrics?: MetricsRegistry,
+  ) {
     super();
+    this.maxSubscriptionsPerClient = maxSubscriptionsPerClient;
     this.metrics = metrics ?? null;
     if (this.metrics) {
       this.registerMetrics(this.metrics);
@@ -599,21 +602,44 @@ export class EventWebSocketServer extends EventEmitter {
   }
 
   private handleSubscribe(ws: WebSocket, message: any, connectionId: string) {
-    const topics: string[] | undefined = Array.isArray(message.topics)
+    const rawTopics: unknown = Array.isArray(message?.topics)
       ? message.topics
-      : Array.isArray(message.payload?.eventTypes)
+      : Array.isArray(message?.payload?.eventTypes)
         ? message.payload.eventTypes
         : undefined;
 
     const sub = this.clients.get(ws);
     if (!sub) return;
 
-    if (!topics || topics.length === 0) {
+    if (!Array.isArray(rawTopics) || rawTopics.length === 0) {
       ws.send(
         JSON.stringify({ type: "error", message: "Invalid topic format" }),
       );
       return;
     }
+
+    // Validate the subscribe filter before it touches any normalization or
+    // matching logic — a malformed filter (wrong types, oversized arrays,
+    // SQL-like strings) is rejected here with a clear error instead of
+    // risking a crash further downstream.
+    const validation = validateEventFilter({ eventTypes: rawTopics });
+    if (!validation.ok) {
+      logger.warn("rejected malformed subscribe filter", {
+        connectionId,
+        errors: validation.errors,
+      });
+      ws.send(
+        JSON.stringify({
+          type: "error",
+          code: "INVALID_FILTER",
+          message: "Invalid subscribe filter",
+          errors: validation.errors,
+        }),
+      );
+      return;
+    }
+
+    const topics = validation.filter.eventTypes;
 
     for (const t of topics) {
       // normalize: accept legacy short names like 'proposal_executed' and full 'notification:events:FOO'


### PR DESCRIPTION
Closes #1450 
Closes #1451 

Summary

— Deterministic event replay (backend/src/modules/events/replay/)
- New event-sequence.ts: parses each event's <ledger>-<tx_index>-<event_index> id, sorts events by (ledger, tx_index, event_index), assigns a per-ledger eventSequenceNumber (resets at each ledger boundary), and validates replay integrity — flags duplicate ids and detects gaps in event_index within a transaction.
- EventReplayService: the existing backfill batch pipeline previously trusted RPC response order as-is (the actual bug) — now sorts every batch deterministically. Added a new replayEvents(fromLedger, toLedger) method that fetches, sorts, and deduplicates events across a ledger range on demand.
- 21 new tests covering reordered transactions, cross-ledger sequencing, dedup, and gap detection.


— Event filter validation (backend/src/modules/events/filters/, websocket.server.ts)
- New validateEventFilter: checks field types, array sizes (max 50), string lengths (max 128), ledger-range sanity, and rejects SQL-like syntax, with clear per-field error messages.
- Wired into EventWebSocketServer.handleSubscribe — malformed subscribe filters (non-string entries, oversized arrays, SQL injection attempts) now get a clear INVALID_FILTER error instead of risking a crash mid-loop; the connection stays usable afterward.
- 33 new tests (unit + WebSocket integration).