### PR TITLE
feat: implement proposal execution window expiry (#1349)

### DIFF
--- a/contracts/vault/src/errors.rs
+++ b/contracts/vault/src/errors.rs
@@ -354,6 +354,8 @@ pub enum VaultError {
     CannotRemoveSigner = 85,
     DuplicateProposal = 26,
     ExecutionWindowExpired = 27,
+    /// Approved proposal's execution window has passed (issue #1349)
+    ProposalExecutionWindowExpired = 28,
     GasLimitExceeded = 161,
     InsurancePoolInsufficient = 111,
     InvalidDeadline = 44,

--- a/contracts/vault/src/events.rs
+++ b/contracts/vault/src/events.rs
@@ -119,6 +119,24 @@ pub fn emit_proposal_expired(env: &Env, proposal_id: u64, expires_at: u64) {
     );
 }
 
+/// Emit when the execution window ledgers configuration is updated.
+pub fn emit_exec_window_ledgers_updated(env: &Env, admin: &Address, ledgers: u64) {
+    env.events().publish(
+        (Symbol::new(env, "exec_window_ledgers_updated"), admin.clone()),
+        ledgers,
+    );
+}
+
+/// Emit when an approved proposal's execution window has passed and it auto-expires.
+/// This is separate from voting deadline expiry — the proposal was approved but
+/// not executed within the configured `exec_window_ledgers`.
+pub fn emit_execution_window_expired(env: &Env, proposal_id: u64, approved_at: u64, execution_window: u64) {
+    env.events().publish(
+        (Symbol::new(env, "execution_window_expired"), proposal_id),
+        (approved_at, execution_window),
+    );
+}
+
 pub fn emit_proposal_deadline_rejected(env: &Env, proposal_id: u64, voting_deadline: u64) {
     env.events().publish(
         (Symbol::new(env, "proposal_deadline_rejected"), proposal_id),

--- a/contracts/vault/src/lib.rs
+++ b/contracts/vault/src/lib.rs
@@ -623,6 +623,7 @@ impl VaultDAO {
             // Timeouts are configured post-init via dedicated setters; use safe defaults here.
             arbitration_timeout_ledgers: 17_280 * 30, // 30 days
             approval_timeout_ledgers: 0,
+            exec_window_ledgers: 0, // Set via set_exec_window_ledgers post-init (Issue #1349)
         };
 
         // Apply staking config from InitConfig
@@ -1085,6 +1086,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -1159,6 +1161,7 @@ impl VaultDAO {
         ) {
             proposal.approvals.push_back(proposer.clone());
             proposal.status = ProposalStatus::Approved;
+            proposal.approved_at = current_ledger;
             Self::try_execute_transfer(&env, &proposer, &mut proposal, current_ledger)?;
             proposal.status = ProposalStatus::Executed;
             proposal.execution_ledger = current_ledger;
@@ -1386,6 +1389,7 @@ impl VaultDAO {
                 spend_day: storage::get_day_number(&env),
                 spend_week: storage::get_week_number(&env),
                 has_spend_buckets: true,
+            approved_at: 0,
             };
 
             storage::set_proposal(&env, &proposal);
@@ -1994,6 +1998,49 @@ impl VaultDAO {
                 metrics.success_rate_bps(),
             );
             return Err(VaultError::PermissionExpired);
+        }
+
+        // Check execution window: approved_at + exec_window_ledgers
+        let config = storage::get_config(&env)?;
+        if config.exec_window_ledgers > 0
+            && proposal.approved_at > 0
+            && current_ledger > proposal.approved_at + config.exec_window_ledgers
+        {
+            // Refund spending limits (same as regular expiry above)
+            if proposal.status != ProposalStatus::Expired {
+                storage::refund_spending_limits(
+                    &env,
+                    proposal.amount,
+                    proposal.spend_day,
+                    proposal.spend_week,
+                );
+                storage::refund_token_spending_limits(
+                    &env,
+                    &proposal.token,
+                    proposal.amount,
+                    proposal.spend_day,
+                    proposal.spend_week,
+                );
+            }
+            proposal.status = ProposalStatus::Expired;
+            storage::tag_index_prune_proposal(&env, &proposal.tags, proposal_id);
+            storage::set_proposal(&env, &proposal);
+            storage::metrics_on_expiry(&env);
+            events::emit_execution_window_expired(
+                &env,
+                proposal_id,
+                proposal.approved_at,
+                config.exec_window_ledgers,
+            );
+            let metrics = storage::get_metrics(&env);
+            events::emit_metrics_updated(
+                &env,
+                metrics.executed_count,
+                metrics.rejected_count,
+                metrics.expired_count,
+                metrics.success_rate_bps(),
+            );
+            return Err(VaultError::ProposalExecutionWindowExpired);
         }
 
         // Check Timelock
@@ -3624,6 +3671,7 @@ impl VaultDAO {
                 tier_usage_tracking: false,
                 arbitration_timeout_ledgers: 17_280 * 30,
                 approval_timeout_ledgers: 0,
+                exec_window_ledgers: 0,
             }
         });
         (config.quorum, config.quorum_percentage)
@@ -4097,6 +4145,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -4606,6 +4655,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -8383,6 +8433,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -8885,6 +8936,30 @@ impl VaultDAO {
         Ok(())
     }
 
+    /// Set the execution window in ledgers after approval before proposals auto-expire.
+    /// A value of 0 disables the execution window (default on init).
+    pub fn set_exec_window_ledgers(
+        env: Env,
+        admin: Address,
+        ledgers: u64,
+    ) -> Result<(), VaultError> {
+        admin.require_auth();
+
+        let role = storage::get_role(&env, &admin);
+        if !Role::role_satisfies(Role::Admin, role) {
+            return Err(VaultError::Unauthorized);
+        }
+
+        let mut config = storage::get_config(&env)?;
+        config.exec_window_ledgers = ledgers;
+        storage::set_config(&env, &config);
+        storage::extend_instance_ttl(&env);
+
+        events::emit_exec_window_ledgers_updated(&env, &admin, ledgers);
+
+        Ok(())
+    }
+
     /// Get the current gas configuration.
     pub fn get_gas_config(env: Env) -> GasConfig {
         storage::get_gas_config(&env)
@@ -9274,6 +9349,7 @@ impl VaultDAO {
                 }
             } else {
                 proposal.status = ProposalStatus::Approved;
+                proposal.approved_at = current_ledger;
                 proposal.unlock_ledger = if proposal.amount >= config.timelock_threshold {
                     current_ledger + config.timelock_delay
                 } else {
@@ -9960,6 +10036,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -11183,6 +11260,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -13508,6 +13586,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -14473,6 +14552,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -14740,6 +14820,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &proposal);
@@ -14969,6 +15050,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
 
         storage::set_proposal(&env, &new_proposal);
@@ -15137,6 +15219,7 @@ impl VaultDAO {
             spend_day: storage::get_day_number(&env),
             spend_week: storage::get_week_number(&env),
             has_spend_buckets: true,
+            approved_at: 0,
         };
         storage::set_proposal(&env, &new_proposal);
 

--- a/contracts/vault/src/test_proposal_expiration.rs
+++ b/contracts/vault/src/test_proposal_expiration.rs
@@ -9,6 +9,66 @@ mod tests {
         Address, Env, Symbol, Vec,
     };
 
+    // Helper with threshold=2 so proposals reach Approved state (not immediately executed)
+    fn setup_vault_threshold_2() -> (VaultDAOClient<'static>, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(VaultDAO, ());
+        let client = VaultDAOClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        let signer1 = Address::generate(&env);
+        let signer2 = Address::generate(&env);
+
+        let mut signers = Vec::new(&env);
+        signers.push_back(admin.clone());
+        signers.push_back(signer1.clone());
+        signers.push_back(signer2.clone());
+
+        let config = InitConfig {
+            veto_window_ledgers: 0,
+            whitelist_mode: false,
+            grace_period_ledgers: 100,
+            vote_weight: VoteWeight::Flat,
+            high_impact_threshold: 70,
+            admin_rotation_delay: 1440,
+            signers,
+            threshold: 2, // threshold 2 so proposals stay in Approved state after 1 approval
+            quorum: 0,
+            quorum_percentage: 0,
+            spending_limit: 1_000_000,
+            daily_limit: 5_000_000,
+            weekly_limit: 10_000_000,
+            timelock_threshold: 0,
+            timelock_delay: 0,
+            velocity_limit: VelocityConfig {
+                limit: 100_000,
+                window: 3600,
+                per_token_limit: 0,
+            },
+            threshold_strategy: ThresholdStrategy::Fixed,
+            default_voting_deadline: 0,
+            veto_addresses: Vec::new(&env),
+            retry_config: crate::types::RetryConfig {
+                max_retry_delay: 0,
+                enabled: false,
+                max_retries: 0,
+                initial_backoff_ledgers: 0,
+            },
+            recovery_config: crate::types::RecoveryConfig::default(&env),
+            staking_config: crate::types::StakingConfig::default(),
+            proposal_id_prefix: 0,
+            pre_execution_hooks: Vec::new(&env),
+            post_execution_hooks: Vec::new(&env),
+        };
+
+        client.initialize(&admin, &config);
+        client.set_role(&admin, &signer1, &Role::Treasurer);
+        client.set_role(&admin, &signer2, &Role::Treasurer);
+
+        (client, admin, signer1, signer2, contract_id)
+    }
+
     fn setup_vault() -> (VaultDAOClient<'static>, Address, Address, Address, Address) {
         let env = Env::default();
         env.mock_all_auths();
@@ -398,6 +458,128 @@ mod tests {
         // Verify that archival mechanism exists and can be triggered
         let config = client.get_config();
         assert!(config.spending_limit > 0);
+    }
+
+    #[test]
+    fn test_execution_window_allows_execution_within_window() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, signer1, signer2, _contract_id) = setup_vault_threshold_2();
+
+        let token_admin = Address::generate(&env);
+        let token = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        StellarAssetClient::new(&env, &token).mint(&admin, &10_000);
+        let recipient = Address::generate(&env);
+
+        // Set execution window to 500 ledgers
+        client.set_exec_window_ledgers(&admin, &500);
+
+        // Create proposal at ledger 100
+        env.ledger().with_mut(|l| {
+            l.sequence_number = 100;
+        });
+        let proposal_id = propose_transfer(&env, &client, &signer1, &recipient, &token);
+
+        // First approval - proposal stays Pending (needs 2 approvals)
+        client.approve_proposal(&signer1, &proposal_id);
+        // Second approval - proposal becomes Approved
+        client.approve_proposal(&admin, &proposal_id);
+
+        let proposal = client.get_proposal(&proposal_id);
+        assert_eq!(proposal.status, ProposalStatus::Approved);
+        assert_eq!(proposal.approved_at, 100);
+
+        // Advance to ledger 500 (within window: 100 + 500 = 600)
+        env.ledger().with_mut(|l| {
+            l.sequence_number = 500;
+        });
+
+        // Execution should succeed within the window
+        client.execute_proposal(&signer1, &proposal_id);
+
+        let executed = client.get_proposal(&proposal_id);
+        assert_eq!(executed.status, ProposalStatus::Executed);
+    }
+
+    #[test]
+    fn test_execution_window_rejects_execution_outside_window() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, signer1, signer2, _contract_id) = setup_vault_threshold_2();
+
+        let token_admin = Address::generate(&env);
+        let token = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        StellarAssetClient::new(&env, &token).mint(&admin, &10_000);
+        let recipient = Address::generate(&env);
+
+        // Set execution window to 200 ledgers
+        client.set_exec_window_ledgers(&admin, &200);
+
+        // Create proposal at ledger 100
+        env.ledger().with_mut(|l| {
+            l.sequence_number = 100;
+        });
+        let proposal_id = propose_transfer(&env, &client, &signer1, &recipient, &token);
+
+        // First approval
+        client.approve_proposal(&signer1, &proposal_id);
+        // Second approval - proposal becomes Approved at ledger 100
+        client.approve_proposal(&admin, &proposal_id);
+
+        let proposal = client.get_proposal(&proposal_id);
+        assert_eq!(proposal.status, ProposalStatus::Approved);
+
+        // Advance to ledger 400 (outside window: 100 + 200 = 300)
+        env.ledger().with_mut(|l| {
+            l.sequence_number = 400;
+        });
+
+        // Execution should fail because window expired
+        let result = client.try_execute_proposal(&signer1, &proposal_id);
+        assert!(result.is_err());
+
+        // Proposal should now be Expired
+        let expired = client.get_proposal(&proposal_id);
+        assert_eq!(expired.status, ProposalStatus::Expired);
+    }
+
+    #[test]
+    fn test_execution_window_zero_disabled() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, admin, signer1, signer2, _contract_id) = setup_vault_threshold_2();
+
+        let token_admin = Address::generate(&env);
+        let token = env
+            .register_stellar_asset_contract_v2(token_admin)
+            .address();
+        StellarAssetClient::new(&env, &token).mint(&admin, &10_000);
+        let recipient = Address::generate(&env);
+
+        // Keep exec_window_ledgers at 0 (default = disabled, no window)
+        // Create proposal at ledger 100
+        env.ledger().with_mut(|l| {
+            l.sequence_number = 100;
+        });
+        let proposal_id = propose_transfer(&env, &client, &signer1, &recipient, &token);
+
+        // First approval
+        client.approve_proposal(&signer1, &proposal_id);
+        // Second approval - proposal becomes Approved at ledger 100
+        client.approve_proposal(&admin, &proposal_id);
+
+        // Advance far into the future
+        env.ledger().with_mut(|l| {
+            l.sequence_number = 100000;
+        });
+
+        // Execution should succeed because window is 0 (disabled = no limit)
+        let result = client.try_execute_proposal(&signer1, &proposal_id);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/contracts/vault/src/types.rs
+++ b/contracts/vault/src/types.rs
@@ -186,6 +186,8 @@ pub struct Config {
     pub arbitration_timeout_ledgers: u64,
     /// Timeout in ledgers for proposal approval (0 = disabled, issue #1425)
     pub approval_timeout_ledgers: u64,
+    /// Execution window in ledgers after approval before the proposal auto-expires (0 = no window).
+    pub exec_window_ledgers: u64,
 }
 
 /// Audit record for a cancelled proposal
@@ -616,6 +618,9 @@ pub struct Proposal {
     /// True once spend_day/spend_week were recorded at reservation time (Issue #1345).
     /// False on legacy proposals that predate these fields (Soroban default).
     pub has_spend_buckets: bool,
+    /// Ledger when the proposal was approved (0 = not yet approved).
+    /// Used to enforce the execution window (Issue #1349).
+    pub approved_at: u64,
 }
 
 /// Represents a grouped batch of proposals for atomic execution.


### PR DESCRIPTION
## Description

Closes #1349

This PR implements the **Proposal Execution Window Expiry** feature (#1349). Once a proposal is approved, it can now have a configurable grace period (in ledgers) after which it auto-expires if not executed.

### Changes Made

#### Type Definitions (`types.rs`)
- Added `exec_window_ledgers: u64` to the `Config` struct — configured post-init via a dedicated setter
- Added `approved_at: u64` to the `Proposal` struct — records the ledger when a proposal is approved

#### Core Logic (`lib.rs`)
- Initialized `exec_window_ledgers` to `0` (disabled by default) in `initialize()`
- Set `approved_at = current_ledger` in all approval paths:
  - Unilateral execution path in `approve_proposal()`
  - Standard approval path in `reevaluate_vote_state()`
- Added execution window check in `execute_proposal()`:
  - Rejects execution if `approved_at + exec_window_ledgers < current_ledger`
  - Refunds spending limits before marking proposal as Expired
  - Guards against double-refund with `proposal.status != Expired` check
- Added `set_exec_window_ledgers()` — admin-only setter for the window value

#### Events (`events.rs`)
- `emit_exec_window_ledgers_updated` — published when the window config changes
- `emit_execution_window_expired` — published when a proposal's execution window expires

#### Error Codes (`errors.rs`)
- Added `ProposalExecutionWindowExpired = 28` error variant

#### Tests (`test_proposal_expiration.rs`)
- Added `setup_vault_threshold_2()` helper for Approved state testing
- `test_execution_window_allows_execution_within_window` — verifies execution succeeds when within the window
- `test_execution_window_rejects_execution_outside_window` — verifies execution fails and proposal becomes Expired when outside the window
- `test_execution_window_zero_disabled` — verifies `0` (default) disables the window entirely

### Acceptance Criteria
✅ Execution window configurable via `set_exec_window_ledgers()` (default: 0 = disabled)
✅ Check in `execute_proposal()` rejects expired proposals
✅ `ProposalExecutionWindowExpired` error returned when window expired
✅ Spending limits refunded on expiry
✅ Events emitted on configuration change and window expiry
✅ Tests cover: within window, outside window, disabled

Closes #1349
